### PR TITLE
fix(deps): declare mlx-lm as a required dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,6 @@ jobs:
       - name: Install package + dev/release dependencies
         run: |
           pip install -e ".[dev]"
-          # mlx_lm is not in [project.dependencies] but 35 non-test modules
-          # (including veloxquant_mlx/__init__.py's own import chain) import
-          # it at module level, so the package cannot even be imported
-          # without it -- required here for the test suite to collect at all.
-          pip install mlx-lm
 
       - name: Run test suite (release gate)
         run: python -m pytest veloxquant_mlx/tests -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,14 @@ classifiers = [
 ]
 dependencies = [
     "mlx>=0.18",
+    "mlx-lm>=0.31.3",
     "numpy>=1.26",
-    "matplotlib>=3.8",
 ]
 
 [project.optional-dependencies]
+plots = [
+    "matplotlib>=3.8",
+]
 dev = [
     "pytest>=8.0",
     "pytest-xdist",


### PR DESCRIPTION
Closes #55

## Problem
`mlx-lm` is imported at module level across 35+ files in `veloxquant_mlx` (e.g. `from mlx_lm.models.cache import KVCache` in every cache implementation, plus `KVCacheBuilder.for_model()` in `veloxquant_mlx/cache/base.py`), but it was never listed in `[project.dependencies]` in `pyproject.toml`.

A user who does `pip install VeloxQuant-MLX` and follows the README/quickstart gets an `ImportError` on first real use.

This was already known internally — `.github/workflows/release.yml` had a `pip install mlx-lm` workaround with a comment explaining exactly this gap, and `requirements.local.txt` separately pins `mlx-lm==0.31.3` for local dev.

## Fix
- Added `mlx-lm>=0.31.3` to `[project.dependencies]` (floor version matches the one already validated in `requirements.local.txt`).
- Removed the now-redundant `pip install mlx-lm` workaround (and its explanatory comment) from `release.yml`, since `pip install -e ".[dev]"` now pulls it in.
- Per the issue's optional suggestion: demoted `matplotlib` to a new `plots` extra (`pip install VeloxQuant-MLX[plots]`), since it's only used by standalone scripts in `veloxquant_mlx/benchmarks/` and one lazily-imported method (`DistortionObserver.plot()`, whose docstring already says "Requires matplotlib") — not by any core/non-optional import path. Verified with `grep -rn "import matplotlib" veloxquant_mlx/` that no test or core module imports it eagerly.

## Testing
I wasn't able to run the test suite locally (this environment is Windows; `mlx`/`mlx-lm` only ship wheels for Apple Silicon macOS), so I verified the change by:
- Confirming `pyproject.toml` still parses correctly (`tomllib.load`).
- Grepping all `import matplotlib` / `import mlx_lm` sites across the package to confirm the dependency moves don't affect any core/eagerly-imported code path.
- Confirming no test file imports `matplotlib`.

CI (which runs on the appropriate platform) should validate the rest.