### PR TITLE
Add issue and PR templates for bugs, features, and validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Something is broken or behaves incorrectly
+title: "[bug] "
+labels: bug
+assignees: ""
+---
+
+## Environment
+
+- Chip (M1 / M2 / M3 / M4, and Pro/Max/Ultra if known):
+- Unified RAM (GB):
+- macOS version:
+- Python version (`python --version`):
+- `mlx` version:
+- `mlx_lm` version:
+- `VeloxQuant-MLX` version or git commit:
+
+## Model
+
+- Hugging Face / mlx-community model id:
+
+## What happened
+
+Clear description of the unexpected behavior.
+
+## Expected behavior
+
+What you expected instead.
+
+## Minimal reproduction
+
+```python
+# smallest snippet that reproduces the issue
+```
+
+## Full error output
+
+```text
+Paste the full traceback or log here.
+```
+
+## Method / config
+
+- `method=` (if any):
+- Other relevant `KVCacheConfig` fields:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation site
+    url: https://veloxquant-mlx.netlify.app/
+    about: Guides, algorithm pages, and API reference
+  - name: Discussions / questions
+    url: https://github.com/rajveer43/VeloxQuant-MLX/issues
+    about: Prefer a structured template above for bugs, features, and validation runs

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Propose a new capability, method, or API change
+title: "[feat] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What user or maintainer problem does this solve?
+
+## Proposed API or UX
+
+Sketch the interface (config fields, CLI flags, docs page). Keep it minimal.
+
+## Non-goals
+
+What this request explicitly does **not** include.
+
+## Success metric
+
+How we will know it worked (test, benchmark script, docs checklist).
+
+## Related work
+
+Links to papers, prior issues, or similar methods already in the library.

--- a/.github/ISSUE_TEMPLATE/validation_run.md
+++ b/.github/ISSUE_TEMPLATE/validation_run.md
@@ -1,0 +1,55 @@
+---
+name: Validation run
+about: Record a reproducible memory / quality / throughput comparison
+title: "[validation] "
+labels: validation
+assignees: ""
+---
+
+## Hardware
+
+- Chip:
+- Unified RAM (GB):
+- macOS version:
+
+## Software
+
+- Python / mlx / mlx_lm / VeloxQuant-MLX versions (or commit SHA):
+
+## Model and workload
+
+- Model id:
+- Prompt length (tokens) or how the prompt was built:
+- `max_tokens`:
+- Methods compared (e.g. fp16, RVQ-1bit, VecInfer-1bit):
+
+## Metrics reported
+
+Distinguish these clearly:
+
+| Metric | Value | Notes |
+| --- | --- | --- |
+| Tokens in cache (`offset`) | | |
+| Key accounting ratio (`fp16_key_bytes / compressed_key_bytes`) | | |
+| Value accounting (if any) | | |
+| MLX peak MB (`mx.get_peak_memory`) | | |
+| Throughput (tok/s) | | |
+| Output quality notes | | |
+
+## Accounting vs resident memory
+
+State whether claimed compression is **key-byte accounting** only, or measured **resident / packed** storage. Default RVQ and VecInfer paths often dequantize into the parent fp16 cache; counters can show large ratios while process RSS barely moves at short context.
+
+## Artifact path
+
+Path to committed `results.json` (and script that produced it):
+
+```text
+figures/validation/<model>/results.json
+```
+
+## Script used
+
+```bash
+# exact command line
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Summary
+
+Brief description of what this PR changes and why.
+
+## Related issue
+
+Closes #
+
+## Test plan
+
+- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
+- [ ] New or updated unit tests cover the change
+- [ ] Docs updated if user-facing behavior changed
+
+## Number claims (if any)
+
+Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.
+
+- Script path:
+- Results path:
+- Metric type (check one):
+  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
+  - [ ] Full-KV accounting (keys + values + residual windows)
+  - [ ] MLX peak memory (`mx.get_peak_memory`)
+  - [ ] OS RSS / long-context OOM comparison
+  - [ ] Throughput (tok/s)
+
+Do not describe accounting ratios as resident RAM savings unless resident memory was measured.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,34 @@ quantization library for `mlx_lm` on Apple Silicon, and contributions of all
 kinds are welcome: bug reports, new quantization methods, benchmarks on
 additional models, documentation, and performance work.
 
+## Issue-first workflow
+
+For anything beyond a tiny typo fix, **open an issue first** using one of the
+templates under `.github/ISSUE_TEMPLATE/`:
+
+| Template | Use when |
+| --- | --- |
+| Bug report | Something is broken or incorrect |
+| Feature request | New API, method, or capability |
+| Validation run | Recording a reproducible comparison |
+
+Then create a feature branch and open a PR that references the issue
+(`Closes #N`). This keeps discussion searchable and reviewable.
+
+### Suggested labels
+
+Maintainers may apply these labels (create them in the GitHub UI as needed):
+
+- `bug`, `enhancement`, `docs`, `validation`, `metal`, `good first issue`
+- `method:*` for work tied to a specific algorithm (e.g. `method:rvq`)
+
+Do not add a heavy project board until issue volume justifies it.
+
 ## Reporting bugs and requesting features
 
 Please open an issue at
-<https://github.com/rajveer43/veloxquant-mlx/issues>. For bugs, include:
+<https://github.com/rajveer43/VeloxQuant-MLX/issues>. Prefer the issue
+templates. For bugs, include:
 
 - your hardware (chip + RAM) and macOS version,
 - `python`, `mlx`, and `mlx_lm` versions,
@@ -16,16 +40,42 @@ Please open an issue at
 - a minimal snippet that reproduces the problem, and
 - the full error output.
 
+## Accounting vs resident memory
+
+Every compression or memory claim in an issue or PR must say which metric
+was measured:
+
+1. **Key-byte accounting** — `fp16_key_bytes / compressed_key_bytes` on the
+   cache objects. This is what many benches print as `key_x`. It reflects
+   packed-format size, not necessarily process RSS.
+2. **Full-KV accounting** — keys + values (+ residual fp16 windows when the
+   method keeps them).
+3. **MLX peak memory** — `mx.get_peak_memory()` (weights, activations, and
+   temporary tensors dominate at short context).
+4. **Resident / OS RSS** — Activity Monitor or `ps` RSS. Use long contexts
+   before claiming the user will see large RAM savings.
+
+Default **RVQ** and **VecInfer** paths quantize then dequantize into the
+parent `mlx_lm` fp16 `KVCache`. Headline ratios such as 7.5× or 16× are
+**key accounting** unless a packed or fused storage path is active and
+measured. Do not describe accounting ratios as resident RAM savings.
+
+We do not merge number claims that lack a reproducible script and a
+committed `results.json` (see Submitting changes).
+
 ## Getting set up
 
 Requires Apple Silicon (M1 or later), Python ≥ 3.11, and MLX ≥ 0.18.
 
 ```bash
-git clone https://github.com/rajveer43/veloxquant-mlx
+git clone https://github.com/rajveer43/VeloxQuant-MLX
 cd VeloxQuant-MLX
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 ```
+
+Fork first if you do not have write access, then add
+`upstream` pointing at `rajveer43/VeloxQuant-MLX`.
 
 ## Running the tests
 
@@ -35,16 +85,22 @@ python -m pytest veloxquant_mlx/tests -q
 
 New code should come with tests that mirror the existing conventions in
 `veloxquant_mlx/tests/` (shape/dtype preservation, reconstruction-quality
-bounds on seeded synthetic data, and — for any Metal kernel — a parity test
+bounds on seeded synthetic data, and for any Metal kernel a parity test
 against the pure-MLX path). Seed all randomness: determinism is treated as a
 correctness requirement.
 
+End-to-end `mlx_lm` generation benches require Apple Silicon and are run
+locally. CI may run unit tests that do not need Metal; see
+`docs/CI_AND_TESTING.md` once present.
+
 ## Submitting changes
 
-1. Fork the repository and create a feature branch.
-2. Make your change with accompanying tests and documentation.
-3. Ensure the full test suite passes locally.
-4. Open a pull request describing the change and, for any performance or
+1. Open or reference an issue for non-trivial work.
+2. Fork (if needed) and create a feature branch
+   (`chore/...`, `docs/...`, `feat/...`, `fix/...`).
+3. Make your change with accompanying tests and documentation.
+4. Ensure the full test suite passes locally.
+5. Open a pull request describing the change and, for any performance or
    compression claim, the committed `results.json` it traces to. We do not
    merge numbers that are not reproducible from a script in the repository.
 


### PR DESCRIPTION
## Summary

- Add bug, feature, and validation-run issue templates under `.github/ISSUE_TEMPLATE/`
- Add a PR template that requires reproducible scripts for number claims
- Update CONTRIBUTING with issue-first workflow, suggested labels, and the accounting vs resident-memory rule

## Test plan

- [x] Templates render as expected under GitHub issue chooser (after merge)
- [x] No code/runtime changes; docs and meta only

Closes #11