### PR TITLE
docs: distinguish accounting vs resident-RAM compression claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@
 
 **VeloxQuant-MLX** compresses the KV cache of any `mlx_lm` model on Apple Silicon — up to **16× smaller** with near-lossless quality, in three lines of code. It ships **41 research-adapted compression methods**, from zero-calibration 1-bit quantizers to token-eviction caches to cross-layer merging, plus hand-written Metal kernels that make the hottest path **up to 14.7× faster**.
 
+> **Accounting vs. resident memory:** compression ratios above are computed from bit-width
+> accounting (bits actually needed to represent the values), not measured process RSS. Most
+> quantization methods still store dequantized fp16 tensors under the hood on the default
+> `mlx_lm` serving path today, so Activity Monitor / RSS won't drop by the same factor — see
+> [#27](https://github.com/rajveer43/VeloxQuant-MLX/issues/27) for the packed-storage roadmap.
+> Methods that reduce **resident** memory today are marked 🔻RSS in the
+> [method library](#method-library) below (eviction/merging methods, which actually shrink
+> token count); others reduce accounting-only storage at equal fp16 residency.
+
 **Why VeloxQuant-MLX:**
 - 41 methods behind one identical 3-line API — swap `method="..."` and go
 - Metal-accelerated hot paths: 6.9–14.7× faster quantize, 98% less peak memory at the OOM-trigger shape
@@ -57,6 +66,11 @@ response = mlx_lm.generate(model, tokenizer, prompt="Explain relativity simply."
 ---
 
 ## Numbers that matter
+
+> Compression ratios below are bit-width accounting, not measured RSS — see the
+> accounting-vs-resident note above and [#27](https://github.com/rajveer43/VeloxQuant-MLX/issues/27).
+> "Peak memory reduction" and "context at 8 GB" rows are Metal-kernel working-set/estimate
+> figures, not steady-state cache RSS under default `mlx_lm` serving.
 
 | Metric | Value | Notes |
 |---|---|---|
@@ -153,59 +167,65 @@ the [documentation site](https://veloxquant-mlx.netlify.app/docs/algorithms/over
 
 ### Quantization — compress every token
 
-| Method | `method=` | What it does | Compression | New in |
-|---|---|---|---|---|
-| [TurboQuant RVQ](https://veloxquant-mlx.netlify.app/docs/algorithms/rvq) | `turboquant_rvq` | Residual VQ, zero calibration — **the default** | 7.5× @ 1-bit | — |
-| [VecInfer](https://veloxquant-mlx.netlify.app/docs/algorithms/vecinfer) | `vecinfer` | Dual-transform product VQ, Metal-accelerated | 16× | 0.4.0 |
-| [SpectralQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/spectral) | `spectral` | Rotate keys into eigenbasis — best quality-per-bit | 5.33× | 0.6.0 |
-| [RateQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/ratequant) | *(allocator)* | Per-layer mixed precision via reverse-waterfilling | 5.2× @ 1.5 avg bit | — |
-| [RaBitQ](https://veloxquant-mlx.netlify.app/docs/algorithms/rabitq) | `rabitq` | 1-bit keys + MSE-b4 values | **6× full KV** | 0.7.0 |
-| [QJL](https://veloxquant-mlx.netlify.app/docs/algorithms/qjl) | `qjl` | 1-bit JL sketch, simplest/fastest to set up | ~16× | — |
-| [PolarQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/polarquant) | `polar` | Polar-coordinate quant for geometric key distributions | varies | — |
-| [CommVQ](https://veloxquant-mlx.netlify.app/docs/algorithms/commvq) | `comm_vq` | RoPE-commutative VQ, exact inner product (ICML 2025) | 64× keys | — |
-| [KIVI](https://veloxquant-mlx.netlify.app/docs/algorithms/kivi) | `kivi` | Tuning-free asymmetric 2-bit baseline | 5.8× | 0.8.0 |
-| [KIVI-Sink](https://veloxquant-mlx.netlify.app/docs/algorithms/kivi-sink) | `kivi_sink` | Sink-protected low-bit quantization | ~5.8× | 0.9.0 |
-| [SKVQ-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/skvq) | `skvq` | Channel reordering + clipped dynamic quant behind a sliding fp16 window + sink filter (COLM 2024) | varies | 0.30.0 |
-| [SVDq](https://veloxquant-mlx.netlify.app/docs/algorithms/svdq) | `svdq` | Sub-2-bit keys (~1.25 bit) via prefill SVD | ~10× | 0.10.0 |
-| [Kitty](https://veloxquant-mlx.netlify.app/docs/algorithms/kitty) | `kitty` | Adaptive channel precision, zero calibration | varies | 0.11.0 |
-| [KVQuant-NUQ](https://veloxquant-mlx.netlify.app/docs/algorithms/kvquant) | `kvquant` | Non-uniform datatype + outlier isolation | varies | 0.14.0 |
-| [NSNQuant-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/nsnquant) | `nsnquant` | Calibration-free universal-codebook VQ — fixed Gaussian codebook (NeurIPS 2025) | 1–2 bit/elem | 0.28.0 |
-| [ZipCache-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/zipcache) | `zipcache` | Per-token mixed bit-width by key-norm saliency | varies | 0.18.0 |
-| [GEAR](https://veloxquant-mlx.netlify.app/docs/algorithms/gear) | `gear` | Error-feedback: low-rank + sparse residual correction | varies | 0.17.0 |
-| [CacheGen](https://veloxquant-mlx.netlify.app/docs/algorithms/cachegen) | `cachegen` | Entropy-coded cache — storage win on correlated KV | varies | 0.16.0 |
-| [AMC-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/amc) | `amc` | Saliency-driven tiered rank + precision — one L1-norm score drives both rank and bit-width per token, never evicts (**no verified venue** — second exception; hardware/RTL half of paper out of scope) | varies | 0.38.0 |
-| [A2ATS-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/a2ats) | `a2ats` | Windowed RoPE + query-aware retrieval VQ — exact RoPE within a trailing window, shared approximate rotation outside it; query-aware codebook assignment for a retrieval-fraction subset (ACL 2025 Findings) | ~4× | 0.39.0 |
+> Category legend: 🧮 `accounting_only` (stores dequantized fp16 today — bit-width savings
+> are bookkeeping, not RSS; see [#27](https://github.com/rajveer43/VeloxQuant-MLX/issues/27)),
+> 🔻RSS `eviction`/`true_latent` (drops tokens or stores a genuinely smaller tensor — reduces
+> resident memory today), ⚙️ `standalone` (does not subclass `mlx_lm`'s `KVCache`, so it
+> isn't wired into the default serving path via `patch_model_kv_cache` the same way).
+
+| Method | `method=` | What it does | Compression | Category | New in |
+|---|---|---|---|---|---|
+| [TurboQuant RVQ](https://veloxquant-mlx.netlify.app/docs/algorithms/rvq) | `turboquant_rvq` | Residual VQ, zero calibration — **the default** | 7.5× @ 1-bit | 🧮 accounting_only | — |
+| [VecInfer](https://veloxquant-mlx.netlify.app/docs/algorithms/vecinfer) | `vecinfer` | Dual-transform product VQ, Metal-accelerated | 16× | 🧮 accounting_only | 0.4.0 |
+| [SpectralQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/spectral) | `spectral` | Rotate keys into eigenbasis — best quality-per-bit | 5.33× | ⚙️ standalone | 0.6.0 |
+| [RateQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/ratequant) | *(allocator)* | Per-layer mixed precision via reverse-waterfilling | 5.2× @ 1.5 avg bit | 🧮 accounting_only | — |
+| [RaBitQ](https://veloxquant-mlx.netlify.app/docs/algorithms/rabitq) | `rabitq` | 1-bit keys + MSE-b4 values | **6× full KV** | 🧮 accounting_only | 0.7.0 |
+| [QJL](https://veloxquant-mlx.netlify.app/docs/algorithms/qjl) | `qjl` | 1-bit JL sketch, simplest/fastest to set up | ~16× | ⚙️ standalone | — |
+| [PolarQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/polarquant) | `polar` | Polar-coordinate quant for geometric key distributions | varies | ⚙️ standalone | — |
+| [CommVQ](https://veloxquant-mlx.netlify.app/docs/algorithms/commvq) | `comm_vq` | RoPE-commutative VQ, exact inner product (ICML 2025) | 64× keys | 🧮 accounting_only | — |
+| [KIVI](https://veloxquant-mlx.netlify.app/docs/algorithms/kivi) | `kivi` | Tuning-free asymmetric 2-bit baseline | 5.8× | 🧮 accounting_only | 0.8.0 |
+| [KIVI-Sink](https://veloxquant-mlx.netlify.app/docs/algorithms/kivi-sink) | `kivi_sink` | Sink-protected low-bit quantization | ~5.8× | 🧮 accounting_only | 0.9.0 |
+| [SKVQ-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/skvq) | `skvq` | Channel reordering + clipped dynamic quant behind a sliding fp16 window + sink filter (COLM 2024) | varies | 🧮 accounting_only | 0.30.0 |
+| [SVDq](https://veloxquant-mlx.netlify.app/docs/algorithms/svdq) | `svdq` | Sub-2-bit keys (~1.25 bit) via prefill SVD | ~10× | 🧮 accounting_only | 0.10.0 |
+| [Kitty](https://veloxquant-mlx.netlify.app/docs/algorithms/kitty) | `kitty` | Adaptive channel precision, zero calibration | varies | 🧮 accounting_only | 0.11.0 |
+| [KVQuant-NUQ](https://veloxquant-mlx.netlify.app/docs/algorithms/kvquant) | `kvquant` | Non-uniform datatype + outlier isolation | varies | 🧮 accounting_only | 0.14.0 |
+| [NSNQuant-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/nsnquant) | `nsnquant` | Calibration-free universal-codebook VQ — fixed Gaussian codebook (NeurIPS 2025) | 1–2 bit/elem | 🧮 accounting_only | 0.28.0 |
+| [ZipCache-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/zipcache) | `zipcache` | Per-token mixed bit-width by key-norm saliency | varies | 🧮 accounting_only | 0.18.0 |
+| [GEAR](https://veloxquant-mlx.netlify.app/docs/algorithms/gear) | `gear` | Error-feedback: low-rank + sparse residual correction | varies | 🧮 accounting_only | 0.17.0 |
+| [CacheGen](https://veloxquant-mlx.netlify.app/docs/algorithms/cachegen) | `cachegen` | Entropy-coded cache — storage win on correlated KV | varies | 🧮 accounting_only | 0.16.0 |
+| [AMC-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/amc) | `amc` | Saliency-driven tiered rank + precision — one L1-norm score drives both rank and bit-width per token, never evicts (**no verified venue** — second exception; hardware/RTL half of paper out of scope) | varies | 🧮 accounting_only | 0.38.0 |
+| [A2ATS-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/a2ats) | `a2ats` | Windowed RoPE + query-aware retrieval VQ — exact RoPE within a trailing window, shared approximate rotation outside it; query-aware codebook assignment for a retrieval-fraction subset (ACL 2025 Findings) | ~4× | 🧮 accounting_only | 0.39.0 |
 
 ### Low-rank & cross-layer — compress across dimensions or depth
 
-| Method | `method=` | What it does | Compression | New in |
-|---|---|---|---|---|
-| [PALU](https://veloxquant-mlx.netlify.app/docs/algorithms/palu) | `palu` | True low-rank latent storage of both K and V | varies | 0.15.0 |
-| [XQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/xquant) | `xquant` | Cross-layer code reuse — adjacent layers share codes | varies | 0.12.0 |
-| [MiniCache](https://veloxquant-mlx.netlify.app/docs/algorithms/minicache) | `minicache` | Cross-layer SLERP merge — deep layer pairs cost one | ~2× on deep layers | 0.16.0 |
-| [xKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/xkv) | `xkv` | Cross-layer shared-subspace SVD — one basis jointly fit across a layer group | varies | 0.27.0 |
-| [AdaKV-proxy](https://veloxquant-mlx.netlify.app/docs/algorithms/adakv) | `adakv` | Per-head adaptive bit budget, layered on KIVI | varies | 0.13.0 |
-| [KVTC-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/kvtc) | `kvtc` | Local PCA + DP-optimal per-component bit allocation + entropy coding (ICLR 2026) — beats fixed-split mixed-precision at matched byte budget on skewed variance | varies | 0.35.0 |
+| Method | `method=` | What it does | Compression | Category | New in |
+|---|---|---|---|---|---|
+| [PALU](https://veloxquant-mlx.netlify.app/docs/algorithms/palu) | `palu` | True low-rank latent storage of both K and V | varies | 🔻RSS true_latent | 0.15.0 |
+| [XQuant](https://veloxquant-mlx.netlify.app/docs/algorithms/xquant) | `xquant` | Cross-layer code reuse — adjacent layers share codes | varies | 🧮 accounting_only | 0.12.0 |
+| [MiniCache](https://veloxquant-mlx.netlify.app/docs/algorithms/minicache) | `minicache` | Cross-layer SLERP merge — deep layer pairs cost one | ~2× on deep layers | 🧮 accounting_only | 0.16.0 |
+| [xKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/xkv) | `xkv` | Cross-layer shared-subspace SVD — one basis jointly fit across a layer group | varies | 🧮 accounting_only | 0.27.0 |
+| [AdaKV-proxy](https://veloxquant-mlx.netlify.app/docs/algorithms/adakv) | `adakv` | Per-head adaptive bit budget, layered on KIVI | varies | 🧮 accounting_only | 0.13.0 |
+| [KVTC-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/kvtc) | `kvtc` | Local PCA + DP-optimal per-component bit allocation + entropy coding (ICLR 2026) — beats fixed-split mixed-precision at matched byte budget on skewed variance | varies | 🧮 accounting_only | 0.35.0 |
 
 ### Token eviction & merging — drop or merge low-value tokens
 
-| Method | `method=` | What it does | New in |
-|---|---|---|---|
-| [SnapKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/snapkv) | `snapkv` | Prefill observation-window eviction, once at prefill end | 0.19.0 |
-| [StreamingLLM-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/streaming_llm) | `streaming_llm` | Sink + recency window, constant memory | 0.20.0 |
-| [H2O-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/h2o) | `h2o` | Cumulative attention-mass heavy-hitter eviction | 0.21.0 |
-| [TOVA-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/tova) | `tova` | Memoryless current-step attention-weight eviction | 0.22.0 |
-| [PyramidKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/pyramidkv) | `pyramidkv` | H2O eviction with a per-layer pyramid budget | 0.23.0 |
-| [SqueezeAttention-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/squeeze) | `squeeze` | 2D layer×token data-driven budget eviction | 0.24.0 |
-| [ChunkKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/chunkkv) | `chunkkv` | Chunk-level eviction (`chunk_size=1` == H2O) | 0.25.0 |
-| [CaM-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/cam) | `cam` | Cache **merging** — merge evicted tokens, don't drop (`cam_merge=drop` == H2O) | 0.26.0 |
-| [L2Norm-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/knorm) | `knorm` | Intrinsic key-norm eviction — low norm ⇒ important (EMNLP 2024) | 0.29.0 |
-| [Q-Filters-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/qfilters) | `qfilters` | Query-agnostic projection eviction — frozen per-head key-SVD direction | 0.31.0 |
-| [Keyformer-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/keyformer) | `keyformer` | Gumbel-regularized heavy-hitter eviction (MLSys 2024); `keyformer_tau=0` == H2O | 0.32.0 |
-| [MorphKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/morphkv) | `morphkv` | Recent-window correlation retention (ICML 2025); `morphkv_window=1` == TOVA | 0.33.0 |
-| [KVzip-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/kvzip) | `kvzip` | Context-reconstruction reliance eviction (NeurIPS 2025); `kvzip_probe=latest` == TOVA | 0.34.0 |
-| [CurDKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/curdkv) | `curdkv` | Value-aware leverage-score eviction via approximated CUR decomposition (NeurIPS 2025) — evicts key-similar but value-irrelevant tokens that key-only eviction (H2O) cannot distinguish | 0.36.0 |
-| [NestedKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/nestedkv) | `nestedkv` | Multi-scale ensembled prefill eviction — stable + episodic + current key anomaly, combined by a head-adaptive blend and surprise-gated route (**no verified venue** — one-time exception) | 0.37.0 |
+| Method | `method=` | What it does | Category | New in |
+|---|---|---|---|---|
+| [SnapKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/snapkv) | `snapkv` | Prefill observation-window eviction, once at prefill end | 🔻RSS eviction | 0.19.0 |
+| [StreamingLLM-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/streaming_llm) | `streaming_llm` | Sink + recency window, constant memory | 🔻RSS eviction | 0.20.0 |
+| [H2O-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/h2o) | `h2o` | Cumulative attention-mass heavy-hitter eviction | 🔻RSS eviction | 0.21.0 |
+| [TOVA-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/tova) | `tova` | Memoryless current-step attention-weight eviction | 🔻RSS eviction | 0.22.0 |
+| [PyramidKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/pyramidkv) | `pyramidkv` | H2O eviction with a per-layer pyramid budget | 🔻RSS eviction | 0.23.0 |
+| [SqueezeAttention-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/squeeze) | `squeeze` | 2D layer×token data-driven budget eviction | 🔻RSS eviction | 0.24.0 |
+| [ChunkKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/chunkkv) | `chunkkv` | Chunk-level eviction (`chunk_size=1` == H2O) | 🔻RSS eviction | 0.25.0 |
+| [CaM-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/cam) | `cam` | Cache **merging** — merge evicted tokens, don't drop (`cam_merge=drop` == H2O) | 🔻RSS eviction | 0.26.0 |
+| [L2Norm-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/knorm) | `knorm` | Intrinsic key-norm eviction — low norm ⇒ important (EMNLP 2024) | 🔻RSS eviction | 0.29.0 |
+| [Q-Filters-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/qfilters) | `qfilters` | Query-agnostic projection eviction — frozen per-head key-SVD direction | 🔻RSS eviction | 0.31.0 |
+| [Keyformer-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/keyformer) | `keyformer` | Gumbel-regularized heavy-hitter eviction (MLSys 2024); `keyformer_tau=0` == H2O | 🔻RSS eviction | 0.32.0 |
+| [MorphKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/morphkv) | `morphkv` | Recent-window correlation retention (ICML 2025); `morphkv_window=1` == TOVA | 🔻RSS eviction | 0.33.0 |
+| [KVzip-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/kvzip) | `kvzip` | Context-reconstruction reliance eviction (NeurIPS 2025); `kvzip_probe=latest` == TOVA | 🔻RSS eviction | 0.34.0 |
+| [CurDKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/curdkv) | `curdkv` | Value-aware leverage-score eviction via approximated CUR decomposition (NeurIPS 2025) — evicts key-similar but value-irrelevant tokens that key-only eviction (H2O) cannot distinguish | 🔻RSS eviction | 0.36.0 |
+| [NestedKV-adapted](https://veloxquant-mlx.netlify.app/docs/algorithms/nestedkv) | `nestedkv` | Multi-scale ensembled prefill eviction — stable + episodic + current key anomaly, combined by a head-adaptive blend and surprise-gated route (**no verified venue** — one-time exception) | 🔻RSS eviction | 0.37.0 |
 
 > Every "-adapted" method is an honest adaptation, not a faithful port — the cache
 > wrapper sees per-layer K/V but not the model's true query/attention maps, so

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -447,6 +447,25 @@ h1 span::after {
   margin: 0 auto 2rem;
 }
 
+.hero-disclaimer {
+  font-size: 0.8rem;
+  color: var(--muted);
+  opacity: 0.75;
+  max-width: 560px;
+  margin: -1.25rem auto 1.75rem;
+  line-height: 1.5;
+}
+
+.hero-disclaimer a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.hero-disclaimer a:hover {
+  color: var(--accent);
+}
+
 .install-block {
   display: inline-flex;
   align-items: center;

--- a/landing/index.html
+++ b/landing/index.html
@@ -122,6 +122,18 @@
         <span class="hero-pill">Apple Silicon only</span>
       </div>
 
+      <!-- Accounting vs resident RAM: compression ratios are bit-width accounting,
+           not measured process RSS. Most quantization methods still store dequantized
+           fp16 tensors on the default mlx_lm serving path today (see GitHub #27). Only
+           eviction/true-latent methods reduce resident memory today. -->
+      <p class="hero-disclaimer">
+        Compression ratios are bit-width accounting, not measured RAM. Methods that shrink
+        <strong>resident</strong> memory today are marked 🔻RSS in the
+        <a href="https://github.com/rajveer43/VeloxQuant-MLX#method-library" target="_blank" rel="noopener">method table</a>;
+        others reduce precision at equal fp16 storage for now
+        (<a href="https://github.com/rajveer43/VeloxQuant-MLX/issues/27" target="_blank" rel="noopener">packed-storage roadmap</a>).
+      </p>
+
       <div class="install-block" id="hero-install" title="Click to copy">
         <span class="dollar">$</span>
         <span id="install-cmd">pip install VeloxQuant-MLX</span>


### PR DESCRIPTION
## Summary
- README hero line and "Numbers that matter" section read as resident-RAM claims ("16× smaller"), but per #27, 35/40 methods subclass `mlx_lm`'s `KVCache` and store *dequantized* fp16 tensors under the hood — the reported compression ratios are bit-width accounting, not measured RSS.
- Adds one explicit clarifying note near the hero claim and above the benchmark table.
- Adds a `Category` column to all three method-library tables classifying each method as `accounting_only` / `eviction` / `true_latent` / `standalone`, per the taxonomy proposed in #51's audit.
- Applies the same disclaimer to the Netlify landing page hero (`landing/index.html`), with a small `.hero-disclaimer` style addition.

## Scope
Docs/copy only, per #54's stated scope. Actually wiring the taxonomy into `KVCacheConfig`/`for_model()` to refuse incompatible methods is explicitly out of scope here and tracked as a separate follow-up.

Fixes #54

## Test plan
- [x] Visual review of rendered README tables (column counts consistent per table, verified via script)
- [x] No Python files touched — ruff/lint/tests unaffected
- [ ] Netlify preview will render on this PR — visually confirm hero disclaimer placement/readability in both light/dark