### PR TITLE
fix(cache): reject sliding_window for non-standalone (mlx_lm-protocol) methods

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -577,6 +577,20 @@ class KVCacheFactory:
             )
 
         if config.sliding_window is not None:
+            if config.method not in STANDALONE_METHODS:
+                raise QuantizerConfigError(
+                    f"KVCacheFactory: sliding_window is only compatible with "
+                    f"standalone methods (see STANDALONE_METHODS: "
+                    f"{sorted(STANDALONE_METHODS)}) — method {config.method!r} "
+                    f"produces a cache implementing mlx_lm.models.cache.KVCache's "
+                    f"update_and_fetch protocol, not VeloxQuant's own "
+                    f"append_key/append_value/attend interface that "
+                    f"SlidingWindowKVCache wraps, so the result would have "
+                    f"neither method working. Drop sliding_window for this "
+                    f"method — several mlx_lm-protocol methods (h2o, tova, "
+                    f"streaming_llm, snapkv, etc.) already implement their own "
+                    f"budget/window-based eviction."
+                )
             cache = SlidingWindowKVCache(cache, window_size=config.sliding_window)
 
         return cache

--- a/veloxquant_mlx/tests/cache/test_sliding_window.py
+++ b/veloxquant_mlx/tests/cache/test_sliding_window.py
@@ -91,13 +91,7 @@ def test_sliding_window_rejected_via_builder() -> None:
     from veloxquant_mlx.core.exceptions import QuantizerConfigError
 
     with pytest.raises(QuantizerConfigError, match="sliding_window"):
-        (
-            KVCacheBuilder()
-            .with_method("h2o")
-            .with_head_dim(16)
-            .with_sliding_window(8)
-            .build()
-        )
+        (KVCacheBuilder().with_method("h2o").with_head_dim(16).with_sliding_window(8).build())
 
 
 @pytest.mark.parametrize("method,extra", [("qjl", {"jl_dim": 8}), ("polar", {})])

--- a/veloxquant_mlx/tests/cache/test_sliding_window.py
+++ b/veloxquant_mlx/tests/cache/test_sliding_window.py
@@ -51,3 +51,78 @@ def test_sliding_window_invalid_size() -> None:
     cache = KVCacheBuilder().with_method("qjl").with_head_dim(64).with_jl_dim(64).build()
     with pytest.raises(ValueError):
         SlidingWindowKVCache(cache, window_size=0)
+
+
+# ---------------------------------------------------------------------------
+# Regression for #81: KVCacheConfig.sliding_window + a non-standalone method
+# (mlx_lm-protocol, i.e. update_and_fetch-based) must raise a clear config
+# error at construction time, not produce a cache broken at first use.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,extra",
+    [
+        ("h2o", {}),
+        ("tova", {}),
+        ("kivi", {}),
+        ("snapkv", {}),
+        ("streaming_llm", {}),
+    ],
+)
+def test_sliding_window_rejected_for_mlx_lm_protocol_methods(method, extra) -> None:
+    """Regression for #81's exact repro: sliding_window combined with any
+    mlx_lm-protocol (update_and_fetch-based) method must raise
+    QuantizerConfigError at KVCacheFactory.create(), not silently produce a
+    cache with neither update_and_fetch (not on the wrapper) nor
+    append_key/append_value (not on the inner cache) working."""
+    from veloxquant_mlx.cache.base import KVCacheConfig, KVCacheFactory
+    from veloxquant_mlx.core.exceptions import QuantizerConfigError
+
+    cfg = KVCacheConfig(method=method, head_dim=16, sliding_window=8, **extra)
+    with pytest.raises(QuantizerConfigError, match="sliding_window"):
+        KVCacheFactory.create(cfg)
+
+
+def test_sliding_window_rejected_via_builder() -> None:
+    """Same guard must apply through the KVCacheBuilder.build() entry point,
+    since it delegates to KVCacheFactory.create()."""
+    from veloxquant_mlx.cache.base import KVCacheBuilder
+    from veloxquant_mlx.core.exceptions import QuantizerConfigError
+
+    with pytest.raises(QuantizerConfigError, match="sliding_window"):
+        (
+            KVCacheBuilder()
+            .with_method("h2o")
+            .with_head_dim(16)
+            .with_sliding_window(8)
+            .build()
+        )
+
+
+@pytest.mark.parametrize("method,extra", [("qjl", {"jl_dim": 8}), ("polar", {})])
+def test_sliding_window_accepted_for_standalone_methods(method, extra) -> None:
+    """sliding_window must still work end-to-end for STANDALONE_METHODS —
+    the only family SlidingWindowKVCache's append_key/append_value/attend
+    wrapping is actually compatible with."""
+    import mlx.core as mx
+
+    from veloxquant_mlx.cache.base import KVCacheConfig, KVCacheFactory
+    from veloxquant_mlx.cache.sliding_window_cache import SlidingWindowKVCache
+
+    d = 16
+    cfg = KVCacheConfig(method=method, head_dim=d, sliding_window=4, bit_width_inlier=2, **extra)
+    cache = KVCacheFactory.create(cfg)
+    assert isinstance(cache, SlidingWindowKVCache)
+
+    rng = np.random.default_rng(0)
+    for _ in range(6):
+        k = mx.array(rng.standard_normal(d).astype(np.float16))
+        v = mx.array(rng.standard_normal(d).astype(np.float16))
+        cache.append(k, v)
+    assert len(cache) == 4
+
+    q = mx.array(rng.standard_normal(d).astype(np.float16))
+    out = cache.attend(q)
+    mx.eval(out)
+    assert out.shape == (d,)


### PR DESCRIPTION
## Summary

`KVCacheConfig.sliding_window` carried no restriction on which `method` it's compatible with, and `KVCacheFactory.create()` applied `SlidingWindowKVCache` wrapping unconditionally. `SlidingWindowKVCache` subclasses VeloxQuant's own `KVCache` ABC (`append_key`/`append_value`/`attend`) and delegates to those methods on its inner cache — but 35+ of the 40 registered methods produce a cache subclassing `mlx_lm.models.cache.KVCache`, which implements `update_and_fetch`, not `append_key`/`append_value`. Wrapping one of those produced an object with **neither** method working: no `update_and_fetch` (not defined on the wrapper) and no `append_key` (not defined on the inner cache) — broken at the very first call, for any mlx_lm-protocol method combined with `sliding_window`.

Fixes #81.

## Fix

Guarded the wrap behind `STANDALONE_METHODS` in `KVCacheFactory.create()`, raising a clear `QuantizerConfigError` for the other 35+ methods instead of constructing a cache broken at first use — mirroring the existing `STANDALONE_METHODS` guard pattern already used in `KVCacheBuilder.for_model()` for this exact interface-mismatch class of problem.

`KVCacheBuilder.build()` delegates to `KVCacheFactory.create()`, so the guard covers both public entry points. `KVCacheBuilder.for_model()` never reads `config.sliding_window` at all, so it wasn't a third crash path — verified by grep.

## Testing

Extended `veloxquant_mlx/tests/cache/test_sliding_window.py`:
- `sliding_window` + each of several mlx_lm-protocol methods (h2o, tova, kivi, snapkv, streaming_llm) raises `QuantizerConfigError` at `KVCacheFactory.create()` — the issue's exact repro
- Same guard fires through `KVCacheBuilder.build()`
- `sliding_window` still works end-to-end for standalone methods (qjl, polar) — append/attend round trip, window correctly bounds retained size

- `pytest veloxquant_mlx/tests/cache/test_sliding_window.py -v` → 11/11 passed
- `pytest veloxquant_mlx/tests/` → 1651/1652 passed (1 pre-existing, unrelated failure in `test_mlx_lm_patch.py` — missing `pytest` import on master, confirmed in a prior PR via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)