### PR TITLE
fix(cache): re-enforce SnapKV budget across chunked prefill calls

### DIFF
--- a/veloxquant_mlx/cache/snapkv_cache.py
+++ b/veloxquant_mlx/cache/snapkv_cache.py
@@ -10,6 +10,13 @@ a per-token importance score. Only the top-``snap_budget`` tokens (plus the
 first ``snap_n_sink`` sink positions) are retained as fp16. All subsequent
 decode tokens (S == 1) are always appended — never evicted.
 
+mlx_lm's chunked prefill calls ``update_and_fetch`` once per
+``prefill_step_size`` chunk for prompts longer than one chunk. Every S > 1
+call re-enforces the budget against the *accumulated* kept set (prior kept
+tokens concatenated with the new chunk), not just that chunk in isolation —
+otherwise the retained count would grow by up to ``snap_budget`` per chunk
+instead of staying capped (see #84).
+
 This is the repo's first **eviction** method. Every other method compresses
 all tokens to fewer bits; SnapKV-adapted stores fewer tokens at full fp16
 precision. The two axes compose: wrap a quantizer cache around the selected
@@ -55,10 +62,14 @@ class SnapKVKVCache(_MLXKVCache):
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
         Single-layer (no coordinator); ``for_model`` propagates all ``snap_*``
         fields automatically via ``dataclasses.replace``.
-        Eviction happens once at prefill (S > 1). Decode tokens (S == 1) are
-        always kept. Accumulated decode tokens grow the cache beyond the initial
-        budget in the decode phase — consistent with the paper's design (the
-        budget constrains prefill history, not the decode stream).
+        Eviction happens at every prefill chunk (S > 1) — mlx_lm's chunked
+        prefill (``prefill_step_size``) calls ``update_and_fetch`` once per
+        chunk for prompts longer than one chunk, so budget enforcement must
+        re-run over the accumulated kept set, not just each chunk in
+        isolation (see #84). Decode tokens (S == 1) are always kept.
+        Accumulated decode tokens grow the cache beyond the initial budget in
+        the decode phase — consistent with the paper's design (the budget
+        constrains prefill history, not the decode stream).
     """
 
     def __init__(self, config: Any) -> None:
@@ -73,6 +84,13 @@ class SnapKVKVCache(_MLXKVCache):
         self._full_value_bytes = 0
         self._tokens_kept = 0
         self._tokens_total = 0
+
+        # True once the first S>1 (prefill) call has been processed. Any
+        # later S>1 call is a subsequent chunk of the *same* prompt (mlx_lm
+        # chunked prefill), not a fresh prefill, and must re-enforce the
+        # budget against the accumulated kept set rather than compressing
+        # the new chunk in isolation and appending.
+        self._prefill_done = False
 
     # ------------------------------------------------------------------
     def _evict_head(self, keys: mx.array, values: mx.array) -> tuple[mx.array, mx.array, int]:
@@ -119,11 +137,67 @@ class SnapKVKVCache(_MLXKVCache):
         self._tokens_total += B * H * S
         return keys.astype(mx.float16), values.astype(mx.float16)
 
+    def _process_prefill_chunk(self, keys: mx.array, values: mx.array):
+        """Re-enforce the budget for a later chunk of the same prefill.
+
+        Concatenates each head's already-kept tokens (``self.keys`` /
+        ``self.values`` from prior chunks, sink-anchored at true position 0)
+        with the new chunk, then re-runs ``snapkv_compress`` over that
+        concatenation so the total retained count stays capped at
+        ``self._budget`` instead of growing by up to ``budget`` per chunk.
+
+        Byte/token accounting: this recomputed kept set *replaces* what was
+        previously counted as kept for this (b, h) (the prior chunk's kept
+        rows are being re-selected from, not kept in addition to), so the
+        prior per-(b, h) kept contribution is subtracted before adding the
+        new one. ``tokens_total`` only grows by this chunk's ``S`` (prior
+        chunks' totals were already counted when first seen).
+        """
+        B, H, S, D = keys.shape
+        prev_kept = self.offset
+        prev_kept_bytes = prev_kept * D * 2  # per (b, h), K or V alone
+        k_out_b, v_out_b = [], []
+        for b in range(B):
+            k_out_h, v_out_h = [], []
+            for h in range(H):
+                prior_k = self.keys[b, h, :prev_kept, :]
+                prior_v = self.values[b, h, :prev_kept, :]
+                cat_k = mx.concatenate([prior_k, keys[b, h]], axis=0)
+                cat_v = mx.concatenate([prior_v, values[b, h]], axis=0)
+                k_h, v_h, n_kept = self._evict_head(cat_k, cat_v)
+                k_out_h.append(k_h)
+                v_out_h.append(v_h)
+                kept_bytes = n_kept * D * 2
+                self._evicted_key_bytes += kept_bytes - prev_kept_bytes
+                self._evicted_value_bytes += kept_bytes - prev_kept_bytes
+                self._tokens_kept += n_kept - prev_kept
+            k_out_b.append(mx.stack(k_out_h, axis=0))
+            v_out_b.append(mx.stack(v_out_h, axis=0))
+        k_out = mx.stack(k_out_b, axis=0)
+        v_out = mx.stack(v_out_b, axis=0)
+
+        self._full_key_bytes += B * H * S * D * 2
+        self._full_value_bytes += B * H * S * D * 2
+        self._tokens_total += B * H * S
+
+        # The recomputed kept set replaces (not appends to) what's stored:
+        # reset so the base class's append-only update_and_fetch starts a
+        # fresh buffer instead of stacking this chunk's output on top of
+        # the pre-recompression rows still sitting in self.keys/values.
+        self.offset = 0
+        self.keys = None
+        self.values = None
+        return k_out, v_out
+
     # ------------------------------------------------------------------
     def update_and_fetch(self, keys: mx.array, values: mx.array):
         is_prefill = keys.shape[2] > 1
         if is_prefill:
-            k_out, v_out = self._process_prefill(keys, values)
+            if not self._prefill_done:
+                k_out, v_out = self._process_prefill(keys, values)
+                self._prefill_done = True
+            else:
+                k_out, v_out = self._process_prefill_chunk(keys, values)
         else:
             k_out, v_out = self._process_decode(keys, values)
         return super().update_and_fetch(k_out, v_out)

--- a/veloxquant_mlx/tests/cache/test_snapkv_cache.py
+++ b/veloxquant_mlx/tests/cache/test_snapkv_cache.py
@@ -86,6 +86,76 @@ def test_no_eviction_short_seq() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Chunked prefill (#84)
+# ---------------------------------------------------------------------------
+
+
+def test_chunked_prefill_budget_stays_capped() -> None:
+    """Regression for #84: mlx_lm's chunked prefill calls update_and_fetch
+    once per prefill_step_size chunk. The retained token count must stay
+    capped at snap_budget across multiple S>1 calls, not grow by up to
+    budget per chunk."""
+    c = _make(snap_budget=10, snap_obs_window=2, snap_n_sink=1)
+    k1, v1 = _rand_kv(S=50, H=1, D=8, seed=1)
+    k2, v2 = _rand_kv(S=50, H=1, D=8, seed=2)
+    k3, v3 = _rand_kv(S=50, H=1, D=8, seed=3)
+
+    ko1, _ = c.update_and_fetch(k1, v1)
+    assert ko1.shape[2] == 10
+
+    ko2, _ = c.update_and_fetch(k2, v2)
+    assert ko2.shape[2] == 10, (
+        f"budget violated after 2nd prefill chunk: kept {ko2.shape[2]} > snap_budget=10"
+    )
+
+    ko3, _ = c.update_and_fetch(k3, v3)
+    assert ko3.shape[2] == 10, (
+        f"budget violated after 3rd prefill chunk: kept {ko3.shape[2]} > snap_budget=10"
+    )
+    assert c.offset == 10
+
+
+def test_chunked_prefill_then_decode_appends() -> None:
+    """After multi-chunk prefill re-caps the budget, decode tokens (S==1)
+    must still always append, never evict."""
+    c = _make(snap_budget=10, snap_obs_window=2, snap_n_sink=1)
+    k1, v1 = _rand_kv(S=50, H=1, D=8, seed=1)
+    k2, v2 = _rand_kv(S=50, H=1, D=8, seed=2)
+    c.update_and_fetch(k1, v1)
+    c.update_and_fetch(k2, v2)
+    assert c.offset == 10
+
+    for i in range(5):
+        k1d, v1d = _rand_kv(S=1, H=1, D=8, seed=200 + i)
+        ko, _ = c.update_and_fetch(k1d, v1d)
+    assert ko.shape[2] == 15
+    assert c.offset == 15
+
+
+def test_chunked_prefill_sink_anchored_at_true_start() -> None:
+    """The sink token planted at true sequence position 0 must still be
+    protected after a later chunk re-runs eviction over the concatenated
+    kept + new tokens — sink anchoring must not drift to the chunk-local
+    position 0 of a later chunk."""
+    c = _make(snap_budget=10, snap_obs_window=2, snap_n_sink=1, head_dim=8)
+    rng = np.random.default_rng(7)
+    k1 = rng.standard_normal((1, 1, 50, 8)).astype(np.float32)
+    k1[:, :, 0, :] = 50.0  # true sequence-start sink token
+    v1 = rng.standard_normal((1, 1, 50, 8)).astype(np.float32)
+    k2 = rng.standard_normal((1, 1, 50, 8)).astype(np.float32)
+    v2 = rng.standard_normal((1, 1, 50, 8)).astype(np.float32)
+
+    c.update_and_fetch(mx.array(k1.astype(np.float16)), mx.array(v1.astype(np.float16)))
+    ko2, _ = c.update_and_fetch(mx.array(k2.astype(np.float16)), mx.array(v2.astype(np.float16)))
+    mx.eval(ko2)
+
+    ko2_np = np.array(ko2).astype(np.float32)
+    assert np.any(np.all(np.isclose(ko2_np[0, 0], k1[0, 0, 0, :], atol=1e-2), axis=-1)), (
+        "true sequence-start sink token must still be retained after a later chunk"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Decode accumulation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`SnapKVKVCache.update_and_fetch` treated *any* call with `S > 1` as "the prefill" and ran `snapkv_compress` independently on just that call's rows, letting the base mlx_lm cache append the kept subset on top of whatever was already stored.

mlx_lm's standard chunked prefill (`prefill_step_size`, default 512–2048) calls `update_and_fetch` once per chunk for any prompt longer than one chunk — not a rare or adversarial case. Each additional `S>1` chunk:
1. Mis-anchored sink protection to that chunk's local position 0 instead of the true sequence start.
2. Grew the retained token count by up to `snap_budget` per chunk instead of staying capped, silently defeating the memory-bound guarantee the method exists to provide.

## Fix

- Added `self._prefill_done` to distinguish the first prefill call from later chunks of the same prompt.
- The first `S>1` call behaves as before (`_process_prefill`).
- Any subsequent `S>1` call now goes through a new `_process_prefill_chunk`: it concatenates each head's already-kept tokens (still sitting in `self.keys`/`self.values`, sink-anchored at true position 0 since kept indices are returned in ascending order) with the new chunk, re-runs `snapkv_compress` over that concatenation, and **replaces** the stored contents (resets `self.offset`/`self.keys`/`self.values`) instead of letting the base class append on top. This keeps the total retained count capped at `snap_budget` across any number of prefill chunks, with sink anchoring staying correct.
- Decode (`S == 1`) is unchanged — always appended, never evicted, including after multi-chunk prefill.
- Byte/token accounting deltas correctly subtract each head's prior kept-byte contribution before adding the recomputed one, so `evicted_key_bytes`/`tokens_kept` reflect the final capped set rather than double-counting.

## Testing

Three new regression tests in `test_snapkv_cache.py`, using the issue's own repro pattern (`snap_budget=10`, multiple 50-token chunks):
- `test_chunked_prefill_budget_stays_capped` — retained count stays at `snap_budget` after 2nd and 3rd prefill chunks.
- `test_chunked_prefill_then_decode_appends` — decode tokens after multi-chunk prefill still always append.
- `test_chunked_prefill_sink_anchored_at_true_start` — a sink token planted at true sequence position 0 remains protected after a later chunk re-runs eviction.

Full cache suite: `pytest veloxquant_mlx/tests/cache/` → 560/560 passed (557 prior + 3 new).

Fixes #84.