### PR TITLE
fix(cache): track sink positions independently per batch element

### DIFF
--- a/veloxquant_mlx/cache/sink_cache.py
+++ b/veloxquant_mlx/cache/sink_cache.py
@@ -52,7 +52,11 @@ class SinkProtectedKVCache(KIVIKVCache):
         Selection signal is the per-token key L2-norm averaged over KV heads
         (mean, not max: a sink absorbs attention from *all* heads, and the
         mean is robust to a single head's scale spikes).  Positions are
-        tracked in absolute sequence coordinates via ``self.offset``.
+        tracked in absolute sequence coordinates via ``self.offset``,
+        **independently per batch element** — sink/outlier positions are a
+        property of each sequence's own content and generally differ across
+        a batch (see #85: collapsing to batch element 0 silently
+        misprotected every other batch element).
     """
 
     def __init__(self, config: Any) -> None:
@@ -60,31 +64,40 @@ class SinkProtectedKVCache(KIVIKVCache):
         self._n_sink = int(getattr(config, "n_sink_tokens", 5))
         if self._n_sink < 0:
             raise ValueError(f"SinkProtectedKVCache: n_sink_tokens={self._n_sink} must be >= 0.")
-        # Running candidates: absolute position -> key-norm (float).
-        # Pruned to the top n_sink entries after every update.
-        self._sink_norms: dict[int, float] = {}
+        # Running candidates per batch element: list index b -> {absolute
+        # position -> key-norm}. Each batch element's dict is independently
+        # pruned to the top n_sink entries after every update. Lazily grown
+        # to size B on the first call (B is not known at construction).
+        self._sink_norms: list[dict[int, float]] = []
         self._sink_fp16_bytes = 0
 
     # ------------------------------------------------------------------
     # Sink bookkeeping
     # ------------------------------------------------------------------
-    def _update_sinks(self, keys: mx.array, start_pos: int) -> set:
-        """Fold the incoming block's key norms into the running top-k.
+    def _update_sinks(self, keys: mx.array, start_pos: int) -> list:
+        """Fold the incoming block's key norms into each batch element's
+        running top-k independently.
 
-        Returns the current sink-position set after the update.
+        Returns a list of length ``B``, one sink-position set per batch
+        element, after the update.
         """
+        B = keys.shape[0]
+        if len(self._sink_norms) < B:
+            self._sink_norms.extend({} for _ in range(B - len(self._sink_norms)))
         if self._n_sink == 0:
-            return set()
-        # [B, H, S, D] -> per-token norm, mean over heads, batch 0.
+            return [set() for _ in range(B)]
+        # [B, H, S, D] -> per-token norm, mean over heads, kept per batch.
         norms = mx.linalg.norm(keys.astype(mx.float32), axis=-1)  # [B, H, S]
-        per_tok = mx.mean(norms, axis=1)[0]  # [S]
-        per_tok_np = [float(v) for v in per_tok.tolist()]
-        for i, v in enumerate(per_tok_np):
-            self._sink_norms[start_pos + i] = v
-        if len(self._sink_norms) > self._n_sink:
-            keep = sorted(self._sink_norms.items(), key=lambda kv: -kv[1])
-            self._sink_norms = dict(keep[: self._n_sink])
-        return set(self._sink_norms.keys())
+        per_tok = mx.mean(norms, axis=1)  # [B, S]
+        per_tok_np = per_tok.tolist()
+        for b in range(B):
+            norms_b = self._sink_norms[b]
+            for i, v in enumerate(per_tok_np[b]):
+                norms_b[start_pos + i] = float(v)
+            if len(norms_b) > self._n_sink:
+                keep = sorted(norms_b.items(), key=lambda kv: -kv[1])
+                self._sink_norms[b] = dict(keep[: self._n_sink])
+        return [set(self._sink_norms[b].keys()) for b in range(B)]
 
     # ------------------------------------------------------------------
     # mlx_lm protocol
@@ -96,13 +109,16 @@ class SinkProtectedKVCache(KIVIKVCache):
         fix in ``KIVIKVCache.update_and_fetch``): store the incoming block
         via the parent first, then quantize-in-place the newly-aged leading
         slice ``[self._n_quantized, self.offset - residual_length)`` of the
-        accumulated buffer, skipping any position still marked a sink.
+        accumulated buffer, skipping any position still marked a sink **for
+        that batch element** — sink selection and exclusion are computed
+        independently per batch index (#85), since each sequence's own
+        outlier tokens generally sit at different positions.
         """
         B, H, S, D = keys.shape
         r = self._residual_length
         start = self.offset  # absolute position of keys[:, :, 0, :]
 
-        sinks = self._update_sinks(keys, start)
+        sinks_per_batch = self._update_sinks(keys, start)
         k_all, v_all = super(KIVIKVCache, self).update_and_fetch(keys, values)
 
         new_boundary = max(0, self.offset - r)
@@ -110,39 +126,56 @@ class SinkProtectedKVCache(KIVIKVCache):
         n_sink_in_block = 0
         if n_quant_now > 0:
             lo, hi = self._n_quantized, new_boundary
-            sink_local = sorted(p - lo for p in sinks if lo <= p < hi)
             k_region = self.keys[:, :, lo:hi, :]
             v_region = self.values[:, :, lo:hi, :]
-            if sink_local:
+            sink_local_per_b = [
+                sorted(p - lo for p in sinks_per_batch[b] if lo <= p < hi) for b in range(B)
+            ]
+            any_sinks = any(sink_local_per_b)
+            if any_sinks:
                 # Per the KVSink paper, sinks must be excluded from
                 # quantization *parameter calibration*, not just restored
                 # afterwards: a 25x-magnitude sink inflates its group's
                 # min/max scale and ruins every neighbor in the group.
                 # Neutralize each sink row with the nearest non-sink row
-                # before computing quant params, then restore fp16 below.
-                sink_set = set(sink_local)
+                # (within the same batch element) before computing quant
+                # params, then restore fp16 below.
                 k_region = mx.array(k_region)  # materialize a copy
                 v_region = mx.array(v_region)
-                for idx in sink_local:
-                    src = idx - 1
-                    while src in sink_set and src > 0:
-                        src -= 1
-                    if src < 0 or src in sink_set:
-                        src = idx + 1
-                        while src in sink_set and src < n_quant_now - 1:
-                            src += 1
-                    if 0 <= src < n_quant_now and src not in sink_set:
-                        k_region[:, :, idx, :] = self.keys[:, :, lo + src, :]
-                        v_region[:, :, idx, :] = self.values[:, :, lo + src, :]
+                for b in range(B):
+                    sink_local = sink_local_per_b[b]
+                    if not sink_local:
+                        continue
+                    sink_set = set(sink_local)
+                    for idx in sink_local:
+                        src = idx - 1
+                        while src in sink_set and src > 0:
+                            src -= 1
+                        if src < 0 or src in sink_set:
+                            src = idx + 1
+                            while src in sink_set and src < n_quant_now - 1:
+                                src += 1
+                        if 0 <= src < n_quant_now and src not in sink_set:
+                            k_region[b, :, idx, :] = self.keys[b, :, lo + src, :]
+                            v_region[b, :, idx, :] = self.values[b, :, lo + src, :]
             k_q = self._quant_dequant_along(k_region, axis=-2)
             v_q = self._quant_dequant_along(v_region, axis=-1)
-            # Restore fp16 for sink positions inside the quantized region.
-            for idx in sink_local:
-                k_q[:, :, idx, :] = self.keys[:, :, lo + idx, :]
-                v_q[:, :, idx, :] = self.values[:, :, lo + idx, :]
+            # Restore fp16 for sink positions inside the quantized region,
+            # per batch element.
+            max_sinks = 0
+            for b in range(B):
+                sink_local = sink_local_per_b[b]
+                max_sinks = max(max_sinks, len(sink_local))
+                for idx in sink_local:
+                    k_q[b, :, idx, :] = self.keys[b, :, lo + idx, :]
+                    v_q[b, :, idx, :] = self.values[b, :, lo + idx, :]
             self.keys[:, :, lo:hi, :] = k_q
             self.values[:, :, lo:hi, :] = v_q
-            n_sink_in_block = len(sink_local)
+            # Byte accounting is a single scalar pool shared across the
+            # batch; use the max per-batch sink count so the reported sink
+            # pool never under-counts (all batch elements pay the same
+            # fp16 storage shape regardless of how many are true sinks).
+            n_sink_in_block = max_sinks
             self._n_quantized = new_boundary
             k_all, v_all = self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
 
@@ -190,8 +223,21 @@ class SinkProtectedKVCache(KIVIKVCache):
 
     @property
     def sink_positions(self) -> list:
-        """Current protected absolute token positions, highest-norm first."""
-        return [p for p, _ in sorted(self._sink_norms.items(), key=lambda kv: -kv[1])]
+        """Current protected absolute token positions for batch element 0,
+        highest-norm first.
+
+        For ``B > 1`` each batch element has its own independently tracked
+        sink set (#85) — use :meth:`sink_positions_for` to inspect a
+        specific batch index.
+        """
+        return self.sink_positions_for(0)
+
+    def sink_positions_for(self, b: int) -> list:
+        """Current protected absolute token positions for batch element
+        ``b``, highest-norm first."""
+        if b >= len(self._sink_norms):
+            return []
+        return [p for p, _ in sorted(self._sink_norms[b].items(), key=lambda kv: -kv[1])]
 
 
 __all__ = ["SinkProtectedKVCache"]

--- a/veloxquant_mlx/tests/cache/test_sink_cache.py
+++ b/veloxquant_mlx/tests/cache/test_sink_cache.py
@@ -123,6 +123,41 @@ def test_decode_steps_after_prefill() -> None:
     assert c.offset == 45
 
 
+def test_sinks_tracked_independently_per_batch_element() -> None:
+    """Regression for #85: sink selection must not collapse the batch
+    dimension to element 0. A batch-1-only outlier at position 5 must be
+    detected and protected for batch element 1, independent of batch 0's
+    (different) sinks."""
+    cache = _make(head_dim=8, n_sink_tokens=2, kivi_group_size=4, residual_length=4)
+
+    B, H, S, D = 2, 1, 20, 8
+    rng = np.random.default_rng(1)
+    keys_np = rng.standard_normal((B, H, S, D)).astype(np.float32)
+    keys_np[1, 0, 5, :] = 50.0  # huge outlier only in batch element 1, token 5
+    values_np = rng.standard_normal((B, H, S, D)).astype(np.float32)
+    keys = mx.array(keys_np.astype(np.float16))
+    values = mx.array(values_np.astype(np.float16))
+
+    ko, vo = cache.update_and_fetch(keys, values)
+    mx.eval(ko, vo)
+
+    assert 5 in cache.sink_positions_for(1), (
+        "batch element 1's true outlier (position 5) must be in its own sink set"
+    )
+    ko_np = np.array(ko)
+    assert np.array_equal(ko_np[1, :, 5, :], keys_np[1, :, 5, :].astype(np.float16)), (
+        "batch element 1's protected sink token must be preserved exactly (fp16)"
+    )
+    # Batch 0 has no planted outlier: position 5 there is ordinary-magnitude
+    # noise, so it must NOT be preserved bit-exact the way a true sink is —
+    # if batch 0's sink set were being applied to batch 1 (the pre-fix bug)
+    # or vice versa, this quantized value would coincidentally match, which
+    # position 5's huge magnitude in batch 1 makes exceedingly unlikely here.
+    assert not np.array_equal(ko_np[0, :, 5, :], keys_np[0, :, 5, :].astype(np.float16)), (
+        "batch element 0's ordinary token 5 should be quantized, not sink-protected"
+    )
+
+
 def test_decode_tokens_age_out_of_residual_window() -> None:
     """Regression for #86 (inherited via KIVIKVCache.update_and_fetch):
     with S==1 every decode step, tokens must still age out of the fp16
@@ -184,7 +219,7 @@ def test_dynamic_selection_vs_pfn_equal_budget() -> None:
     # PFN-5 emulation: force the sink set to positions 0..4 by planting
     # nothing and protecting first-5 via a cache whose selection we bypass.
     pfn = _make(n_sink_tokens=5, residual_length=8)
-    pfn._sink_norms = {i: float("inf") for i in range(5)}
-    pfn._update_sinks = lambda keys, start: set(pfn._sink_norms)  # freeze
+    pfn._sink_norms = [{i: float("inf") for i in range(5)}]
+    pfn._update_sinks = lambda keys, start: [set(pfn._sink_norms[0])]  # freeze, B=1
     err_pfn = _recon_err(pfn, K, V)
     assert err_dyn < err_pfn, f"dynamic MSE {err_dyn:.5f} not < PFN-5 {err_pfn:.5f}"


### PR DESCRIPTION
## Summary

`SinkProtectedKVCache._update_sinks` computed per-token key norms across the full `[B, H, S, D]` batch but collapsed to batch element 0 before ranking sinks (`per_tok = mx.mean(norms, axis=1)[0]`). The resulting sink-position set — derived entirely from batch 0's content — was then applied identically to every batch element in `update_and_fetch`, silently misprotecting any other sequence in the batch whose true high-key-norm outlier token sat at a different position.

Per the module's own docstring rationale, an unprotected sink inflates its quantization group's min/max scale and degrades every neighboring token's precision — exactly the failure this cache exists to prevent, for every batch element other than 0.

## Fix

- `_sink_norms` is now a list of per-batch-element dicts (`list[dict[int, float]]`), lazily grown to size `B` on first call.
- `_update_sinks` computes and prunes each batch element's top-k sink candidates independently, returning one sink-position `set` per batch index instead of a single shared set.
- `update_and_fetch`'s neutralize-before-calibration and restore-after-dequant steps now loop per batch element using that element's own sink set.
- Added `sink_positions_for(b)` for per-batch introspection. The existing `sink_positions` property is preserved for backward compatibility and documented as returning batch element 0's positions only.

Byte accounting (`_account_bytes_with_sinks`) is unchanged in shape — it already scales by `H * B`, so using the max per-batch sink count for the shared scalar pool keeps the reported sink byte count accurate without under-counting.

## Testing

- Added `test_sinks_tracked_independently_per_batch_element`, using the issue's own repro pattern: a `B=2` batch with a planted 50x-magnitude outlier only in batch element 1. Confirms the outlier is detected and preserved fp16 for batch 1, and that batch 0's ordinary token at the same position is correctly quantized (not spuriously sink-protected).
- Full cache suite: `pytest veloxquant_mlx/tests/cache/` → 557/557 passed (556 prior + 1 new).

Fixes #85.