### PR TITLE
fix(cache): rename KVQuantKVCache.bits to nuq_bits to avoid mlx_lm SDPA dispatch trap

### DIFF
--- a/veloxquant_mlx/cache/kvquant_cache.py
+++ b/veloxquant_mlx/cache/kvquant_cache.py
@@ -56,6 +56,11 @@ class KVQuantKVCache(_MLXKVCache):
             ``kvquant_group_size``       (int, default 32; reserved for grouped fits),
             ``kvquant_lloyd_iters``      (int, default 8),
             ``kvquant_refit_interval``   (int, default 0 = freeze prefill levels).
+
+    No ``.bits`` attribute — mlx_lm's SDPA checks ``hasattr(cache, "bits")``
+    to route to its quantized-matmul kernel path, which expects a different
+    cache layout (mx.quantize's native tuple format) and a ``.group_size``
+    attribute this cache doesn't have. We expose ``.nuq_bits`` instead.
     """
 
     def __init__(self, config: Any) -> None:
@@ -170,7 +175,13 @@ class KVQuantKVCache(_MLXKVCache):
     # Properties
     # ------------------------------------------------------------------
     @property
-    def bits(self) -> int:
+    def nuq_bits(self) -> int:
+        # Deliberately not named `.bits` — mlx_lm's SDPA checks
+        # `hasattr(cache, "bits")` to route to its quantized-matmul kernel,
+        # which expects mx.quantize's native tuple layout and a `.group_size`
+        # attribute this cache doesn't have. Exposing `.bits` here would
+        # silently hijack attention dispatch. See other *_cache.py classes
+        # (e.g. kivi_cache.py, turboquant_rvq_cache.py) for the same guard.
         return self._bits
 
     @property

--- a/veloxquant_mlx/tests/cache/test_kvquant_cache.py
+++ b/veloxquant_mlx/tests/cache/test_kvquant_cache.py
@@ -1,6 +1,6 @@
 """Tests for KVQuantKVCache — non-uniform quantization + dense/sparse outliers.
 
-15 tests covering:
+16 tests covering:
   1.  Factory dispatch
   2.  Output shape (prefill + decode)
   3.  Values reconstructed within tolerance
@@ -16,6 +16,7 @@
   13. effective_bits within [bits, bits + overhead] at realistic context
   14. Per-channel (key) vs per-token (value) axis correctness
   15. Determinism (end-to-end)
+  16. No public `.bits` attribute (mlx_lm SDPA dispatch trap)
 """
 
 from __future__ import annotations
@@ -215,10 +216,10 @@ def test_key_value_axes():
     cache.update_and_fetch(_laplace(1, 1, 64, 64), _laplace(1, 1, 64, 64, seed=1))
     # Keys: per-channel levels → [L, D] with D = head_dim columns.
     kl = cache.key_levels[0]
-    assert kl.shape[0] == (1 << cache.bits) and kl.shape[1] == 64
+    assert kl.shape[0] == (1 << cache.nuq_bits) and kl.shape[1] == 64
     # Values: per-token levels (transposed space) → columns are tokens (S=64).
     vl = cache.value_levels[0]
-    assert vl.shape[0] == (1 << cache.bits) and vl.shape[1] == 64
+    assert vl.shape[0] == (1 << cache.nuq_bits) and vl.shape[1] == 64
 
 
 # ---------------------------------------------------------------------------
@@ -237,3 +238,19 @@ def test_determinism():
     k2, v2 = run()
     np.testing.assert_array_equal(k1, k2)
     np.testing.assert_array_equal(v1, v2)
+
+
+# ---------------------------------------------------------------------------
+# Test 16 — no public .bits attribute (mlx_lm SDPA dispatch trap)
+# ---------------------------------------------------------------------------
+def test_no_bits_leak():
+    """mlx_lm's SDPA checks `hasattr(cache, "bits")` to route to its
+    quantized-matmul kernel, which expects mx.quantize's native tuple layout
+    and a `.group_size` attribute this cache doesn't have. Exposing `.bits`
+    here would silently hijack attention dispatch — see issue #87."""
+    cache = KVQuantKVCache(_cfg(kvquant_bits=3))
+    assert not hasattr(cache, "bits"), (
+        "KVQuantKVCache must not expose .bits — would break mlx_lm SDPA dispatch"
+    )
+    assert hasattr(cache, "nuq_bits")
+    assert cache.nuq_bits == 3


### PR DESCRIPTION
## Summary

- `KVQuantKVCache` exposed a public `.bits` property, which mlx_lm's `scaled_dot_product_attention` treats as a sentinel (`hasattr(cache, "bits")`) for routing attention through its quantized-matmul kernel path — a path that expects MLX's native quantized tuple layout and a `.group_size` attribute.
- `KVQuantKVCache.update_and_fetch` actually returns plain fp16 tensors and has no `.group_size`, so any attention call through the standard `mlx_lm` dispatcher for `method="kvquant"` crashed immediately with `AttributeError: 'KVQuantKVCache' object has no attribute 'group_size'`.
- Renamed the public property to `.nuq_bits`, matching the `.assigned_avg_bits` convention already used by `kivi_cache.py` and `turboquant_rvq_cache.py` to sidestep this exact hazard.

Fixes #87.

## Test plan

- [x] `pytest veloxquant_mlx/tests/cache/test_kvquant_cache.py -v` — 16/16 passed (added `test_no_bits_leak` regression guard)
- [x] `pytest veloxquant_mlx/tests/cache/` — 554/554 passed, no regressions
- [x] Verified the issue's repro script: `hasattr(cache, "bits")` is now `False`, `cache.nuq_bits` returns the configured bit width

🤖 Generated with [Claude Code](https://claude.com/claude-code)