### PR TITLE
fix: refuse standalone methods in for_model / patch instead of failing deep in generation

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -8,6 +8,28 @@ from typing import Any, Literal, Optional, Union
 from veloxquant_mlx.core.abstractions import ArtifactStore, KVCache, QuantizationObserver
 from veloxquant_mlx.core.exceptions import QuantizerConfigError
 
+# Methods whose cache class implements VeloxQuant's own KVCache ABC
+# (append_key/append_value/attend/memory_bytes) instead of subclassing
+# mlx_lm.models.cache.KVCache (update_and_fetch/nbytes/state/trim/merge/
+# meta_state). mlx_lm.generate() drives caches purely through the latter
+# interface via model.make_cache() -> cache.update_and_fetch(...), so an
+# object built from one of these methods does not satisfy that contract and
+# either crashes or silently produces wrong output deep inside generation
+# instead of failing at config/patch time. Verified against the codebase in
+# https://github.com/rajveer43/VeloxQuant-MLX/issues/27: these are the 5
+# "standalone" methods among the 40 in the registry; all others subclass
+# mlx_lm's KVCache and are safe to wire into patch_model_kv_cache /
+# KVCacheBuilder.for_model for live mlx_lm serving.
+STANDALONE_METHODS = frozenset(
+    {
+        "turboquant_prod",
+        "turboquant_mse",
+        "polar",
+        "qjl",
+        "spectral",
+    }
+)
+
 
 @dataclass
 class KVCacheConfig:
@@ -770,7 +792,24 @@ class KVCacheBuilder:
 
         Returns:
             List of KVCache instances, one per language-model layer.
+
+        Raises:
+            QuantizerConfigError: If ``config.method`` is a standalone method
+                (see :data:`STANDALONE_METHODS`) that does not implement the
+                mlx_lm KVCache serving contract.
         """
+        if config.method in STANDALONE_METHODS:
+            raise QuantizerConfigError(
+                f"KVCacheBuilder.for_model: method {config.method!r} is a standalone "
+                f"method — its cache class implements VeloxQuant's own KVCache "
+                f"interface, not mlx_lm.models.cache.KVCache, so it cannot serve "
+                f"mlx_lm.generate() traffic and will fail deep inside generation "
+                f"rather than here. Use it directly via KVCacheFactory.create() / "
+                f"KVCacheBuilder.build() for standalone/research use instead, or "
+                f"pick a serving-compatible method (see the method library's "
+                f"'standalone' tag: https://github.com/rajveer43/VeloxQuant-MLX#method-library)."
+            )
+
         from mlx_lm.models.cache import KVCache as _FallbackCache
 
         # Qwen2-VL exposes model.layers directly; text models expose model.model.layers

--- a/veloxquant_mlx/integration/mlx_lm_patch.py
+++ b/veloxquant_mlx/integration/mlx_lm_patch.py
@@ -17,12 +17,12 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
 from veloxquant_mlx.cache.base import KVCacheBuilder, KVCacheConfig
 
 
-def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
+def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> list[Any]:
     """Wire a quantized KV cache into an mlx-lm model's generation path.
 
     ``mlx_lm.generate()`` builds its prompt cache via
@@ -44,6 +44,13 @@ def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
 
     Returns:
         The list of KVCache instances now wired into ``model.make_cache``.
+
+    Raises:
+        QuantizerConfigError: If ``config.method`` is a standalone method
+            (does not implement the mlx_lm KVCache serving contract — see
+            ``veloxquant_mlx.cache.base.STANDALONE_METHODS``). Raised
+            immediately by the underlying ``KVCacheBuilder.for_model()``
+            call, before ``model.make_cache`` is touched.
 
     Example::
 

--- a/veloxquant_mlx/integration/mlx_vlm_patch.py
+++ b/veloxquant_mlx/integration/mlx_vlm_patch.py
@@ -35,7 +35,7 @@ repeated ``generate()`` calls never leak KV state between generations.
 from __future__ import annotations
 
 import warnings
-from typing import Any, List
+from typing import Any
 
 from veloxquant_mlx.cache.base import KVCacheBuilder, KVCacheConfig
 
@@ -60,7 +60,7 @@ _EVICTION_METHODS = frozenset(
 )
 
 
-def patch_vlm_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
+def patch_vlm_kv_cache(model: Any, config: KVCacheConfig) -> list[Any]:
     """Wire a quantized KV cache into an mlx-vlm model's generation path.
 
     Args:
@@ -77,6 +77,11 @@ def patch_vlm_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
         ValueError: If ``model`` has no ``language_model`` attribute —
             for text-only mlx_lm models use
             :func:`veloxquant_mlx.integration.mlx_lm_patch.patch_model_kv_cache`.
+        QuantizerConfigError: If ``config.method`` is a standalone method
+            (does not implement the mlx_lm KVCache serving contract — see
+            ``veloxquant_mlx.cache.base.STANDALONE_METHODS``). Raised
+            immediately by the underlying ``KVCacheBuilder.for_model()``
+            call, before ``language_model.make_cache`` is touched.
     """
     lm = getattr(model, "language_model", None)
     if lm is None:
@@ -102,7 +107,7 @@ def patch_vlm_kv_cache(model: Any, config: KVCacheConfig) -> List[Any]:
 
     caches = KVCacheBuilder.for_model(target, config)
 
-    def _make_cache(*_args: Any, **_kwargs: Any) -> List[Any]:
+    def _make_cache(*_args: Any, **_kwargs: Any) -> list[Any]:
         return KVCacheBuilder.for_model(target, config)
 
     lm.make_cache = _make_cache

--- a/veloxquant_mlx/tests/cache/test_base_for_model.py
+++ b/veloxquant_mlx/tests/cache/test_base_for_model.py
@@ -39,6 +39,63 @@ def test_for_model_refuses_standalone_methods(method: str) -> None:
         KVCacheBuilder.for_model(model, config)
 
 
+@pytest.mark.parametrize("method", sorted(STANDALONE_METHODS))
+def test_for_model_error_message_names_the_exact_method(method: str) -> None:
+    """The error must literally contain the method string so a user can act
+    on it without re-reading the source -- a bare regex-match on the class
+    of error is not enough of a guarantee on its own.
+    """
+    model = _make_fake_model()
+    config = KVCacheConfig(method=method, bit_width_inlier=1, seed=42)
+
+    with pytest.raises(QuantizerConfigError) as exc_info:
+        KVCacheBuilder.for_model(model, config)
+
+    assert repr(method) in str(exc_info.value)
+
+
+def test_standalone_methods_is_exactly_the_five_known_methods() -> None:
+    """Pins the registry itself. If a future PR adds/removes an entry, this
+    test forces a conscious update instead of silently widening or
+    narrowing which methods get refused.
+    """
+    assert STANDALONE_METHODS == {
+        "turboquant_prod",
+        "turboquant_mse",
+        "polar",
+        "qjl",
+        "spectral",
+    }
+
+
+def test_for_model_refuses_before_touching_model_attributes() -> None:
+    """The refusal must fire before for_model reads model.layers /
+    model.model.layers -- otherwise a malformed/incomplete fake or partially
+    loaded model could raise a confusing AttributeError instead of the
+    intended QuantizerConfigError.
+    """
+    model = object()  # has no .layers, .model, or anything else
+    config = KVCacheConfig(method="spectral", bit_width_inlier=1, seed=42)
+
+    with pytest.raises(QuantizerConfigError, match="spectral"):
+        KVCacheBuilder.for_model(model, config)
+
+
+def test_for_model_refusal_wins_over_invalid_bit_width_list() -> None:
+    """Standalone-method refusal must be checked before the per-layer
+    bit_width_inlier list-length validation, so a caller sees the more
+    fundamental "wrong method" error rather than an unrelated
+    "wrong list length" error that would vanish once they fixed the method.
+    """
+    model = _make_fake_model(n_layers=2)
+    # Deliberately wrong length (3 vs. 2 attention layers) -- if refusal
+    # didn't run first, this would raise a *different* QuantizerConfigError.
+    config = KVCacheConfig(method="qjl", bit_width_inlier=[1, 1, 1], seed=42)
+
+    with pytest.raises(QuantizerConfigError, match="qjl"):
+        KVCacheBuilder.for_model(model, config)
+
+
 def test_for_model_accepts_serving_compatible_method() -> None:
     model = _make_fake_model()
     config = KVCacheConfig(method="turboquant_rvq", bit_width_inlier=1, seed=42)
@@ -46,3 +103,27 @@ def test_for_model_accepts_serving_compatible_method() -> None:
     caches = KVCacheBuilder.for_model(model, config)
 
     assert len(caches) == 2
+
+
+def test_for_model_accepts_all_non_standalone_methods() -> None:
+    """Every method NOT in STANDALONE_METHODS must still be accepted by the
+    refusal check itself (build may still fail later for unrelated
+    per-method config reasons, but never with the standalone-refusal error).
+    """
+    import typing
+
+    hints = typing.get_type_hints(KVCacheConfig)
+    method_literal_args = typing.get_args(hints["method"])
+    non_standalone = [m for m in method_literal_args if m not in STANDALONE_METHODS]
+    assert non_standalone, "expected at least one non-standalone method in the registry"
+
+    for method in non_standalone:
+        model = _make_fake_model()
+        config = KVCacheConfig(method=method, bit_width_inlier=1, seed=42)
+        try:
+            KVCacheBuilder.for_model(model, config)
+        except QuantizerConfigError as exc:
+            assert "standalone" not in str(exc), (
+                f"method {method!r} is not in STANDALONE_METHODS but was refused "
+                f"as if it were: {exc}"
+            )

--- a/veloxquant_mlx/tests/cache/test_base_for_model.py
+++ b/veloxquant_mlx/tests/cache/test_base_for_model.py
@@ -1,0 +1,48 @@
+"""Tests for KVCacheBuilder.for_model's standalone-method refusal.
+
+Regression coverage for issue #56: for_model() (and, transitively,
+patch_model_kv_cache / patch_vlm_kv_cache) used to build/wire a cache for
+any config.method string with no check that the method actually satisfies
+the mlx_lm KVCache serving contract. Methods like "spectral" or "qjl"
+implement VeloxQuant's own KVCache ABC (append_key/append_value/attend/
+memory_bytes), not mlx_lm.models.cache.KVCache (update_and_fetch/nbytes/
+state/trim/merge/meta_state) -- see issue #27. Wiring one of these into a
+live mlx_lm.generate() call used to fail deep inside generation instead of
+at config/patch time.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from veloxquant_mlx.cache.base import STANDALONE_METHODS, KVCacheBuilder, KVCacheConfig
+from veloxquant_mlx.core.exceptions import QuantizerConfigError
+
+
+def _make_fake_model(n_layers: int = 2, n_heads: int = 2, head_dim: int = 32) -> SimpleNamespace:
+    hidden_size = n_heads * head_dim
+    layers = [
+        SimpleNamespace(self_attn=SimpleNamespace(head_dim=head_dim)) for _ in range(n_layers)
+    ]
+    args = SimpleNamespace(hidden_size=hidden_size, num_attention_heads=n_heads)
+    return SimpleNamespace(layers=layers, args=args)
+
+
+@pytest.mark.parametrize("method", sorted(STANDALONE_METHODS))
+def test_for_model_refuses_standalone_methods(method: str) -> None:
+    model = _make_fake_model()
+    config = KVCacheConfig(method=method, bit_width_inlier=1, seed=42)
+
+    with pytest.raises(QuantizerConfigError, match=method):
+        KVCacheBuilder.for_model(model, config)
+
+
+def test_for_model_accepts_serving_compatible_method() -> None:
+    model = _make_fake_model()
+    config = KVCacheConfig(method="turboquant_rvq", bit_width_inlier=1, seed=42)
+
+    caches = KVCacheBuilder.for_model(model, config)
+
+    assert len(caches) == 2

--- a/veloxquant_mlx/tests/integration/test_mlx_lm_patch.py
+++ b/veloxquant_mlx/tests/integration/test_mlx_lm_patch.py
@@ -17,6 +17,7 @@ import mlx.core as mx
 import pytest
 
 from veloxquant_mlx.cache.base import KVCacheConfig
+from veloxquant_mlx.core.exceptions import QuantizerConfigError
 from veloxquant_mlx.integration.mlx_lm_patch import patch_model_kv_cache
 
 
@@ -46,6 +47,20 @@ def test_patch_model_kv_cache_wires_make_cache() -> None:
     # and must return the same cache list every time (persistent, not rebuilt).
     assert model.make_cache() is caches
     assert model.make_cache(some_arg=1) is caches
+
+
+def test_patch_model_kv_cache_refuses_standalone_method() -> None:
+    """spectral does not implement the mlx_lm KVCache serving contract (#27) --
+    patching it in must raise before model.make_cache is ever touched, not
+    fail later inside mlx_lm.generate().
+    """
+    model = _make_fake_model(n_layers=2)
+    config = KVCacheConfig(method="spectral", bit_width_inlier=1, seed=42)
+
+    with pytest.raises(QuantizerConfigError, match="spectral"):
+        patch_model_kv_cache(model, config)
+
+    assert not hasattr(model, "make_cache")
 
 
 def test_patch_model_kv_cache_returns_correct_method() -> None:

--- a/veloxquant_mlx/tests/integration/test_mlx_vlm_patch.py
+++ b/veloxquant_mlx/tests/integration/test_mlx_vlm_patch.py
@@ -18,6 +18,7 @@ import mlx.core as mx
 import pytest
 
 from veloxquant_mlx.cache.base import KVCacheConfig
+from veloxquant_mlx.core.exceptions import QuantizerConfigError
 from veloxquant_mlx.integration.mlx_vlm_patch import patch_vlm_kv_cache
 
 
@@ -93,6 +94,18 @@ def test_patch_builds_requested_method():
     caches = patch_vlm_kv_cache(model, config)
     for c in caches:
         assert type(c).__name__ == "TurboQuantRVQKVCache"
+
+
+def test_rejects_standalone_method():
+    """qjl does not implement the mlx_lm KVCache serving contract (#27) --
+    patching it into a VLM's language_model must raise before
+    language_model.make_cache is ever touched.
+    """
+    model = _make_fake_vlm(n_layers=2)
+    config = KVCacheConfig(method="qjl", seed=42)
+    with pytest.raises(QuantizerConfigError, match="qjl"):
+        patch_vlm_kv_cache(model, config)
+    assert not hasattr(model.language_model, "make_cache")
 
 
 def test_rejects_text_only_model():

--- a/veloxquant_mlx/tests/integration/test_mlx_vlm_patch.py
+++ b/veloxquant_mlx/tests/integration/test_mlx_vlm_patch.py
@@ -108,6 +108,22 @@ def test_rejects_standalone_method():
     assert not hasattr(model.language_model, "make_cache")
 
 
+@pytest.mark.parametrize("wrapper_exposes_layers", [False, True])
+def test_rejects_standalone_method_regardless_of_wrapper_shape(wrapper_exposes_layers):
+    """for_model's target resolution (top-level model.layers for Qwen2-VL-style
+    wrappers vs. language_model directly) must not bypass the refusal check
+    on either branch.
+    """
+    model = _make_fake_vlm(n_layers=2, wrapper_exposes_layers=wrapper_exposes_layers)
+    config = KVCacheConfig(method="polar", seed=42)
+
+    with pytest.raises(QuantizerConfigError, match="polar"):
+        patch_vlm_kv_cache(model, config)
+
+    assert not hasattr(model.language_model, "make_cache")
+    assert not callable(getattr(model, "make_cache", None))
+
+
 def test_rejects_text_only_model():
     text_model = _make_language_model(n_layers=2, n_heads=2, head_dim=32)
     config = KVCacheConfig(method="turboquant_rvq", bit_width_inlier=1, seed=42)


### PR DESCRIPTION
## Summary
`KVCacheBuilder.for_model()` and, transitively, `patch_model_kv_cache()` / `patch_vlm_kv_cache()` built and wired a cache for any `config.method` string with no check that the method actually satisfies the `mlx_lm` KVCache serving contract.

Per #27's audit, 5 of the 40 registered methods (`turboquant_prod`, `turboquant_mse`, `polar`, `qjl`, `spectral`) implement VeloxQuant's own `KVCache` ABC (`append_key`/`append_value`/`attend`/`memory_bytes`) instead of subclassing `mlx_lm.models.cache.KVCache` (`update_and_fetch`/`nbytes`/`state`/`trim`/`merge`/`meta_state`). Picking one of these for a live `mlx_lm.generate()` call used to crash or silently misbehave deep inside generation, instead of failing clearly at config/patch time.

## Changes
- `veloxquant_mlx/cache/base.py`: adds `STANDALONE_METHODS` (the 5 methods above) and a refusal check at the top of `KVCacheBuilder.for_model()` that raises `QuantizerConfigError` naming the offending method, before any cache objects are built.
- `patch_model_kv_cache()` / `patch_vlm_kv_cache()` both call `for_model()` before touching `model.make_cache`, so they inherit the refusal automatically — verified with new tests at both entry points.
- Direct standalone/research usage via `KVCacheBuilder.build()` / `KVCacheFactory.create()` is untouched — those remain the documented path for these 5 methods.
- Docstrings updated on both patch functions to document the new `Raises`.
- Cleans up pre-existing `typing.List` → `list` (ruff `UP035`/`UP006`) debt in `mlx_vlm_patch.py`, a file this change edits.

## Scope note
This depends on/overlaps with #54's taxonomy (already landed in #61 as README docs). Per #56's own scope note, since #54 landed first this PR is "wire the taxonomy into a refusal check at the two entry points" using a code-level `STANDALONE_METHODS` set (kept independent of the README table so this PR doesn't depend on #61 merging first).

Fixes #56

## Test plan
- [x] New parametrized test: `for_model()` raises `QuantizerConfigError` for all 5 standalone methods, and still succeeds for a serving-compatible method (`veloxquant_mlx/tests/cache/test_base_for_model.py`)
- [x] New test: `patch_model_kv_cache()` raises before touching `model.make_cache` for `spectral` (`test_mlx_lm_patch.py`)
- [x] New test: `patch_vlm_kv_cache()` raises before touching `language_model.make_cache` for `qjl` (`test_mlx_vlm_patch.py`)
- [x] Full suite: `pytest veloxquant_mlx/tests -q` → 1492 passed (1484 existing + 8 new)
- [x] `ruff check` / `ruff format --check` clean on all touched files