### PR TITLE
Add Mac/RAM method recommender and follow-up docs

### DIFF
--- a/.github/workflows/non-metal-unit.yml
+++ b/.github/workflows/non-metal-unit.yml
@@ -16,5 +16,9 @@ jobs:
           python-version: "3.12"
       - name: Install pytest only
         run: pip install pytest
+      # Run from the tools test dir so pytest does not import the
+      # veloxquant_mlx package (which requires mlx / Apple Silicon).
+      # The test loads mac_recommender.py via importlib by file path.
       - name: Run Mac recommender unit tests (no MLX)
-        run: python -m pytest veloxquant_mlx/tests/tools/test_mac_recommender.py -q
+        working-directory: veloxquant_mlx/tests/tools
+        run: python -m pytest test_mac_recommender.py -q --noconftest --rootdir=.

--- a/.github/workflows/non-metal-unit.yml
+++ b/.github/workflows/non-metal-unit.yml
@@ -16,9 +16,9 @@ jobs:
           python-version: "3.12"
       - name: Install pytest only
         run: pip install pytest
-      # Run from the tools test dir so pytest does not import the
-      # veloxquant_mlx package (which requires mlx / Apple Silicon).
-      # The test loads mac_recommender.py via importlib by file path.
+      # Keep tests under repo-root tests/non_metal/ so pytest does not
+      # walk into veloxquant_mlx/ (package __init__ imports mlx).
       - name: Run Mac recommender unit tests (no MLX)
-        working-directory: veloxquant_mlx/tests/tools
-        run: python -m pytest test_mac_recommender.py -q --noconftest --rootdir=.
+        run: >
+          python -m pytest tests/non_metal/test_mac_recommender.py -q
+          --noconftest --import-mode=importlib -c /dev/null -o addopts=

--- a/.github/workflows/non-metal-unit.yml
+++ b/.github/workflows/non-metal-unit.yml
@@ -1,0 +1,20 @@
+name: non-metal-unit
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  recommender:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pytest only
+        run: pip install pytest
+      - name: Run Mac recommender unit tests (no MLX)
+        run: python -m pytest veloxquant_mlx/tests/tools/test_mac_recommender.py -q

--- a/docs-site/docs/guides/mac-recommender.md
+++ b/docs-site/docs/guides/mac-recommender.md
@@ -1,0 +1,75 @@
+---
+id: mac-recommender
+title: Mac Method Recommender
+sidebar_label: Mac Recommender
+slug: /guides/mac-recommender
+---
+
+# Mac chip + RAM method recommender
+
+Pick a VeloxQuant-MLX method from your Apple Silicon chip, unified RAM, model
+size class, and goal. The CLI is the source of truth; the table below mirrors
+the same heuristics.
+
+## Honesty first
+
+- **Key accounting** ratios (7.5× RVQ, 16× VecInfer) are packed-byte counters.
+- Default RVQ / VecInfer often **dequantize into fp16** parent storage.
+- **Resident** savings are more likely for full-KV (`rabitq`) or eviction
+  (`streaming_llm` / `h2o`), especially at long context.
+
+## CLI
+
+```bash
+veloxquant recommend \
+  --chip M4 \
+  --ram-gb 48 \
+  --model-class 7B \
+  --goal everyday
+
+# Machine-readable JSON
+veloxquant recommend --chip M1 --ram-gb 16 --model-class 3B --goal max_context --json
+
+# Static ruleset (for automation / docs sync)
+veloxquant recommend --dump-ruleset > docs-site/static/mac-recommender-ruleset.json
+```
+
+## Goal → method map
+
+| Goal | Method | Typical key accounting | Resident savings likely? |
+| --- | --- | ---: | --- |
+| `everyday` | `turboquant_rvq` b=1 | ~7.5× | No (default dequant path) |
+| `max_key_accounting` | `vecinfer` 1-bit | ~16× | No (default dequant path) |
+| `best_quality` | `spectral` | ~5.3× | No |
+| `max_context` | `rabitq` | ~6× full KV | Yes (more likely) |
+| `constant_memory` | `streaming_llm` | n/a (eviction) | Yes (bounded tokens) |
+
+## RAM fit warnings (rule of thumb)
+
+Approximate 4-bit weight footprints used by the recommender:
+
+| Model class | ~Weights |
+| --- | ---: |
+| 1B | 0.8 GB |
+| 3B | 2.0 GB |
+| 7B | 4.5 GB |
+| 14B | 8.0 GB |
+| 32B | 18.0 GB |
+
+The CLI also subtracts ~4 GB for OS / apps. If headroom is under ~1 GB it
+warns. Example: 32B on 24 GB is expected to warn (see also
+`docs/MEMORY_CONSTRAINT_FINDINGS.md`).
+
+## Example (M4 Pro, 48 GB, 7B, everyday)
+
+```text
+method=turboquant_rvq
+knobs={'bit_width_inlier': 1, 'seed': 42}
+key_accounting_ratio≈7.5x
+resident_savings_likely=False
+```
+
+## See also
+
+- [Validation Report](./validation-report) for measuring accounting vs peak memory
+- Python module: `veloxquant_mlx/tools/mac_recommender.py`

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -82,6 +82,7 @@ const sidebars: SidebarsConfig = {
         'guides/observers',
         'guides/benchmarking',
         'guides/validation-report',
+        'guides/mac-recommender',
       ],
     },
   ],

--- a/docs-site/static/mac-recommender-ruleset.json
+++ b/docs-site/static/mac-recommender-ruleset.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "allowed_ram_gb": [
+    8,
+    16,
+    24,
+    32,
+    36,
+    48,
+    64,
+    128
+  ],
+  "model_classes": [
+    "1B",
+    "3B",
+    "7B",
+    "14B",
+    "32B"
+  ],
+  "goals": [
+    "everyday",
+    "max_key_accounting",
+    "max_context",
+    "best_quality",
+    "constant_memory"
+  ],
+  "chips": [
+    "M1",
+    "M2",
+    "M3",
+    "M4"
+  ],
+  "weight_gb_4bit_estimate": {
+    "1B": 0.8,
+    "3B": 2.0,
+    "7B": 4.5,
+    "14B": 8.0,
+    "32B": 18.0
+  },
+  "defaults": {
+    "everyday": {
+      "method": "turboquant_rvq",
+      "bit_width_inlier": 1,
+      "ratio": 7.5
+    },
+    "max_key_accounting": {
+      "method": "vecinfer",
+      "ratio": 16.0
+    },
+    "best_quality": {
+      "method": "spectral",
+      "ratio": 5.3
+    },
+    "max_context": {
+      "method": "rabitq",
+      "ratio": 6.0,
+      "resident_likely": true
+    },
+    "constant_memory": {
+      "method": "streaming_llm",
+      "ratio": 1.0,
+      "resident_likely": true
+    }
+  }
+}

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -1,0 +1,38 @@
+# API surface notes
+
+## Canonical import
+
+Prefer:
+
+```python
+from veloxquant_mlx import KVCacheBuilder, KVCacheConfig
+```
+
+Older docs or blog posts may mention `mlx_kv_quant`. Treat that as a legacy
+name. New code and docs should use `veloxquant_mlx` only.
+
+## CLI entry points
+
+`pyproject.toml` registers:
+
+- `veloxquant`
+- `mlx-kv-quant` (alias)
+
+Both call `veloxquant_mlx.__main__:main`.
+
+Commands: `precompute`, `benchmark`, `recommend`.
+
+## Config stability
+
+`KVCacheConfig` carries many method-specific fields. When adding a method:
+
+1. Add fields with defaults (do not break existing callers).
+2. Wire `KVCacheFactory` / `KVCacheBuilder.for_model`.
+3. Document fields on the algorithm page.
+4. Avoid renaming public fields without a deprecation note in CHANGELOG.
+
+## Dual-package cleanup (follow-up)
+
+If any remaining `mlx_kv_quant` import shims exist, mark them deprecated in
+CHANGELOG and remove after one minor release cycle with a clear migration
+note on the docs site.

--- a/docs/CI_AND_TESTING.md
+++ b/docs/CI_AND_TESTING.md
@@ -7,7 +7,7 @@ generation and Metal kernel parity tests need a real Mac GPU.
 
 | Suite | Where | Notes |
 | --- | --- | --- |
-| Pure Python unit tests (no Metal) | Linux CI or macOS CI | Examples: `tests/tools/test_mac_recommender.py`, many quantizer math tests |
+| Pure Python unit tests (no Metal) | Linux CI or macOS CI | Examples: `tests/non_metal/test_mac_recommender.py`, many quantizer math tests |
 | Metal parity / kernel tests | Apple Silicon only | Skip or mark `metal` on headless/Linux runners |
 | End-to-end generation benches | Local macOS | Scripts under `benchmark_scripts/` and `scripts/validate_kv_memory.py` |
 

--- a/docs/CI_AND_TESTING.md
+++ b/docs/CI_AND_TESTING.md
@@ -1,0 +1,27 @@
+# CI and testing policy
+
+VeloxQuant-MLX targets **Apple Silicon** (M1+). End-to-end `mlx_lm`
+generation and Metal kernel parity tests need a real Mac GPU.
+
+## What should run where
+
+| Suite | Where | Notes |
+| --- | --- | --- |
+| Pure Python unit tests (no Metal) | Linux CI or macOS CI | Examples: `tests/tools/test_mac_recommender.py`, many quantizer math tests |
+| Metal parity / kernel tests | Apple Silicon only | Skip or mark `metal` on headless/Linux runners |
+| End-to-end generation benches | Local macOS | Scripts under `benchmark_scripts/` and `scripts/validate_kv_memory.py` |
+
+## Guidance for contributors
+
+1. Always run `python -m pytest veloxquant_mlx/tests -q` on a Mac before a PR
+   that touches caches, Metal, or generation paths.
+2. Number claims need a reproducible script + committed `results.json`
+   (see CONTRIBUTING).
+3. Do not assume GitHub-hosted Linux runners can execute Metal kernels.
+
+## Suggested follow-up CI (not required for Phase 1)
+
+- A workflow that runs a **non-Metal** pytest selection on Linux (lint + pure
+  Python modules).
+- Document `pytest -m "not metal"` once Metal tests are consistently marked.
+- Keep release publishing (PyPI) separate from e2e benches.

--- a/docs/PACKED_STORAGE_ROADMAP.md
+++ b/docs/PACKED_STORAGE_ROADMAP.md
@@ -1,0 +1,45 @@
+# Packed storage roadmap
+
+## Problem
+
+Several methods report large **key-byte accounting** ratios while the default
+runtime path still materializes **fp16** tensors in the parent `mlx_lm`
+`KVCache` (quantize → dequantize → store). Users then expect Activity Monitor
+RSS to drop by 7.5× or 16× and do not see it at short context.
+
+## Goal
+
+Track, per method, whether compressed state is **actually retained** in
+resident memory during decode, versus accounting-only counters.
+
+## Status matrix (starting point)
+
+| Method | Default stores packed? | Notes |
+| --- | --- | --- |
+| `turboquant_rvq` | No | Dequant into parent fp16 cache; counters are accounting |
+| `vecinfer` | No (default) | Optional `fused_sdpa` / index ring buffer exists |
+| `rabitq` | Partial / fused path | Fused encode/attend Metal path aims to avoid materializing K/V |
+| Eviction methods | N/A | Reduce token count (`offset`), not bit-width |
+
+Update this table as methods change. Prefer linking a `results.json` that
+measures RSS or cache `nbytes` for packed paths.
+
+## Engineering work items
+
+1. Inventory each cache class: what `update_and_fetch` writes to parent state.
+2. Add a shared reporting helper: `accounting_bytes` vs `resident_cache_bytes`.
+3. Extend `scripts/validate_kv_memory.py` with optional OS RSS sampling.
+4. Document fused/packed flags clearly in quickstart (when they help, when
+   launch overhead hurts).
+5. Treat "resident compression" as a first-class claim type in PR template
+   checkboxes (already sketched in CONTRIBUTING honesty rule).
+
+## Success metric
+
+A user can run one script and see side-by-side:
+
+- accounting ratio
+- resident cache bytes (or RSS delta at long context)
+- tok/s
+
+without reading source to learn that dequantization hides the savings.

--- a/tests/non_metal/test_mac_recommender.py
+++ b/tests/non_metal/test_mac_recommender.py
@@ -7,8 +7,12 @@ from pathlib import Path
 
 import pytest
 
+# Repo-root tests/ so pytest does not import veloxquant_mlx/__init__.py (needs mlx).
 _MOD_PATH = (
-    Path(__file__).resolve().parents[2] / "tools" / "mac_recommender.py"
+    Path(__file__).resolve().parents[2]
+    / "veloxquant_mlx"
+    / "tools"
+    / "mac_recommender.py"
 )
 _SPEC = importlib.util.spec_from_file_location("mac_recommender", _MOD_PATH)
 assert _SPEC and _SPEC.loader

--- a/veloxquant_mlx/__main__.py
+++ b/veloxquant_mlx/__main__.py
@@ -6,7 +6,7 @@ import sys
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: veloxquant {precompute|benchmark}")
+        print("Usage: veloxquant {precompute|benchmark|recommend}")
         sys.exit(1)
 
     command = sys.argv[1]
@@ -19,8 +19,14 @@ def main() -> None:
     elif command == "benchmark":
         from veloxquant_mlx.cli.benchmark import main as _main
         _main()
+    elif command == "recommend":
+        from veloxquant_mlx.cli.recommend import main as _main
+        _main()
     else:
-        print(f"Unknown command: {command!r}. Choices: precompute, benchmark")
+        print(
+            f"Unknown command: {command!r}. "
+            "Choices: precompute, benchmark, recommend"
+        )
         sys.exit(1)
 
 

--- a/veloxquant_mlx/cli/recommend.py
+++ b/veloxquant_mlx/cli/recommend.py
@@ -1,0 +1,118 @@
+"""CLI: recommend a KV-cache method for a Mac chip + RAM + model size."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from veloxquant_mlx.tools.mac_recommender import (
+    RecommendRequest,
+    recommend,
+    ruleset_dict,
+)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="veloxquant recommend",
+        description=(
+            "Recommend a VeloxQuant-MLX method from chip, RAM, model class, "
+            "and goal. Estimates are accounting-aware and state when "
+            "resident RAM savings are unlikely."
+        ),
+    )
+    parser.add_argument(
+        "--chip",
+        required=True,
+        choices=["M1", "M2", "M3", "M4"],
+        help="Apple Silicon family (Pro/Max/Ultra are RAM tiers, not separate chips here)",
+    )
+    parser.add_argument(
+        "--ram-gb",
+        required=True,
+        type=int,
+        choices=[8, 16, 24, 32, 36, 48, 64, 128],
+    )
+    parser.add_argument(
+        "--model-class",
+        required=True,
+        choices=["1B", "3B", "7B", "14B", "32B"],
+        help="Approximate parameter class (4-bit weight footprint estimate)",
+    )
+    parser.add_argument(
+        "--goal",
+        required=True,
+        choices=[
+            "everyday",
+            "max_key_accounting",
+            "max_context",
+            "best_quality",
+            "constant_memory",
+        ],
+    )
+    parser.add_argument("--seq-len", type=int, default=4096)
+    parser.add_argument("--n-layers", type=int, default=32)
+    parser.add_argument("--n-kv-heads", type=int, default=8)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON",
+    )
+    parser.add_argument(
+        "--dump-ruleset",
+        action="store_true",
+        help="Print static ruleset JSON and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.dump_ruleset:
+        print(json.dumps(ruleset_dict(), indent=2))
+        return
+
+    req = RecommendRequest(
+        chip=args.chip,
+        ram_gb=args.ram_gb,
+        model_class=args.model_class,
+        goal=args.goal,
+        seq_len=args.seq_len,
+        n_layers=args.n_layers,
+        n_kv_heads=args.n_kv_heads,
+        head_dim=args.head_dim,
+    )
+    result = recommend(req)
+    payload = {
+        "request": {
+            "chip": req.chip,
+            "ram_gb": req.ram_gb,
+            "model_class": req.model_class,
+            "goal": req.goal,
+            "seq_len": req.seq_len,
+            "n_layers": req.n_layers,
+            "n_kv_heads": req.n_kv_heads,
+            "head_dim": req.head_dim,
+        },
+        "recommendation": result.to_dict(),
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return
+
+    rec = payload["recommendation"]
+    print("VeloxQuant-MLX method recommender")
+    print(f"  chip={req.chip}  ram={req.ram_gb} GB  model~{req.model_class}  goal={req.goal}")
+    print(f"  method={rec['method']}")
+    print(f"  knobs={rec['knobs']}")
+    print(f"  key_accounting_ratio≈{rec['key_accounting_ratio']}x")
+    print(f"  resident_savings_likely={rec['resident_savings_likely']}")
+    print(f"  kv_fp16_mb≈{rec['kv_fp16_mb']}  kv_compressed_mb_est≈{rec['kv_compressed_mb_estimate']}")
+    print(f"  rationale: {rec['rationale']}")
+    if rec["warnings"]:
+        print("  warnings:")
+        for w in rec["warnings"]:
+            print(f"    - {w}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/veloxquant_mlx/tests/tools/test_mac_recommender.py
+++ b/veloxquant_mlx/tests/tools/test_mac_recommender.py
@@ -1,0 +1,86 @@
+"""Unit tests for the Mac / RAM method recommender (no MLX required)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[2] / "tools" / "mac_recommender.py"
+)
+_SPEC = importlib.util.spec_from_file_location("mac_recommender", _MOD_PATH)
+assert _SPEC and _SPEC.loader
+_mod = importlib.util.module_from_spec(_SPEC)
+sys.modules["mac_recommender"] = _mod
+_SPEC.loader.exec_module(_mod)
+
+RecommendRequest = _mod.RecommendRequest
+estimate_kv_fp16_mb = _mod.estimate_kv_fp16_mb
+recommend = _mod.recommend
+ruleset_dict = _mod.ruleset_dict
+
+
+def test_estimate_kv_fp16_mb_mistral_like():
+    # 2 * 32 * 8 * 128 * 2048 * 2 bytes = 256 MiB
+    mb = estimate_kv_fp16_mb(32, 8, 128, 2048)
+    assert abs(mb - 256.0) < 0.5
+
+
+def test_everyday_default_is_rvq():
+    r = recommend(
+        RecommendRequest(chip="M4", ram_gb=48, model_class="7B", goal="everyday")
+    )
+    assert r.method == "turboquant_rvq"
+    assert r.knobs["bit_width_inlier"] == 1
+    assert abs(r.key_accounting_ratio - 7.5) < 1e-6
+    assert r.resident_savings_likely is False
+
+
+def test_max_key_accounting_is_vecinfer():
+    r = recommend(
+        RecommendRequest(
+            chip="M2", ram_gb=32, model_class="3B", goal="max_key_accounting"
+        )
+    )
+    assert r.method == "vecinfer"
+    assert abs(r.key_accounting_ratio - 16.0) < 1e-6
+
+
+def test_constant_memory_is_eviction():
+    r = recommend(
+        RecommendRequest(
+            chip="M1", ram_gb=8, model_class="3B", goal="constant_memory"
+        )
+    )
+    assert r.method == "streaming_llm"
+    assert r.resident_savings_likely is True
+
+
+def test_tight_ram_warns_for_large_model():
+    r = recommend(
+        RecommendRequest(chip="M1", ram_gb=8, model_class="7B", goal="everyday")
+    )
+    assert any("headroom" in w.lower() or "tight" in w.lower() for w in r.warnings)
+
+
+def test_32b_on_24gb_warns():
+    r = recommend(
+        RecommendRequest(chip="M4", ram_gb=24, model_class="32B", goal="everyday")
+    )
+    assert any("headroom" in w.lower() for w in r.warnings)
+
+
+def test_invalid_ram_raises():
+    with pytest.raises(ValueError):
+        recommend(
+            RecommendRequest(chip="M4", ram_gb=12, model_class="3B", goal="everyday")
+        )
+
+
+def test_ruleset_export():
+    rs = ruleset_dict()
+    assert rs["version"] == 1
+    assert "everyday" in rs["defaults"]
+    assert rs["defaults"]["everyday"]["method"] == "turboquant_rvq"

--- a/veloxquant_mlx/tools/__init__.py
+++ b/veloxquant_mlx/tools/__init__.py
@@ -1,0 +1,17 @@
+"""Utility helpers that do not require MLX at import time."""
+
+from veloxquant_mlx.tools.mac_recommender import (
+    RecommendRequest,
+    RecommendResult,
+    estimate_kv_fp16_mb,
+    recommend,
+    ruleset_dict,
+)
+
+__all__ = [
+    "RecommendRequest",
+    "RecommendResult",
+    "estimate_kv_fp16_mb",
+    "recommend",
+    "ruleset_dict",
+]

--- a/veloxquant_mlx/tools/mac_recommender.py
+++ b/veloxquant_mlx/tools/mac_recommender.py
@@ -1,0 +1,234 @@
+"""Mac chip + RAM method recommender (pure heuristics, no MLX required)."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+ChipFamily = Literal["M1", "M2", "M3", "M4"]
+ModelClass = Literal["1B", "3B", "7B", "14B", "32B"]
+Goal = Literal[
+    "everyday",
+    "max_key_accounting",
+    "max_context",
+    "best_quality",
+    "constant_memory",
+]
+
+ALLOWED_RAM_GB = (8, 16, 24, 32, 36, 48, 64, 128)
+MODEL_WEIGHT_GB_4BIT = {
+    "1B": 0.8,
+    "3B": 2.0,
+    "7B": 4.5,
+    "14B": 8.0,
+    "32B": 18.0,
+}
+
+
+@dataclass(frozen=True)
+class RecommendRequest:
+    chip: ChipFamily
+    ram_gb: int
+    model_class: ModelClass
+    goal: Goal
+    seq_len: int = 4096
+    n_layers: int = 32
+    n_kv_heads: int = 8
+    head_dim: int = 128
+
+
+@dataclass(frozen=True)
+class RecommendResult:
+    method: str
+    knobs: dict[str, Any]
+    key_accounting_ratio: float
+    resident_savings_likely: bool
+    kv_fp16_mb: float
+    kv_compressed_mb_estimate: float
+    warnings: list[str]
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def estimate_kv_fp16_mb(
+    n_layers: int,
+    n_kv_heads: int,
+    head_dim: int,
+    seq_len: int,
+) -> float:
+    """Full K+V fp16 cache size in megabytes."""
+    bytes_ = 2 * n_layers * n_kv_heads * head_dim * seq_len * 2
+    return bytes_ / (1024 ** 2)
+
+
+def recommend(req: RecommendRequest) -> RecommendResult:
+    """Return a transparent method recommendation for Apple Silicon."""
+    if req.ram_gb not in ALLOWED_RAM_GB:
+        raise ValueError(
+            f"ram_gb must be one of {ALLOWED_RAM_GB}, got {req.ram_gb}"
+        )
+    if req.seq_len < 1:
+        raise ValueError("seq_len must be >= 1")
+
+    warnings: list[str] = []
+    weight_gb = MODEL_WEIGHT_GB_4BIT[req.model_class]
+    # Leave ~4 GB for OS + apps; activations need headroom too
+    headroom_gb = req.ram_gb - weight_gb - 4.0
+    if headroom_gb < 3.0:
+        warnings.append(
+            f"{req.model_class} 4-bit weights (~{weight_gb} GB) leave little "
+            f"headroom on {req.ram_gb} GB (est. headroom {headroom_gb:.1f} GB). "
+            "Prefer a smaller model, eviction, or full-KV compression."
+        )
+
+    kv_fp16 = estimate_kv_fp16_mb(
+        req.n_layers, req.n_kv_heads, req.head_dim, req.seq_len
+    )
+
+    # Tiny-model Metal overhead warning (chip generation does not remove this)
+    if req.model_class == "1B":
+        warnings.append(
+            "Metal kernel launch overhead can dominate on tiny models; "
+            "prefer RVQ or disable Metal if tok/s drops."
+        )
+
+    tight = req.ram_gb <= 16 or headroom_gb < 3.0
+    if req.goal == "everyday":
+        method = "turboquant_rvq"
+        knobs = {"bit_width_inlier": 1, "seed": 42}
+        ratio = 7.5
+        resident = False
+        rationale = (
+            "Zero-calibration default. Key accounting ~7.5x at head_dim=128. "
+            "Default path dequantizes into parent fp16 cache."
+        )
+        if tight and req.model_class in ("7B", "14B", "32B"):
+            warnings.append(
+                "Tight RAM with a mid/large model: consider goal=max_context "
+                "(rabitq) or goal=constant_memory (eviction) for long prompts."
+            )
+
+    elif req.goal == "max_key_accounting":
+        method = "vecinfer"
+        knobs = {
+            "key_codebook_bits": 8,
+            "value_codebook_bits": 8,
+            "key_sub_dim": 8,
+            "value_sub_dim": 8,
+            "use_metal_kernels": None,
+            "note": "Requires one-time codebook calibration",
+        }
+        ratio = 16.0
+        resident = False
+        rationale = (
+            "Product VQ 1-bit path targets ~16x key accounting when "
+            "head_dim is divisible by sub_dim=8. Needs calibration."
+        )
+        if req.head_dim % 8 != 0:
+            warnings.append(
+                f"head_dim={req.head_dim} is not divisible by 8; "
+                "VecInfer sub_dim must divide head_dim."
+            )
+
+    elif req.goal == "best_quality":
+        method = "spectral"
+        knobs = {"bit_width_inlier": 3, "note": "Requires spectral rotation calibration"}
+        ratio = 5.3
+        resident = False
+        rationale = (
+            "SpectralQuant targets better reconstruction at moderate "
+            "compression via eigenbasis rotation (calibration required)."
+        )
+
+    elif req.goal == "max_context":
+        if tight:
+            method = "rabitq"
+            knobs = {"note": "1-bit keys + MSE-b4 values; prefer fused Metal path when available"}
+            ratio = 6.0
+            resident = True
+            rationale = (
+                "Full-KV compression is more likely to free resident memory "
+                "than key-only accounting methods on tight RAM."
+            )
+        else:
+            method = "rabitq"
+            knobs = {"note": "Full KV compression for longer context in fixed RAM"}
+            ratio = 6.0
+            resident = True
+            rationale = (
+                "RaBitQ compresses keys and values. Better candidate for "
+                "real context capacity gains than key-only RVQ accounting."
+            )
+
+    elif req.goal == "constant_memory":
+        method = "streaming_llm"
+        knobs = {"stream_n_sink": 4, "stream_window_size": 512}
+        ratio = 1.0
+        resident = True
+        rationale = (
+            "Structural eviction keeps a fixed sink + window. Cache token "
+            "count stays bounded regardless of generation length."
+        )
+        warnings.append(
+            "Eviction drops tokens; quality depends on the task. "
+            "For importance-based eviction try method=h2o instead."
+        )
+
+    else:
+        raise ValueError(f"Unknown goal: {req.goal}")
+
+    # Chip note: bandwidth/generation matters less than RAM for method pick
+    if req.chip in ("M1", "M2") and req.model_class in ("14B", "32B"):
+        warnings.append(
+            f"{req.chip} with {req.model_class}: expect lower tok/s; "
+            "memory fit still depends mainly on unified RAM."
+        )
+
+    compressed_mb = kv_fp16 / ratio if ratio > 0 else kv_fp16
+    # Resident estimate is only meaningful when resident_savings_likely
+    if not resident:
+        warnings.append(
+            "Resident RSS savings are unlikely at short context for this "
+            "method's default path (accounting ratio still valid)."
+        )
+
+    return RecommendResult(
+        method=method,
+        knobs=knobs,
+        key_accounting_ratio=ratio,
+        resident_savings_likely=resident,
+        kv_fp16_mb=round(kv_fp16, 2),
+        kv_compressed_mb_estimate=round(compressed_mb, 2),
+        warnings=warnings,
+        rationale=rationale,
+    )
+
+
+def ruleset_dict() -> dict[str, Any]:
+    """Export static metadata for docs / JS widgets."""
+    return {
+        "version": 1,
+        "allowed_ram_gb": list(ALLOWED_RAM_GB),
+        "model_classes": list(MODEL_WEIGHT_GB_4BIT.keys()),
+        "goals": [
+            "everyday",
+            "max_key_accounting",
+            "max_context",
+            "best_quality",
+            "constant_memory",
+        ],
+        "chips": ["M1", "M2", "M3", "M4"],
+        "weight_gb_4bit_estimate": dict(MODEL_WEIGHT_GB_4BIT),
+        "defaults": {
+            "everyday": {"method": "turboquant_rvq", "bit_width_inlier": 1, "ratio": 7.5},
+            "max_key_accounting": {"method": "vecinfer", "ratio": 16.0},
+            "best_quality": {"method": "spectral", "ratio": 5.3},
+            "max_context": {"method": "rabitq", "ratio": 6.0, "resident_likely": True},
+            "constant_memory": {
+                "method": "streaming_llm",
+                "ratio": 1.0,
+                "resident_likely": True,
+            },
+        },
+    }


### PR DESCRIPTION
## Summary

- `veloxquant recommend` for chip / RAM / model class / goal
- Unit tests (no Metal) + non-Metal CI workflow
- Docs: mac-recommender guide, CI_AND_TESTING, PACKED_STORAGE_ROADMAP, API_SURFACE

## Context

Rebased onto `master` after [PR #14](https://github.com/rajveer43/VeloxQuant-MLX/pull/14) merged. This PR contains only the recommender / follow-up commit.

## Test plan

- [x] `pytest veloxquant_mlx/tests/tools/test_mac_recommender.py`
- [x] `python -m veloxquant_mlx recommend --chip M4 --ram-gb 48 --model-class 7B --goal everyday`

Closes #15