### PR TITLE
fix(cache): populate mlx_lm base cache state in 17 eviction/compression caches

### DIFF
--- a/veloxquant_mlx/cache/amc_cache.py
+++ b/veloxquant_mlx/cache/amc_cache.py
@@ -74,6 +74,12 @@ class AMCKVCache(_MLXKVCache):
         CurDKV's key-as-query-proxy) — when enabled, the mean of the current
         step's keys is used as a proxy query, disclosed here as the same
         category of approximation as the eviction methods' proxy queries.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -225,7 +231,24 @@ class AMCKVCache(_MLXKVCache):
 
         self._amc_kept_bytes = amc_fp16_bytes(self._tier_counts, self._head_dim)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state (AMC never evicts), not a
+        # delta — reset so the base class's append-only buffer starts fresh
+        # each call instead of stacking on top of the previous call's rows.
+        # Without this, self.keys/self.values/self.offset stay at their
+        # __init__ defaults (None/None/0) forever, and mlx_lm's generate()
+        # crashes on `cache.state` during chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     def _compress_step(self, x: mx.array, tiers: List[int], head_dim: int) -> mx.array:
         """Apply per-token rank mask + quantization according to each token's tier."""

--- a/veloxquant_mlx/cache/cam_cache.py
+++ b/veloxquant_mlx/cache/cam_cache.py
@@ -84,6 +84,12 @@ class CaMKVCache(_MLXKVCache):
         Because CaM merges (not drops) it always trims to exactly ``budget`` — the
         output is rectangular ``[B, H, budget, D]`` once past budget, so no
         cross-head alignment is needed.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token merge state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -165,7 +171,24 @@ class CaMKVCache(_MLXKVCache):
         # Byte accounting: sum across all head states.
         self._cam_kept_bytes = sum(cam_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/chunkkv_cache.py
+++ b/veloxquant_mlx/cache/chunkkv_cache.py
@@ -80,6 +80,12 @@ class ChunkKVCache(_MLXKVCache):
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
         Both prefill (S > 1) and decode (S == 1) tokens go through the same
         eviction loop. Per-head state is lazily initialised on the first call.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -176,7 +182,24 @@ class ChunkKVCache(_MLXKVCache):
         # Byte accounting: sum across all head states.
         self._chunkkv_kept_bytes = sum(chunkkv_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/curdkv_cache.py
+++ b/veloxquant_mlx/cache/curdkv_cache.py
@@ -79,6 +79,12 @@ class CurDKVKVCache(_MLXKVCache):
         all ``curdkv_*`` fields automatically via ``dataclasses.replace``.
         The per-head state is lazily initialised on the first call to
         ``update_and_fetch`` when shapes are known.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -153,7 +159,24 @@ class CurDKVKVCache(_MLXKVCache):
         # Byte accounting: sum across all head states
         self._curdkv_kept_bytes = sum(curdkv_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/h2o_cache.py
+++ b/veloxquant_mlx/cache/h2o_cache.py
@@ -68,6 +68,12 @@ class H2OKVCache(_MLXKVCache):
         all ``h2o_*`` fields automatically via ``dataclasses.replace``.
         The per-head state is lazily initialised on the first call to
         ``update_and_fetch`` when shapes are known.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token eviction state can't be rolled back by a
+        base-class ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -138,7 +144,24 @@ class H2OKVCache(_MLXKVCache):
         # Byte accounting: sum across all head states
         self._h2o_kept_bytes = sum(h2o_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/keyformer_cache.py
+++ b/veloxquant_mlx/cache/keyformer_cache.py
@@ -78,6 +78,12 @@ class KeyformerKVCache(_MLXKVCache):
         propagates all ``keyformer_*`` fields via ``dataclasses.replace``. The
         per-head state is lazily initialised on the first ``update_and_fetch``.
         Validation (tau >= 0, sink/recent-vs-budget) happens at construction.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -164,7 +170,25 @@ class KeyformerKVCache(_MLXKVCache):
         V_out = mx.stack(v_out_b, axis=0)
 
         self._keyformer_kept_bytes = sum(keyformer_fp16_bytes(st) for st in self._states)
-        return K_out, V_out
+
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/knorm_cache.py
+++ b/veloxquant_mlx/cache/knorm_cache.py
@@ -71,6 +71,12 @@ class L2NormKVCache(_MLXKVCache):
         path returns one ``L2NormKVCache`` per attention layer. Per-head state
         is lazily initialised on the first ``update_and_fetch``. Validation
         (keep mode, sink/recent-vs-budget guard) happens at construction.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -147,7 +153,25 @@ class L2NormKVCache(_MLXKVCache):
         V_out = mx.stack(v_out_b, axis=0)
 
         self._knorm_kept_bytes = sum(knorm_fp16_bytes(st) for st in self._states)
-        return K_out, V_out
+
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/kvtc_cache.py
+++ b/veloxquant_mlx/cache/kvtc_cache.py
@@ -126,6 +126,22 @@ class _TensorKVTC:
         """
         assert self._fitted and self._artifact is not None and self._raw_rows is not None
         self._raw_rows = mx.concatenate([self._raw_rows, x.astype(mx.float32)], axis=0)
+        return self._requantize()
+
+    def trim(self, n: int) -> None:
+        """Drop the ``n`` most-recent rows and re-quantize through the frozen basis."""
+        assert self._fitted and self._raw_rows is not None
+        keep = max(0, self._raw_rows.shape[0] - n)
+        self._raw_rows = self._raw_rows[:keep]
+        if keep > 0:
+            self._requantize()
+        else:
+            self._fitted = False
+            self._artifact = None
+
+    def _requantize(self) -> mx.array:
+        """Re-derive the entropy-coded artifact for the current ``_raw_rows`` through the frozen basis/allocation."""
+        assert self._artifact is not None and self._raw_rows is not None
         V = self._artifact.V
         mean = self._artifact.mean
         bit_alloc = self._artifact.bit_allocation
@@ -226,6 +242,12 @@ class KVTCKVCache(_MLXKVCache):
         self._H = 0
 
         self._full_seq_bytes = 0
+        # Last (k_out, v_out) reconstructed by update_and_fetch, for .state —
+        # mlx_lm's generate() reads cache.state directly (e.g. during chunked
+        # prefill and the speculative-decoding rewind path); since self.keys/
+        # self.values are never populated (true latent storage), .state must
+        # be overridden to serve this instead (see #83).
+        self._last_state: Optional[tuple] = None
 
     # ------------------------------------------------------------------
     def _ensure_states(self, B: int, H: int) -> None:
@@ -274,6 +296,7 @@ class KVTCKVCache(_MLXKVCache):
 
         self._kvtc_offset += S
         self._full_seq_bytes += B * H * S * D * 2 * 2  # K + V, fp16
+        self._last_state = (K_out, V_out)
         return K_out, V_out
 
     # ------------------------------------------------------------------
@@ -289,6 +312,36 @@ class KVTCKVCache(_MLXKVCache):
 
     def size(self) -> int:
         return self._kvtc_offset
+
+    @property
+    def state(self):  # type: ignore[override]
+        if self._last_state is None:
+            empty = mx.zeros((1, self._H, 0, self._D), dtype=mx.float16)
+            return empty, empty
+        return self._last_state
+
+    @state.setter
+    def state(self, v) -> None:
+        k, v_ = v
+        self._last_state = (k, v_)
+        self._kvtc_offset = int(k.shape[2])
+
+    def is_trimmable(self) -> bool:
+        return True
+
+    def trim(self, n: int) -> int:
+        n = min(self._kvtc_offset, n)
+        if n <= 0:
+            return 0
+        for ks in self._keys_states:
+            ks.trim(n)
+        for vs in self._vals_states:
+            vs.trim(n)
+        self._kvtc_offset -= n
+        if self._last_state is not None:
+            k, v_ = self._last_state
+            self._last_state = (k[:, :, : k.shape[2] - n, :], v_[:, :, : v_.shape[2] - n, :])
+        return n
 
     # ------------------------------------------------------------------
     # Reporting

--- a/veloxquant_mlx/cache/kvzip_cache.py
+++ b/veloxquant_mlx/cache/kvzip_cache.py
@@ -80,6 +80,12 @@ class KVzipKVCache(_MLXKVCache):
         state is lazily initialised on the first ``update_and_fetch``. KVzip is
         deterministic (no RNG). Validation (budget/sink bounds, probe value)
         happens at construction.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -153,7 +159,25 @@ class KVzipKVCache(_MLXKVCache):
         V_out = mx.stack(v_out_b, axis=0)
 
         self._kvzip_kept_bytes = sum(kvzip_fp16_bytes(st) for st in self._states)
-        return K_out, V_out
+
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/morphkv_cache.py
+++ b/veloxquant_mlx/cache/morphkv_cache.py
@@ -77,6 +77,12 @@ class MorphKVKVCache(_MLXKVCache):
         state is lazily initialised on the first ``update_and_fetch``. MorphKV is
         deterministic (no RNG). Validation (budget/window/sink bounds) happens at
         construction.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -150,7 +156,25 @@ class MorphKVKVCache(_MLXKVCache):
         V_out = mx.stack(v_out_b, axis=0)
 
         self._morphkv_kept_bytes = sum(morphkv_fp16_bytes(st) for st in self._states)
-        return K_out, V_out
+
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/nestedkv_cache.py
+++ b/veloxquant_mlx/cache/nestedkv_cache.py
@@ -96,6 +96,12 @@ class NestedKVKVCache(_MLXKVCache):
         Single-layer (no coordinator); ``KVCacheBuilder.for_model()``
         propagates all ``nestedkv_*`` fields automatically via
         ``dataclasses.replace``.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -243,7 +249,25 @@ class NestedKVKVCache(_MLXKVCache):
 
         self._nestedkv_kept_bytes = sum(nestedkv_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call (front-padded to
+        # a common per-head length by _pad_heads_to_common_length), not a
+        # delta — reset so the base class's append-only buffer starts fresh
+        # instead of stacking on top of the previous call's rows. Without
+        # this, self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/palu_cache.py
+++ b/veloxquant_mlx/cache/palu_cache.py
@@ -159,6 +159,13 @@ class _TensorLowRank:
             heads.append(reconstruct_from_latent(L, self._V[g], self._mu[g]))  # [S, D]
         return mx.stack(heads, axis=0)[None]  # [1, H, S, D]
 
+    def trim(self, n: int) -> None:
+        """Drop the ``n`` most-recent tokens from every head's latent buffer."""
+        if not self._latents or n <= 0:
+            return
+        keep = max(0, self._latents[0].shape[0] - n)
+        self._latents = [L[:keep] for L in self._latents]
+
     # ------------------------------------------------------------------
     @property
     def stored_rank(self) -> int:
@@ -244,6 +251,12 @@ class PALUKVCache(_MLXKVCache):
         # We bypass the parent fp16 ring buffer; track offset ourselves.
         self._palu_offset = 0
         self._H = 0
+        # Last (k_out, v_out) reconstructed by update_and_fetch, for .state —
+        # mlx_lm's generate() reads cache.state directly (e.g. during chunked
+        # prefill and the speculative-decoding rewind path); since self.keys/
+        # self.values are never populated (true latent storage), .state must
+        # be overridden to serve this instead (see #83).
+        self._last_state: Optional[tuple] = None
 
         # Byte accounting
         self._compressed_key_bytes = 0
@@ -270,6 +283,7 @@ class PALUKVCache(_MLXKVCache):
         k_out = self._keys_lr.reconstruct()  # [1, H, total, D] fp16
         v_out = self._vals_lr.reconstruct()
         self._account_bytes(H, S, D)
+        self._last_state = (k_out, v_out)
         return k_out, v_out
 
     def _account_bytes(self, H: int, S: int, D: int) -> None:
@@ -301,6 +315,34 @@ class PALUKVCache(_MLXKVCache):
 
     def size(self) -> int:
         return self._palu_offset
+
+    @property
+    def state(self):  # type: ignore[override]
+        if self._last_state is None:
+            empty = mx.zeros((1, self._H, 0, self._D), dtype=mx.float16)
+            return empty, empty
+        return self._last_state
+
+    @state.setter
+    def state(self, v) -> None:
+        k, v_ = v
+        self._last_state = (k, v_)
+        self._palu_offset = int(k.shape[2])
+
+    def is_trimmable(self) -> bool:
+        return True
+
+    def trim(self, n: int) -> int:
+        n = min(self._palu_offset, n)
+        if n <= 0:
+            return 0
+        self._keys_lr.trim(n)
+        self._vals_lr.trim(n)
+        self._palu_offset -= n
+        if self._last_state is not None:
+            k, v_ = self._last_state
+            self._last_state = (k[:, :, : k.shape[2] - n, :], v_[:, :, : v_.shape[2] - n, :])
+        return n
 
     @property
     def nbytes(self) -> int:

--- a/veloxquant_mlx/cache/pyramidkv_cache.py
+++ b/veloxquant_mlx/cache/pyramidkv_cache.py
@@ -75,6 +75,12 @@ class PyramidKVCache(_MLXKVCache):
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
         Both prefill (S > 1) and decode (S == 1) tokens go through the same
         eviction loop. Per-head state is lazily initialised on the first call.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -148,7 +154,24 @@ class PyramidKVCache(_MLXKVCache):
         # Byte accounting: sum across all head states
         self._pyramid_kept_bytes = sum(pyramid_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/qfilters_cache.py
+++ b/veloxquant_mlx/cache/qfilters_cache.py
@@ -77,6 +77,12 @@ class QFiltersKVCache(_MLXKVCache):
         path returns one ``QFiltersKVCache`` per attention layer. Per-head
         state is lazily initialised on the first ``update_and_fetch``.
         Validation (sign, sink/recent-vs-budget) happens at construction.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -166,7 +172,25 @@ class QFiltersKVCache(_MLXKVCache):
         V_out = mx.stack(v_out_b, axis=0)
 
         self._qfilters_kept_bytes = sum(qfilters_fp16_bytes(st) for st in self._states)
-        return K_out, V_out
+
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/squeeze_cache.py
+++ b/veloxquant_mlx/cache/squeeze_cache.py
@@ -89,6 +89,12 @@ class SqueezeAttentionCache(_MLXKVCache):
         No ``.bits`` attribute — stores and returns fp16 K/V directly. Per-head
         state is lazily initialised on the first call. The one-shot re-budget
         happens on the first ``update_and_fetch`` once the coordinator finalises.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(
@@ -252,7 +258,24 @@ class SqueezeAttentionCache(_MLXKVCache):
         # Byte accounting: sum across all head states.
         self._squeeze_kept_bytes = sum(squeeze_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/streaming_llm_cache.py
+++ b/veloxquant_mlx/cache/streaming_llm_cache.py
@@ -60,6 +60,12 @@ class StreamingLLMKVCache(_MLXKVCache):
         adapted, which evicts only at prefill. StreamingLLM operates continuously.
         Single-layer (no coordinator); ``for_model`` propagates all ``stream_*``
         fields automatically via ``dataclasses.replace``.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -136,10 +142,24 @@ class StreamingLLMKVCache(_MLXKVCache):
         kept_bytes = stream_fp16_bytes(self._windows[0]) * B * H
         self._stream_kept_bytes = kept_bytes  # snapshot (not cumulative; current state)
 
-        # Pass through to parent's accumulator using the evicted slice
-        # We bypass the parent concatenation and manage state ourselves.
-        # Return directly — StreamingLLM manages its own complete K/V state.
-        return K_out, V_out
+        # K_out/V_out is the full sink+recent window every call, not a
+        # delta — reset so the base class's append-only buffer starts fresh
+        # instead of stacking on top of the previous call's rows. Without
+        # this, self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/cache/tova_cache.py
+++ b/veloxquant_mlx/cache/tova_cache.py
@@ -74,6 +74,12 @@ class TOVAKVCache(_MLXKVCache):
         all ``tova_*`` fields automatically via ``dataclasses.replace``.
         The per-head state is lazily initialised on the first call to
         ``update_and_fetch`` when shapes are known.
+        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
+        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
+        valid (mlx_lm's ``generate()`` reads it unconditionally during
+        chunked prefill); ``is_trimmable()`` reports ``False`` since the
+        internal per-token state can't be rolled back by a base-class
+        ``trim()`` (see #83).
     """
 
     def __init__(self, config: Any) -> None:
@@ -144,7 +150,24 @@ class TOVAKVCache(_MLXKVCache):
         # Byte accounting: sum across all head states
         self._tova_kept_bytes = sum(tova_fp16_bytes(st) for st in self._states)
 
-        return K_out, V_out
+        # K_out/V_out is the full retained state every call, not a delta —
+        # reset so the base class's append-only buffer starts fresh instead
+        # of stacking on top of the previous call's rows. Without this,
+        # self.keys/self.values/self.offset stay at __init__ defaults
+        # forever, and mlx_lm's generate() crashes on `cache.state` during
+        # chunked prefill (see #83).
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        return super().update_and_fetch(K_out, V_out)
+
+    # ------------------------------------------------------------------
+    def is_trimmable(self) -> bool:
+        """False: trim() would only roll back base-class offset bookkeeping,
+        not the internal per-token eviction/compression state that actually
+        determines what gets returned, silently corrupting future calls.
+        """
+        return False
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
+++ b/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
@@ -1,0 +1,227 @@
+"""Regression for #83: eviction/compression caches must populate mlx_lm's
+base ``.keys``/``.values``/``.offset`` so ``.state`` (read unconditionally by
+``mlx_lm.generate()`` during chunked prefill and the speculative-decoding
+rewind path) never crashes with ``AttributeError: 'NoneType' object has no
+attribute 'shape'``.
+
+Covers all 17 affected classes: 15 that now write through to the base class
+via ``super().update_and_fetch(...)`` on every call (and correctly report
+``is_trimmable() == False``, since their internal per-token eviction state
+isn't rolled back by a base-class ``trim()``), plus ``PALUKVCache`` and
+``KVTCKVCache`` which bypass the base fp16 buffer entirely (true latent
+storage) and instead override ``.state``/``.trim()``/``.is_trimmable()``
+directly against their own storage.
+
+Config per method mirrors each method's own dedicated test file's ``_make``
+helper, kept minimal here since only the base-class bookkeeping contract is
+under test — not each method's compression/eviction quality.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from veloxquant_mlx.cache.base import KVCacheConfig, KVCacheFactory
+
+# method -> extra config kwargs beyond method/head_dim
+_CONFIGS = {
+    "amc": {},
+    "cam": {"cam_budget": 8, "cam_n_sink": 1},
+    "chunkkv": {"chunkkv_budget": 8, "chunkkv_n_sink": 1, "chunkkv_chunk_size": 2},
+    "curdkv": {"curdkv_budget": 8, "curdkv_n_sink": 1},
+    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1},
+    "keyformer": {"keyformer_budget": 8, "keyformer_n_sink": 1},
+    "knorm": {"knorm_budget": 8, "knorm_n_sink": 1},
+    "kvzip": {"kvzip_budget": 8, "kvzip_n_sink": 1},
+    "morphkv": {"morphkv_budget": 8, "morphkv_n_sink": 1, "morphkv_window": 4},
+    "nestedkv": {"nestedkv_budget": 8, "nestedkv_n_sink": 1},
+    "pyramidkv": {"pyramid_budget": 8, "pyramid_n_sink": 1},
+    "qfilters": {"qfilters_budget": 8, "qfilters_n_sink": 1, "qfilters_calib_tokens": 4},
+    "squeeze": {"squeeze_budget": 8, "squeeze_n_sink": 1},
+    "streaming_llm": {"stream_n_sink": 1, "stream_window_size": 8},
+    "tova": {"tova_budget": 8, "tova_n_sink": 1},
+    "palu": {"palu_rank": 4, "palu_n_head_groups": 1},
+    "kvtc": {"kvtc_bit_budget": 32},
+}
+
+# The 15 "case A" methods: reset-then-write-through, no real trim support.
+_CASE_A_METHODS = [m for m in _CONFIGS if m not in ("palu", "kvtc")]
+# The 2 "case C" methods: bypass the base buffer, own state/trim.
+_CASE_C_METHODS = ["palu", "kvtc"]
+
+ALL_METHODS = list(_CONFIGS)
+
+
+def _make(method: str, head_dim: int = 8, **extra):
+    cfg = dict(method=method, head_dim=head_dim)
+    cfg.update(_CONFIGS[method])
+    cfg.update(extra)
+    return KVCacheFactory.create(KVCacheConfig(**cfg))
+
+
+def _rand_kv(S: int, H: int = 1, D: int = 8, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    K = mx.array(rng.standard_normal((1, H, S, D)).astype(np.float16))
+    V = mx.array(rng.standard_normal((1, H, S, D)).astype(np.float16))
+    return K, V
+
+
+# ---------------------------------------------------------------------------
+# Core crash repro from the issue: .state must not raise after prefill.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_state_accessible_after_single_prefill(method: str) -> None:
+    """Regression for #83's exact repro: cache.state must not raise
+    AttributeError after a single update_and_fetch call."""
+    cache = _make(method)
+    k, v = _rand_kv(S=4)
+    cache.update_and_fetch(k, v)
+
+    k_state, v_state = cache.state  # must not raise
+    mx.eval(k_state, v_state)
+    assert k_state.shape[0] == 1
+    assert k_state.shape[-1] == 8
+    assert cache.offset > 0
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_state_shape_matches_offset(method: str) -> None:
+    """cache.state's seq-length dim must equal cache.offset, mirroring the
+    base KVCache contract mlx_lm relies on elsewhere (e.g. make_mask)."""
+    cache = _make(method)
+    k, v = _rand_kv(S=6)
+    cache.update_and_fetch(k, v)
+
+    k_state, v_state = cache.state
+    mx.eval(k_state, v_state)
+    assert k_state.shape[2] == cache.offset
+    assert v_state.shape[2] == cache.offset
+
+
+# ---------------------------------------------------------------------------
+# mlx_lm's chunked prefill: update_and_fetch called multiple times with S>1.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_state_accessible_across_chunked_prefill(method: str) -> None:
+    """Simulates mlx_lm's chunked prefill: several S>1 calls in a row (one
+    per prefill_step_size chunk), each followed by a .state access (mirrors
+    generate.py's `mx.eval([c.state for c in cache])` after every chunk)."""
+    cache = _make(method)
+    for seed in range(3):
+        k, v = _rand_kv(S=5, seed=seed)
+        cache.update_and_fetch(k, v)
+        k_state, v_state = cache.state
+        mx.eval(k_state, v_state)
+        assert k_state.shape[2] == cache.offset
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_state_accessible_after_decode_steps(method: str) -> None:
+    """Prefill followed by several S==1 decode steps; .state must stay
+    accessible and consistent with offset throughout."""
+    cache = _make(method)
+    k, v = _rand_kv(S=5)
+    cache.update_and_fetch(k, v)
+
+    for i in range(3):
+        k1, v1 = _rand_kv(S=1, seed=100 + i)
+        cache.update_and_fetch(k1, v1)
+        k_state, v_state = cache.state
+        mx.eval(k_state, v_state)
+        assert k_state.shape[2] == cache.offset
+
+
+# ---------------------------------------------------------------------------
+# is_trimmable() / trim() honesty.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", _CASE_A_METHODS)
+def test_case_a_reports_not_trimmable(method: str) -> None:
+    """These 15 caches' internal per-token eviction/compression state can't
+    be rolled back by the base class's offset-only trim() — is_trimmable()
+    must report False so mlx_lm's can_trim_prompt_cache() correctly skips
+    them instead of silently corrupting state via a no-op-on-content trim."""
+    cache = _make(method)
+    k, v = _rand_kv(S=4)
+    cache.update_and_fetch(k, v)
+    assert cache.is_trimmable() is False
+
+
+@pytest.mark.parametrize("method", _CASE_C_METHODS)
+def test_case_c_trim_rolls_back_state_and_offset(method: str) -> None:
+    """PALU/KVTC own true latent storage end-to-end, so trim() can and must
+    correctly shrink both offset and the reconstructed state, and further
+    update_and_fetch calls after a trim must keep working."""
+    cache = _make(method)
+    k, v = _rand_kv(S=10)
+    cache.update_and_fetch(k, v)
+    assert cache.is_trimmable() is True
+
+    n_trimmed = cache.trim(3)
+    assert n_trimmed == 3
+    assert cache.offset == 7
+
+    k_state, v_state = cache.state
+    mx.eval(k_state, v_state)
+    assert k_state.shape[2] == 7
+    assert v_state.shape[2] == 7
+
+    # Cache must still work after a trim — this is exactly what mlx_lm does
+    # after trimming for prefix-cache reuse / speculative-decoding rewind.
+    k1, v1 = _rand_kv(S=1, seed=99)
+    cache.update_and_fetch(k1, v1)
+    assert cache.offset == 8
+    k_state2, v_state2 = cache.state
+    mx.eval(k_state2, v_state2)
+    assert k_state2.shape[2] == 8
+
+
+# ---------------------------------------------------------------------------
+# No double counting: repeated update_and_fetch calls must not make offset
+# grow faster than the true retained/seen token count.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_offset_does_not_exceed_tokens_seen(method: str) -> None:
+    """A buggy write-through (e.g. appending instead of replacing on a
+    full-state-every-call cache) would make offset grow unboundedly across
+    repeated prefill-shaped calls even though the true retained count is
+    capped by the method's budget."""
+    cache = _make(method)
+    total_seen = 0
+    for seed in range(4):
+        k, v = _rand_kv(S=5, seed=seed)
+        cache.update_and_fetch(k, v)
+        total_seen += 5
+        assert cache.offset <= total_seen
+
+
+# ---------------------------------------------------------------------------
+# The issue's own scenario: a multi-layer cache list, exactly what mlx_lm's
+# generate.py does after every prefill chunk (``mx.eval([c.state for c in
+# cache])``) and in the speculative-decoding rewind path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_multi_layer_cache_list_state_eval(method: str) -> None:
+    """Regression for #83's exact crash site: mlx_lm.generate's _prefill does
+    `mx.eval([c.state for c in cache])` on a *list* of per-layer caches after
+    every chunk. Simulate 3 layers x 2 chunks."""
+    caches = [_make(method) for _ in range(3)]
+    for seed in range(2):
+        k, v = _rand_kv(S=4, seed=seed)
+        for cache in caches:
+            cache.update_and_fetch(k, v)
+        mx.eval([c.state for c in caches])  # must not raise
+        for cache in caches:
+            k_state, v_state = cache.state
+            assert k_state.shape[2] == cache.offset


### PR DESCRIPTION
## Summary

17 of the 40 registered `KVCacheConfig.method` values produced a cache class subclassing `mlx_lm.models.cache.KVCache` that never called `super().update_and_fetch(...)`, so the base class's `self.keys`/`self.values` stayed `None` and `self.offset` stayed `0` forever. mlx_lm's own generation loop unconditionally does `mx.eval([c.state for c in cache])` on every prefill chunk (`generate.py:442,584`) and in the speculative-decoding rewind path (`generate.py:1161,1169`); `KVCache.state` reads `self.keys.shape`, so this crashed with `AttributeError: 'NoneType' object has no attribute 'shape'` on the very first prefill chunk for any of these 17 methods whenever the prompt exceeded `prefill_step_size` (default 512 tokens) — the standard `mlx_lm.generate()` path, not a rare edge case.

Fixes #83.

## Fix

Two fix shapes, chosen per file based on how each cache actually stores state:

**15 methods** — `amc`, `cam`, `chunkkv`, `curdkv`, `h2o`, `keyformer`, `knorm`, `kvzip`, `morphkv`, `nestedkv`, `pyramidkv`, `qfilters`, `squeeze`, `streaming_llm`, `tova`

Each of these returns the **full current retained** K/V window on every call (from persistent per-head eviction/compression state), not a delta. Fixed by resetting `self.keys`/`self.values`/`self.offset` and writing through via `super().update_and_fetch(K_out, V_out)` on every call, so `.state`/`.offset`/`.size()` correctly reflect the retained (post-eviction) K/V. Their `is_trimmable()` now reports `False`: a base-class `trim()` would only roll back offset bookkeeping, not the internal per-token eviction state that actually determines what gets returned next — a "successful" trim would silently corrupt future output instead of really shrinking the cache.

**2 methods** — `palu`, `kvtc`

These bypass the base fp16 ring buffer entirely for true low-rank/entropy-coded latent storage, and already override `offset`/`size()` against their own bookkeeping. Added `.state` overrides (returning the last reconstructed `(k_out, v_out)`), plus real `.trim()`/`is_trimmable() == True` support — trimming their latent buffers and re-deriving the stored artifact through the already-frozen basis/allocation — since their storage genuinely is rollback-capable, unlike the eviction-state caches above.

## Testing

Added `veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py`, parametrized across all 17 affected methods:
- `.state` doesn't raise after a single prefill call (the issue's exact repro)
- `.state`'s shape matches `.offset`
- `.state` stays accessible across multiple chunked-prefill-style `update_and_fetch` calls (mlx_lm's actual chunking behavior)
- `.state` stays accessible through prefill + several decode steps
- `is_trimmable()` reports `False` for the 15 eviction-state caches, `True` for palu/kvtc, with a real trim-then-continue round trip verified for the latter
- `.offset` never exceeds true tokens seen (catches append-instead-of-replace regressions)
- A 3-layer cache list with `mx.eval([c.state for c in caches])` after each of 2 chunks — the exact crash site from the issue

- `pytest veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py -v` → 119/119 passed
- `pytest veloxquant_mlx/tests/cache/` → 679/679 passed (no regressions)
- `pytest veloxquant_mlx/tests/` → 1629/1630 passed (1 pre-existing failure in `test_mlx_lm_patch.py`, unrelated to this change — missing `pytest` import on master, confirmed via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)