### PR TITLE
fix(cache): use ring buffer's live size instead of unbounded counter in QJL/Polar

### DIFF
--- a/veloxquant_mlx/cache/polar_cache.py
+++ b/veloxquant_mlx/cache/polar_cache.py
@@ -78,7 +78,7 @@ class PolarQuantKVCache(KVCache):
         """
         import mlx.core as mx
 
-        n = self._n_tokens
+        n = len(self._k_angles)
         if n == 0:
             return mx.zeros((self._d,), dtype=mx.float16)
 
@@ -111,7 +111,7 @@ class PolarQuantKVCache(KVCache):
 
     def memory_bytes(self) -> int:
         """Estimate memory footprint."""
-        n = self._n_tokens
+        n = len(self._k_angles)
         if n == 0:
             return 0
         d = self._d
@@ -125,7 +125,7 @@ class PolarQuantKVCache(KVCache):
         return angle_bytes + radius_bytes + v_bytes
 
     def __len__(self) -> int:
-        return self._n_tokens
+        return len(self._k_angles)
 
     def __repr__(self) -> str:
         return f"PolarQuantKVCache(d={self._d}, n_tokens={self._n_tokens})"

--- a/veloxquant_mlx/cache/qjl_cache.py
+++ b/veloxquant_mlx/cache/qjl_cache.py
@@ -76,7 +76,7 @@ class QJLKVCache(KVCache):
         """
         import mlx.core as mx
 
-        n = self._n_tokens
+        n = len(self._k_signs)
         if n == 0:
             return mx.zeros((self._d,), dtype=mx.float16)
 
@@ -103,7 +103,7 @@ class QJLKVCache(KVCache):
 
     def memory_bytes(self) -> int:
         """Estimate memory footprint."""
-        n = self._n_tokens
+        n = len(self._k_signs)
         if n == 0:
             return 0
         sign_bytes = n * self._m
@@ -112,7 +112,7 @@ class QJLKVCache(KVCache):
         return sign_bytes + norm_bytes + v_bytes
 
     def __len__(self) -> int:
-        return self._n_tokens
+        return len(self._k_signs)
 
     def __repr__(self) -> str:
         return f"QJLKVCache(d={self._d}, m={self._m}, n_tokens={self._n_tokens})"

--- a/veloxquant_mlx/tests/cache/test_polar_cache.py
+++ b/veloxquant_mlx/tests/cache/test_polar_cache.py
@@ -1,0 +1,123 @@
+"""Tests for PolarQuantKVCache.
+
+Covers the standard append/attend/memory_bytes path plus a regression for
+#82: once more tokens have been appended than the configured ``capacity``,
+the RingBuffer-backed storage silently evicts the oldest entries, so
+``attend()``/``memory_bytes()``/``__len__`` must use the buffer's actual
+(capacity-capped) live size, not the unbounded lifetime append counter.
+
+head_dim must be divisible by 2**n_levels (16, per RecursivePolarTransform's
+default depth) for PolarQuantizer.encode to accept it.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from veloxquant_mlx.cache.base import KVCacheConfig, KVCacheFactory
+
+_D = 16
+
+
+def _make(**cfg):
+    base = dict(method="polar", head_dim=_D, bit_width_inlier=2, seed=0)
+    base.update(cfg)
+    return KVCacheFactory.create(KVCacheConfig(**base))
+
+
+def _rand_vec(D: int = _D, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    return mx.array(rng.standard_normal(D).astype(np.float16))
+
+
+def test_factory_dispatch() -> None:
+    from veloxquant_mlx.cache.polar_cache import PolarQuantKVCache
+
+    assert isinstance(_make(), PolarQuantKVCache)
+
+
+def test_append_and_attend_within_capacity() -> None:
+    cache = _make(capacity=100)
+    for i in range(10):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    assert len(cache) == 10
+
+    out = cache.attend(_rand_vec(seed=999))
+    mx.eval(out)
+    assert out.shape == (_D,)
+
+
+def test_empty_cache_attend_returns_zeros() -> None:
+    cache = _make(capacity=10)
+    out = cache.attend(_rand_vec())
+    mx.eval(out)
+    assert bool(mx.all(out == 0))
+
+
+# ---------------------------------------------------------------------------
+# Regression for #82
+# ---------------------------------------------------------------------------
+
+
+def test_attend_past_capacity_does_not_raise() -> None:
+    """Regression for #82: attend() must not IndexError once more tokens
+    have been appended than the ring buffer's capacity."""
+    cache = _make(capacity=4)
+    for i in range(6):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+
+    out = cache.attend(_rand_vec(seed=999))  # must not raise
+    mx.eval(out)
+    assert out.shape == (_D,)
+
+
+def test_len_capped_at_capacity() -> None:
+    """len() must reflect the ring buffer's live (capped) size, not the
+    unbounded lifetime append count."""
+    cache = _make(capacity=4)
+    for i in range(6):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    assert len(cache) == 4
+
+
+def test_memory_bytes_capped_at_capacity() -> None:
+    """memory_bytes() must scale with the capped live size, not the
+    unbounded lifetime append count (else it over-reports usage — the
+    milder, non-crashing form of the same bug flagged in #82)."""
+    cache = _make(capacity=4)
+    for i in range(4):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    bytes_at_capacity = cache.memory_bytes()
+
+    for i in range(4, 6):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    bytes_past_capacity = cache.memory_bytes()
+
+    assert bytes_past_capacity == bytes_at_capacity, (
+        "memory_bytes() must plateau once past capacity, not keep growing "
+        "with the unbounded lifetime token count"
+    )
+
+
+def test_attend_correct_after_eviction() -> None:
+    """After capacity overflow, attend() must only ever see the surviving
+    (most recent `capacity`) tokens — no crash, and a deterministic result
+    across repeated calls."""
+    cache = _make(capacity=3)
+    for i in range(5):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    assert len(cache) == 3
+
+    q = _rand_vec(seed=999)
+    out1 = cache.attend(q)
+    out2 = cache.attend(q)
+    mx.eval(out1, out2)
+    assert np.array_equal(np.array(out1), np.array(out2))

--- a/veloxquant_mlx/tests/cache/test_qjl_cache.py
+++ b/veloxquant_mlx/tests/cache/test_qjl_cache.py
@@ -1,0 +1,117 @@
+"""Tests for QJLKVCache.
+
+Covers the standard append/attend/memory_bytes path plus a regression for
+#82: once more tokens have been appended than the configured ``capacity``,
+the RingBuffer-backed storage silently evicts the oldest entries, so
+``attend()``/``memory_bytes()``/``__len__`` must use the buffer's actual
+(capacity-capped) live size, not the unbounded lifetime append counter.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from veloxquant_mlx.cache.base import KVCacheConfig, KVCacheFactory
+
+
+def _make(**cfg):
+    base = dict(method="qjl", head_dim=8, jl_dim=8, seed=0)
+    base.update(cfg)
+    return KVCacheFactory.create(KVCacheConfig(**base))
+
+
+def _rand_vec(D: int = 8, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    return mx.array(rng.standard_normal(D).astype(np.float16))
+
+
+def test_factory_dispatch() -> None:
+    from veloxquant_mlx.cache.qjl_cache import QJLKVCache
+
+    assert isinstance(_make(), QJLKVCache)
+
+
+def test_append_and_attend_within_capacity() -> None:
+    cache = _make(capacity=100)
+    for i in range(10):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    assert len(cache) == 10
+
+    out = cache.attend(_rand_vec(seed=999))
+    mx.eval(out)
+    assert out.shape == (8,)
+
+
+def test_empty_cache_attend_returns_zeros() -> None:
+    cache = _make(capacity=10)
+    out = cache.attend(_rand_vec())
+    mx.eval(out)
+    assert bool(mx.all(out == 0))
+
+
+# ---------------------------------------------------------------------------
+# Regression for #82
+# ---------------------------------------------------------------------------
+
+
+def test_attend_past_capacity_does_not_raise() -> None:
+    """Regression for #82: attend() must not IndexError once more tokens
+    have been appended than the ring buffer's capacity."""
+    cache = _make(capacity=4)
+    for i in range(6):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+
+    out = cache.attend(_rand_vec(seed=999))  # must not raise
+    mx.eval(out)
+    assert out.shape == (8,)
+
+
+def test_len_capped_at_capacity() -> None:
+    """len() must reflect the ring buffer's live (capped) size, not the
+    unbounded lifetime append count."""
+    cache = _make(capacity=4)
+    for i in range(6):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    assert len(cache) == 4
+
+
+def test_memory_bytes_capped_at_capacity() -> None:
+    """memory_bytes() must scale with the capped live size, not the
+    unbounded lifetime append count (else it over-reports usage)."""
+    cache = _make(capacity=4)
+    for i in range(4):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    bytes_at_capacity = cache.memory_bytes()
+
+    for i in range(4, 6):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    bytes_past_capacity = cache.memory_bytes()
+
+    assert bytes_past_capacity == bytes_at_capacity, (
+        "memory_bytes() must plateau once past capacity, not keep growing "
+        "with the unbounded lifetime token count"
+    )
+
+
+def test_attend_correct_after_eviction() -> None:
+    """After capacity overflow, attend() must only ever see the surviving
+    (most recent `capacity`) tokens — no crash, and a deterministic result
+    across repeated calls."""
+    cache = _make(capacity=3)
+    for i in range(5):
+        cache.append_key(_rand_vec(seed=i))
+        cache.append_value(_rand_vec(seed=100 + i))
+    assert len(cache) == 3
+
+    q = _rand_vec(seed=999)
+    out1 = cache.attend(q)
+    out2 = cache.attend(q)
+    mx.eval(out1, out2)
+    assert np.array_equal(np.array(out1), np.array(out2))


### PR DESCRIPTION
## Summary

`QJLKVCache.attend()` and `PolarQuantKVCache.attend()` both used the unbounded lifetime counter `self._n_tokens` as the read-loop bound against their `RingBuffer`-backed storage, instead of the buffer's actual (capacity-capped) live size. `RingBuffer.append` silently evicts the oldest entry once full and correctly raises `IndexError` for any index `>= self._size`. Once more tokens had been appended than the configured `capacity`, `attend()` crashed with `IndexError` — `capacity` is a documented, supported `KVCacheConfig` field for exactly this bounded-cache use case, so any user setting it below their generation length hit this immediately.

Fixes #82.

## Root cause

```python
n = self._n_tokens          # unbounded, grows forever
...
k_signs = mx.stack([self._k_signs[i] for i in range(n)])   # RingBuffer caps at capacity
```

`RingBuffer` already implements `__len__` returning its capped live size (`self._size`), so the fix is `n = len(self._k_signs)` (qjl) / `n = len(self._k_angles)` (polar) — matching the pattern already used correctly in `turboquant_cache.py` and `spectral_cache.py` (`n = self._size`, their own custom ring-buffer's capped size).

The same root-cause bug also affected `memory_bytes()` (silently over-reporting usage once past capacity, the milder non-crashing form flagged in the issue) and `__len__` (reporting the unbounded lifetime count instead of the true, retrievable cache size — inconsistent with every sibling cache's `__len__` contract) in **both** classes. Fixed identically for consistency, since leaving them on the unbounded counter would just reintroduce the same bug class `attend()` was just fixed for.

## Testing

Added `veloxquant_mlx/tests/cache/test_qjl_cache.py` and `test_polar_cache.py` (neither existed before — only quantizer-level tests did), each covering:
- Standard append/attend/memory_bytes within capacity
- Empty-cache attend returns zeros
- `attend()` past capacity — the issue's exact repro — no longer raises
- `len()` and `memory_bytes()` correctly plateau at the capacity-capped size instead of growing with the unbounded lifetime count
- `attend()` after eviction stays deterministic across repeated calls

- `pytest veloxquant_mlx/tests/cache/test_qjl_cache.py veloxquant_mlx/tests/cache/test_polar_cache.py -v` → 14/14 passed
- `pytest veloxquant_mlx/tests/` → 1643/1644 passed (1 pre-existing, unrelated failure in `test_mlx_lm_patch.py` — missing `pytest` import on master, confirmed via `git stash` in a prior PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)