### PR TITLE
fix(cache): age KIVI residual tokens out by true cumulative position, not per-call S

### DIFF
--- a/veloxquant_mlx/cache/kivi_cache.py
+++ b/veloxquant_mlx/cache/kivi_cache.py
@@ -79,6 +79,12 @@ class KIVIKVCache(_MLXKVCache):
         self._residual_fp16_bytes = 0
         self._tokens_seen = 0
 
+        # Cumulative count of leading tokens (absolute sequence positions
+        # [0, _n_quantized)) that have already been quantized in-place in
+        # the parent cache's storage. Tokens age out of the fp16 residual
+        # window based on true cumulative position, not this call's S.
+        self._n_quantized = 0
+
     # ------------------------------------------------------------------
     # Group quant/dequant helpers (asymmetric min/max, deterministic)
     # ------------------------------------------------------------------
@@ -116,48 +122,59 @@ class KIVIKVCache(_MLXKVCache):
     # mlx_lm protocol
     # ------------------------------------------------------------------
     def update_and_fetch(self, keys, values):
-        """Quantize the aged-out portion of K/V, keep the residual in fp16.
+        """Quantize whatever has aged out of the fp16 residual window.
 
-        We quantize **only** tokens that fall outside the most-recent
-        ``residual_length`` window of the *current* incoming block.  During
-        prefill (large S) this quantizes the bulk and keeps the tail exact;
-        during decode (S==1) the new token is within the residual window and
-        passes through untouched until it ages out on later steps.
+        Tokens age out based on their **true cumulative position** in the
+        sequence, not this call's own ``S``: after every call, the most
+        recent ``residual_length`` tokens (of the *entire* history) stay
+        fp16 and everything older is quantized. During decode (S==1) that
+        means each new token starts in the residual window and gets
+        quantized ``residual_length`` steps later, once it actually ages
+        out — not never, as a per-call ``S <= residual_length`` check would
+        imply.
+
+        Implementation: store the incoming block via the parent cache
+        first (so ``self.offset``/``self.keys``/``self.values`` reflect the
+        full accumulated history), then quantize-in-place any newly-aged
+        leading slice of that stored buffer that hasn't been quantized yet.
         """
         B, H, S, D = keys.shape
         r = self._residual_length
+        k_all, v_all = super().update_and_fetch(keys, values)
 
-        if S <= r:
-            # Entire incoming block is within the fp16 residual window.
-            k_out, v_out = keys, values
-            n_quant = 0
-        else:
-            n_quant = S - r
-            k_q = self._quant_dequant_along(keys[:, :, :n_quant, :], axis=-2)
-            v_q = self._quant_dequant_along(values[:, :, :n_quant, :], axis=-1)
-            k_out = mx.concatenate([k_q, keys[:, :, n_quant:, :]], axis=2)
-            v_out = mx.concatenate([v_q, values[:, :, n_quant:, :]], axis=2)
+        new_boundary = max(0, self.offset - r)
+        n_quant_now = new_boundary - self._n_quantized
+        if n_quant_now > 0:
+            lo, hi = self._n_quantized, new_boundary
+            k_q = self._quant_dequant_along(self.keys[:, :, lo:hi, :], axis=-2)
+            v_q = self._quant_dequant_along(self.values[:, :, lo:hi, :], axis=-1)
+            self.keys[:, :, lo:hi, :] = k_q
+            self.values[:, :, lo:hi, :] = v_q
+            self._n_quantized = new_boundary
+            k_all, v_all = self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
 
-        self._account_bytes(B, H, S, D, n_quant)
-        return super().update_and_fetch(k_out, v_out)
+        self._account_bytes(B, H, S, D, n_quant_now)
+        return k_all, v_all
 
-    def _account_bytes(self, B: int, H: int, S: int, D: int, n_quant: int) -> None:
-        n_res = S - n_quant
+    def _account_bytes(self, B: int, H: int, S: int, D: int, n_quant_now: int) -> None:
         gs = self._group_size
         # Quantized keys: per-channel — D channels, ceil(n_quant/gs) groups,
         # b bits/code + (scale, zero) fp16 per (group, channel).
-        if n_quant > 0:
-            k_groups = math.ceil(n_quant / gs)
-            k_code_bytes = math.ceil(n_quant * D * self._b / 8) * H * B
+        if n_quant_now > 0:
+            k_groups = math.ceil(n_quant_now / gs)
+            k_code_bytes = math.ceil(n_quant_now * D * self._b / 8) * H * B
             k_param_bytes = k_groups * D * 2 * 2 * H * B  # scale+zero, fp16
             # Quantized values: per-token — ceil(D/gs) groups per token.
             v_groups = math.ceil(D / gs)
-            v_code_bytes = math.ceil(n_quant * D * self._b / 8) * H * B
-            v_param_bytes = n_quant * v_groups * 2 * 2 * H * B
+            v_code_bytes = math.ceil(n_quant_now * D * self._b / 8) * H * B
+            v_param_bytes = n_quant_now * v_groups * 2 * 2 * H * B
             self._key_bytes_compressed += k_code_bytes + k_param_bytes
             self._value_bytes_compressed += v_code_bytes + v_param_bytes
-        # fp16 residual window (kept exact)
-        self._residual_fp16_bytes += n_res * D * 2 * 2 * H * B  # K+V
+        # fp16 residual window: current size (not cumulative) — this is
+        # the live, still-fp16 tail, so it must plateau at residual_length
+        # once the window fills, not grow with every call.
+        n_res = self.offset - self._n_quantized
+        self._residual_fp16_bytes = n_res * D * 2 * 2 * H * B  # K+V
         # fp16 equivalents (for ratio): every token at full precision
         self._key_bytes_fp16 += H * B * S * D * 2
         self._value_bytes_fp16 += H * B * S * D * 2

--- a/veloxquant_mlx/cache/sink_cache.py
+++ b/veloxquant_mlx/cache/sink_cache.py
@@ -90,22 +90,29 @@ class SinkProtectedKVCache(KIVIKVCache):
     # mlx_lm protocol
     # ------------------------------------------------------------------
     def update_and_fetch(self, keys, values):
-        """Quantize aged-out tokens except sinks; keep residual + sinks fp16."""
+        """Quantize aged-out tokens except sinks; keep residual + sinks fp16.
+
+        Ages tokens out based on **true cumulative position** (mirrors the
+        fix in ``KIVIKVCache.update_and_fetch``): store the incoming block
+        via the parent first, then quantize-in-place the newly-aged leading
+        slice ``[self._n_quantized, self.offset - residual_length)`` of the
+        accumulated buffer, skipping any position still marked a sink.
+        """
         B, H, S, D = keys.shape
         r = self._residual_length
         start = self.offset  # absolute position of keys[:, :, 0, :]
 
         sinks = self._update_sinks(keys, start)
+        k_all, v_all = super(KIVIKVCache, self).update_and_fetch(keys, values)
 
-        if S <= r:
-            k_out, v_out = keys, values
-            n_quant = 0
-            n_sink_in_block = 0
-        else:
-            n_quant = S - r
-            sink_local = sorted(p - start for p in sinks if 0 <= p - start < n_quant)
-            k_region = keys[:, :, :n_quant, :]
-            v_region = values[:, :, :n_quant, :]
+        new_boundary = max(0, self.offset - r)
+        n_quant_now = new_boundary - self._n_quantized
+        n_sink_in_block = 0
+        if n_quant_now > 0:
+            lo, hi = self._n_quantized, new_boundary
+            sink_local = sorted(p - lo for p in sinks if lo <= p < hi)
+            k_region = self.keys[:, :, lo:hi, :]
+            v_region = self.values[:, :, lo:hi, :]
             if sink_local:
                 # Per the KVSink paper, sinks must be excluded from
                 # quantization *parameter calibration*, not just restored
@@ -122,39 +129,40 @@ class SinkProtectedKVCache(KIVIKVCache):
                         src -= 1
                     if src < 0 or src in sink_set:
                         src = idx + 1
-                        while src in sink_set and src < n_quant - 1:
+                        while src in sink_set and src < n_quant_now - 1:
                             src += 1
-                    if 0 <= src < n_quant and src not in sink_set:
-                        k_region[:, :, idx, :] = keys[:, :, src, :]
-                        v_region[:, :, idx, :] = values[:, :, src, :]
+                    if 0 <= src < n_quant_now and src not in sink_set:
+                        k_region[:, :, idx, :] = self.keys[:, :, lo + src, :]
+                        v_region[:, :, idx, :] = self.values[:, :, lo + src, :]
             k_q = self._quant_dequant_along(k_region, axis=-2)
             v_q = self._quant_dequant_along(v_region, axis=-1)
             # Restore fp16 for sink positions inside the quantized region.
             for idx in sink_local:
-                k_q[:, :, idx, :] = keys[:, :, idx, :]
-                v_q[:, :, idx, :] = values[:, :, idx, :]
+                k_q[:, :, idx, :] = self.keys[:, :, lo + idx, :]
+                v_q[:, :, idx, :] = self.values[:, :, lo + idx, :]
+            self.keys[:, :, lo:hi, :] = k_q
+            self.values[:, :, lo:hi, :] = v_q
             n_sink_in_block = len(sink_local)
-            k_out = mx.concatenate([k_q, keys[:, :, n_quant:, :]], axis=2)
-            v_out = mx.concatenate([v_q, values[:, :, n_quant:, :]], axis=2)
+            self._n_quantized = new_boundary
+            k_all, v_all = self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
 
-        self._account_bytes_with_sinks(B, H, S, D, n_quant, n_sink_in_block)
-        # offset is advanced by the parent call below.
-        return super(KIVIKVCache, self).update_and_fetch(k_out, v_out)
+        self._account_bytes_with_sinks(B, H, S, D, n_quant_now, n_sink_in_block)
+        return k_all, v_all
 
     def _account_bytes_with_sinks(
-        self, B: int, H: int, S: int, D: int, n_quant: int, n_sink: int
+        self, B: int, H: int, S: int, D: int, n_quant_now: int, n_sink: int
     ) -> None:
         """KIVI accounting with sinks split out — no double counting.
 
-        Of the S incoming tokens: ``n_quant - n_sink`` are compressed,
-        ``n_sink`` go to the sink fp16 pool, and ``S - n_quant`` go to the
-        residual fp16 window.  Calling the parent ``_account_bytes`` with a
-        reduced n_quant would inflate its residual term (it derives
-        ``n_res = S - n_quant``), so we account the three pools explicitly.
+        Of the tokens newly quantized this call: ``n_quant_now - n_sink``
+        are compressed and ``n_sink`` go to the sink fp16 pool.  The
+        residual window is reported as its *current* live size (the
+        cumulative fp16 tail), not a per-call delta, so it plateaus at
+        ``residual_length`` once the window fills.
         """
         import math
 
-        n_compressed = n_quant - n_sink
+        n_compressed = n_quant_now - n_sink
         gs = self._group_size
         if n_compressed > 0:
             k_groups = math.ceil(n_compressed / gs)
@@ -166,7 +174,8 @@ class SinkProtectedKVCache(KIVIKVCache):
             self._key_bytes_compressed += k_code_bytes + k_param_bytes
             self._value_bytes_compressed += v_code_bytes + v_param_bytes
         self._sink_fp16_bytes += n_sink * D * 2 * 2 * H * B  # K+V
-        self._residual_fp16_bytes += (S - n_quant) * D * 2 * 2 * H * B
+        n_res = self.offset - self._n_quantized
+        self._residual_fp16_bytes = n_res * D * 2 * 2 * H * B
         self._key_bytes_fp16 += H * B * S * D * 2
         self._value_bytes_fp16 += H * B * S * D * 2
         self._tokens_seen += S

--- a/veloxquant_mlx/tests/cache/test_kivi_cache.py
+++ b/veloxquant_mlx/tests/cache/test_kivi_cache.py
@@ -113,3 +113,26 @@ def test_higher_bits_more_compressed_bytes_but_better_quality(b: int) -> None:
     ko, _ = cache.update_and_fetch(k, v)
     mx.eval(ko)
     assert cache.assigned_avg_bits == float(b)
+
+
+def test_decode_tokens_age_out_of_residual_window() -> None:
+    """Regression for #86: with S==1 every decode step, tokens must still
+    age out of the fp16 residual window once total cumulative length
+    exceeds residual_length — the residual byte count must plateau, not
+    grow unboundedly with decode steps."""
+    cache = _make(residual_length=4, kivi_group_size=4)
+    k, v = _kv(1, 1, 10, 128, seed=7)
+    cache.update_and_fetch(k, v)  # prefill: 10 tokens, 6 quantized, 4 residual
+
+    for t in range(50):
+        k1, v1 = _kv(1, 1, 1, 128, seed=200 + t)
+        cache.update_and_fetch(k1, v1)
+
+    assert cache.offset == 60
+    D, H, B = 128, 1, 1
+    expected_residual = 4 * D * 2 * 2 * H * B  # residual_length * K+V * fp16 bytes
+    assert cache.residual_fp16_bytes == expected_residual, (
+        f"residual_fp16_bytes={cache.residual_fp16_bytes} did not plateau at "
+        f"{expected_residual} after 50 decode steps past the residual window"
+    )
+    assert cache.compressed_key_bytes > 0

--- a/veloxquant_mlx/tests/cache/test_sink_cache.py
+++ b/veloxquant_mlx/tests/cache/test_sink_cache.py
@@ -123,6 +123,30 @@ def test_decode_steps_after_prefill() -> None:
     assert c.offset == 45
 
 
+def test_decode_tokens_age_out_of_residual_window() -> None:
+    """Regression for #86 (inherited via KIVIKVCache.update_and_fetch):
+    with S==1 every decode step, tokens must still age out of the fp16
+    residual window once cumulative length exceeds residual_length."""
+    c = _make(residual_length=4, n_sink_tokens=1, kivi_group_size=4)
+    K, V = _kv_with_sinks(S=10, H=1, D=128, sink_pos=(0,))
+    c.update_and_fetch(mx.array(K), mx.array(V))
+
+    rng = np.random.default_rng(11)
+    for _ in range(50):
+        k1 = mx.array(rng.standard_normal((1, 1, 1, 128)).astype(np.float16))
+        v1 = mx.array(rng.standard_normal((1, 1, 1, 128)).astype(np.float16))
+        c.update_and_fetch(k1, v1)
+
+    assert c.offset == 60
+    D, H, B = 128, 1, 1
+    expected_residual = 4 * D * 2 * 2 * H * B
+    assert c.residual_fp16_bytes == expected_residual, (
+        f"residual_fp16_bytes={c.residual_fp16_bytes} did not plateau at "
+        f"{expected_residual} after 50 decode steps past the residual window"
+    )
+    assert c.compressed_key_bytes > 0
+
+
 def _recon_err(cache, K, V):
     ko, _ = cache.update_and_fetch(mx.array(K), mx.array(V))
     mx.eval(ko)


### PR DESCRIPTION
## Summary

- `KIVIKVCache.update_and_fetch` decided which tokens to quantize using only the **current call's** incoming row count `S`, compared against `residual_length`. Every decode call has `S == 1`, which is always `<= residual_length` (default 128) — so `n_quant` was always `0` and every decode token stayed fp16 forever, regardless of how long generation ran.
- This silently defeated KIVI's compression benefit for the decode phase — the dominant phase of any long-running generation — since the fp16 residual window grew unboundedly instead of staying capped at `residual_length`.
- `SinkProtectedKVCache` subclasses `KIVIKVCache` and reuses this exact `update_and_fetch`/`_quant_dequant_along` logic for its own residual accounting, so it inherited the identical bug.

## Fix

Both `update_and_fetch` implementations now:
1. Store the incoming block via the parent cache first, so `self.offset`/`self.keys`/`self.values` reflect the **true accumulated history** (not just this call's block).
2. Compute `new_boundary = max(0, self.offset - residual_length)` — the count of leading tokens across the *entire* history that should now be quantized.
3. Quantize in-place only the newly-aged delta `[self._n_quantized, new_boundary)` from the stored buffer (tracked via a new `self._n_quantized` counter), so previously-passed-through residual tokens correctly age out on later calls instead of never being revisited.

`residual_fp16_bytes` accounting changed from an unbounded running sum to the *current* live residual-window size, so it now plateaus at `residual_length` once the window fills, matching the documented contract.

`SinkProtectedKVCache`'s sink-exclusion-from-quantization-calibration logic (excluding high-key-norm tokens from group min/max calibration, restoring them fp16 afterward) is preserved — it now operates over the newly-aged absolute range instead of the incoming block's local range.

Fixes #86.

## Test plan

- [x] `pytest veloxquant_mlx/tests/cache/test_kivi_cache.py -v` — 10/10 passed (added `test_decode_tokens_age_out_of_residual_window` regression guard)
- [x] `pytest veloxquant_mlx/tests/cache/test_sink_cache.py -v` — 10/10 passed (added equivalent regression guard, since the class inherits the bug)
- [x] `pytest veloxquant_mlx/tests/cache/` — 556/556 passed, no regressions
- [x] Verified the issue's repro script: after 10 prefill + 50 decode tokens with `residual_length=4`, `residual_fp16_bytes` now plateaus at 128 bytes (the expected `residual_length * D * 2 * 2 * H * B`) instead of growing to 1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)