### PR TITLE
fix: patch_model_kv_cache builds a fresh cache list per call

### DIFF
--- a/veloxquant_mlx/integration/mlx_lm_patch.py
+++ b/veloxquant_mlx/integration/mlx_lm_patch.py
@@ -17,12 +17,12 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
 from veloxquant_mlx.cache.base import KVCacheBuilder, KVCacheConfig
 
 
-def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
+def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> list[Any]:
     """Wire a quantized KV cache into an mlx-lm model's generation path.
 
     ``mlx_lm.generate()`` builds its prompt cache via
@@ -36,14 +36,20 @@ def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
     ``KVCacheBuilder.for_model()`` (which already handles VLM wrappers,
     MoE-gate fallback layers, per-layer bit-width lists, and cross-layer
     methods like XQuant/MiniCache/PyramidKV) and overrides
-    ``model.make_cache`` so every subsequent call returns it.
+    ``model.make_cache`` so every call builds a *fresh* cache list —
+    matching :func:`veloxquant_mlx.integration.mlx_vlm_patch.patch_vlm_kv_cache`.
+    A prior version closed over a single cache list built once at patch
+    time, so a second ``generate()`` call on the same patched model would
+    reuse the first call's leftover KV state instead of starting clean.
 
     Args:
         model: A loaded mlx_lm model instance.
         config: KVCacheConfig describing the quantization scheme.
 
     Returns:
-        The list of KVCache instances now wired into ``model.make_cache``.
+        The first freshly built cache list (also validates the config
+        eagerly). Subsequent ``generate()`` calls receive their own fresh
+        lists via the installed ``make_cache`` hook.
 
     Example::
 
@@ -54,7 +60,14 @@ def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
         )
         patch_model_kv_cache(model, config)
     """
-    caches = KVCacheBuilder.for_model(model, config)
-    model.make_cache = lambda *_a, **_k: caches
-    print(f"[veloxquant_mlx] Wired {len(caches)} layer cache(s) with {config.method!r}.")
+
+    def _make_cache(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return KVCacheBuilder.for_model(model, config)
+
+    model.make_cache = _make_cache
+    caches = _make_cache()
+    print(
+        f"[veloxquant_mlx] Wired {len(caches)} layer cache(s) with "
+        f"{config.method!r} (fresh per call)."
+    )
     return caches

--- a/veloxquant_mlx/tests/integration/test_mlx_lm_patch.py
+++ b/veloxquant_mlx/tests/integration/test_mlx_lm_patch.py
@@ -1,12 +1,24 @@
 """Integration test for patch_model_kv_cache.
 
-Regression coverage for a real bug: the previous implementation looked for a
-pre-existing ``.cache`` attribute on attention sub-modules and overwrote it.
-mlx_lm never creates such an attribute — caches are only ever built lazily
-through ``model.make_cache()`` (see mlx_lm.models.cache.make_prompt_cache).
-So the old code silently patched zero layers on every real model and only
-emitted a warning, while ``run_turboquant_method`` in the benchmark script
-kept measuring the *unpatched* fp16 model and mislabeling the result.
+Regression coverage for two real bugs:
+
+1. The original implementation looked for a pre-existing ``.cache``
+   attribute on attention sub-modules and overwrote it. mlx_lm never
+   creates such an attribute — caches are only ever built lazily through
+   ``model.make_cache()`` (see mlx_lm.models.cache.make_prompt_cache). So
+   the old code silently patched zero layers on every real model and only
+   emitted a warning, while ``run_turboquant_method`` in the benchmark
+   script kept measuring the *unpatched* fp16 model and mislabeling the
+   result.
+2. A later implementation fixed (1) but built the cache list once at
+   patch time and returned that same list from every subsequent
+   ``model.make_cache()`` call. ``mlx_lm.generate()`` calls
+   ``make_cache()`` fresh at the start of each generation to get a clean
+   cache — reusing one list meant a second ``generate()`` call on the
+   same patched model silently leaked KV state (offsets, cached
+   keys/values) from the first call. ``patch_vlm_kv_cache`` never had
+   this bug (it always rebuilds fresh); ``patch_model_kv_cache`` now
+   matches that behavior.
 """
 
 from __future__ import annotations
@@ -14,7 +26,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import mlx.core as mx
-import pytest
 
 from veloxquant_mlx.cache.base import KVCacheConfig
 from veloxquant_mlx.integration.mlx_lm_patch import patch_model_kv_cache
@@ -43,9 +54,14 @@ def test_patch_model_kv_cache_wires_make_cache() -> None:
     assert len(caches) == 4
     assert hasattr(model, "make_cache")
     # make_cache must be callable with mlx_lm's (args, kwargs) convention
-    # and must return the same cache list every time (persistent, not rebuilt).
-    assert model.make_cache() is caches
-    assert model.make_cache(some_arg=1) is caches
+    # and must return a *fresh* cache list on every call — reusing one list
+    # across generations would leak KV state between unrelated generate() calls.
+    second = model.make_cache()
+    third = model.make_cache(some_arg=1)
+    assert second is not caches
+    assert third is not caches
+    assert second is not third
+    assert len(second) == len(caches) == len(third) == 4
 
 
 def test_patch_model_kv_cache_returns_correct_method() -> None:
@@ -71,3 +87,26 @@ def test_patch_model_kv_cache_caches_are_independently_usable() -> None:
     caches[0].update_and_fetch(k, v)
     # A fresh layer's cache must remain untouched by another layer's writes.
     assert caches[1].offset == 0
+
+
+def test_patch_model_kv_cache_does_not_leak_across_generate_calls() -> None:
+    """Writing to one make_cache() call's caches must not affect the next call's.
+
+    Regression test for the sticky-cache bug: model.make_cache() used to
+    close over a single cache list built once at patch time, so a second
+    generate() call would inherit whatever offset/state the first call left
+    behind instead of starting from an empty cache.
+    """
+    model = _make_fake_model(n_layers=2, n_heads=2, head_dim=32)
+    config = KVCacheConfig(method="turboquant_rvq", bit_width_inlier=1, seed=42)
+    patch_model_kv_cache(model, config)
+
+    first_call_caches = model.make_cache()
+    k = mx.zeros((1, 2, 5, 32), dtype=mx.float16)
+    v = mx.zeros((1, 2, 5, 32), dtype=mx.float16)
+    first_call_caches[0].update_and_fetch(k, v)
+    assert first_call_caches[0].offset == 5
+
+    second_call_caches = model.make_cache()
+    assert second_call_caches[0].offset == 0
+    assert second_call_caches[1].offset == 0


### PR DESCRIPTION
## Summary
- `patch_model_kv_cache()` (`veloxquant_mlx/integration/mlx_lm_patch.py`) overrode `model.make_cache` with a lambda that closed over a single `caches` list built once at patch time. Every subsequent call to `model.make_cache()` returned that same list object.
- `mlx_lm.generate()` calls `model.make_cache()` fresh at the start of each generation expecting a clean cache. Reusing one list meant a second `generate()` call on the same patched model silently inherited leftover KV state (offsets, cached keys/values) from the first call — a correctness bug that fails silently (wrong/degraded output) rather than crashing.
- `patch_vlm_kv_cache` (`mlx_vlm_patch.py`) already rebuilds fresh per call via a `_make_cache` closure that calls `KVCacheBuilder.for_model()` each time it's invoked. This PR makes `patch_model_kv_cache` match that pattern exactly.

## Changes
- `mlx_lm_patch.py`: `model.make_cache` is now a closure that calls `KVCacheBuilder.for_model(model, config)` fresh on every invocation, instead of hoisting the result out and returning the same object forever.
- `test_mlx_lm_patch.py`:
  - Inverted `test_patch_model_kv_cache_wires_make_cache`, which previously asserted `model.make_cache() is caches` on every call (i.e. it was pinning the sticky-cache bug as expected behavior). It now asserts each call returns a distinct, correctly-sized list.
  - Added `test_patch_model_kv_cache_does_not_leak_across_generate_calls`, which writes to one call's cache and asserts a subsequent call's cache starts at `offset == 0` — a direct regression test for the leak.

Fixes #53

## Test plan
- [x] `pytest veloxquant_mlx/tests/integration/test_mlx_lm_patch.py -v` — all 4 tests pass, including the new leak regression test
- [x] `pytest veloxquant_mlx/tests/integration/` — full integration suite (20 tests) passes, including `mlx_vlm_patch` tests confirming parity with the VLM patch's fresh-cache behavior
- [x] `ruff check` / `ruff format --check` — clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)