### PR TITLE
fix: XQuantCoordinator reclaims published anchor segments (#80)

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -935,6 +935,14 @@ class KVCacheBuilder:
         role_by_layer: dict[int, tuple[str, int]] = {
             attn_layer_idx[k]: roles[k] for k in range(len(attn_layer_idx))
         }
+        # Each anchor's published segment is consumed by every reuse layer in
+        # its group before the coordinator can reclaim it (#80). Seed every
+        # group at 0 first so a trailing degenerate group (anchor with no
+        # reusers) doesn't fall through to some other group's reader count.
+        n_readers_by_group: dict[int, int] = {group_id: 0 for _, group_id in roles}
+        for role, group_id in roles:
+            if role == "reuse":
+                n_readers_by_group[group_id] += 1
 
         caches = []
         for i, layer in enumerate(layers):
@@ -954,7 +962,13 @@ class KVCacheBuilder:
                 xquant_max_ctx=config.xquant_max_ctx,
             )
             caches.append(
-                XQuantKVCache(layer_cfg, role=role, group_id=group_id, coordinator=coordinator)
+                XQuantKVCache(
+                    layer_cfg,
+                    role=role,
+                    group_id=group_id,
+                    coordinator=coordinator,
+                    n_readers=n_readers_by_group[group_id],
+                )
             )
         return caches
 

--- a/veloxquant_mlx/cache/xquant_cache.py
+++ b/veloxquant_mlx/cache/xquant_cache.py
@@ -56,6 +56,9 @@ class XQuantKVCache(_MLXKVCache):
         role: ``"anchor"`` or ``"reuse"`` (default ``"anchor"``).
         group_id: Cross-layer group this layer belongs to.
         coordinator: Shared :class:`XQuantCoordinator` (None → degenerate anchor).
+        n_readers: Number of reuse layers in this anchor's group (group_size - 1).
+            Only meaningful for ``role="anchor"``; tells the coordinator how many
+            fetches to expect before a published segment can be reclaimed.
     """
 
     def __init__(
@@ -64,11 +67,13 @@ class XQuantKVCache(_MLXKVCache):
         role: str = "anchor",
         group_id: int = 0,
         coordinator: Optional[XQuantCoordinator] = None,
+        n_readers: int = 1,
     ) -> None:
         super().__init__()
         self._role: str = role if coordinator is not None else "anchor"
         self._group_id: int = int(group_id)
         self._coord: Optional[XQuantCoordinator] = coordinator
+        self._n_readers: int = int(n_readers)
 
         self._base_bits: int = int(getattr(config, "xquant_base_bits", 2))
         self._residual_bits: int = int(getattr(config, "xquant_residual_bits", 0))
@@ -146,6 +151,7 @@ class XQuantKVCache(_MLXKVCache):
                     S,
                     codes=(k_codes, v_codes),
                     params=GroupParams(scale=None, zero=None, n_rows=S, bits=self._base_bits),
+                    n_readers=self._n_readers,
                 )
             self._account_anchor(B, H, S, D)
         else:

--- a/veloxquant_mlx/cache/xquant_coordinator.py
+++ b/veloxquant_mlx/cache/xquant_coordinator.py
@@ -13,6 +13,14 @@ segment (token_start=0); each decode step writes a one-token segment at the next
 offset. A per-group token budget (``max_ctx``) bounds memory; exceeding it raises
 ``RuntimeError`` (mirrors the ``fused_sdpa_max_ctx`` guard in ``base.py``).
 
+Each published segment is consumed by a fixed number of reuse layers (one per
+non-anchor member of the group — usually 1, but ``xquant_group_size > 2`` means
+one anchor feeds multiple reusers). ``fetch_anchor`` counts reads per segment
+and only reclaims it (dropping it from ``_store`` and crediting its tokens back
+against ``_published_tokens``) once every expected reader has consumed it —
+so ``_published_tokens`` tracks live, unconsumed tokens rather than a lifetime
+total, and a long generation no longer exhausts ``max_ctx`` (#80).
+
 Single-threaded by construction (mlx generate is sequential), so a plain
 dict-of-segments needs no locking.
 """
@@ -29,13 +37,21 @@ from veloxquant_mlx.quantizers.xquant import GroupParams
 class _Segment:
     """One published anchor write: codes for a contiguous token range."""
 
-    __slots__ = ("token_start", "n_tokens", "codes", "params")
+    __slots__ = ("token_start", "n_tokens", "codes", "params", "reads_remaining")
 
-    def __init__(self, token_start: int, n_tokens: int, codes: mx.array, params: GroupParams):
+    def __init__(
+        self,
+        token_start: int,
+        n_tokens: int,
+        codes: mx.array,
+        params: GroupParams,
+        n_readers: int,
+    ):
         self.token_start = token_start
         self.n_tokens = n_tokens
         self.codes = codes  # [B, H, n_groups, group_size, D] fp32 codes
         self.params = params  # anchor GroupParams (per (B,H) not stored here; see cache)
+        self.reads_remaining = n_readers
 
 
 class XQuantCoordinator:
@@ -64,6 +80,7 @@ class XQuantCoordinator:
         n_tokens: int,
         codes: mx.array,
         params: GroupParams,
+        n_readers: int = 1,
     ) -> None:
         """Publish anchor codes for a token range.
 
@@ -73,6 +90,8 @@ class XQuantCoordinator:
             n_tokens: Number of tokens in this write.
             codes: Anchor integer codes (shape owned by the cache).
             params: Anchor GroupParams (for shape/bits reference).
+            n_readers: Number of reuse layers expected to fetch this segment
+                before it is reclaimed (group_size - 1; default 1).
         """
         published = self._published_tokens.get(group_id, 0)
         if published + n_tokens > self._max_ctx:
@@ -80,13 +99,24 @@ class XQuantCoordinator:
                 f"XQuantCoordinator: group {group_id} exceeds max_ctx={self._max_ctx} "
                 f"(have {published}, +{n_tokens}). Increase xquant_max_ctx."
             )
+        if n_readers <= 0:
+            # Degenerate anchor (no reusers in its group, e.g. a trailing
+            # partial group): nothing will ever call fetch_anchor for this
+            # segment, so storing it would leak forever. No-op — the caller
+            # doesn't need it back.
+            return
         self._store.setdefault(group_id, {})[token_start] = _Segment(
-            token_start, n_tokens, codes, params
+            token_start, n_tokens, codes, params, n_readers
         )
         self._published_tokens[group_id] = published + n_tokens
 
     def fetch_anchor(self, group_id: int, token_start: int) -> Optional[_Segment]:
         """Fetch the anchor segment a reuse layer needs for this step.
+
+        Once every expected reader (``n_readers`` passed to ``register_anchor``)
+        has fetched a segment, it is reclaimed: dropped from the store and its
+        tokens credited back against ``_published_tokens``, so a long-running
+        generation never exhausts ``max_ctx`` on live-but-consumed segments (#80).
 
         Args:
             group_id: The reuse layer's group.
@@ -96,7 +126,17 @@ class XQuantCoordinator:
             The matching ``_Segment``, or ``None`` if the anchor has not
             published it yet (e.g. mis-ordered iteration — caller must handle).
         """
-        return self._store.get(group_id, {}).get(token_start)
+        group_store = self._store.get(group_id, {})
+        seg = group_store.get(token_start)
+        if seg is None:
+            return None
+        seg.reads_remaining -= 1
+        if seg.reads_remaining <= 0:
+            del group_store[token_start]
+            self._published_tokens[group_id] = (
+                self._published_tokens.get(group_id, 0) - seg.n_tokens
+            )
+        return seg
 
     def published_tokens(self, group_id: int) -> int:
         """Total tokens the anchor of ``group_id`` has published."""

--- a/veloxquant_mlx/tests/cache/test_xquant_cache.py
+++ b/veloxquant_mlx/tests/cache/test_xquant_cache.py
@@ -113,12 +113,17 @@ def test_for_model_pairing():
 def test_coordinator_round_trip():
     coord = XQuantCoordinator()
     codes, params = quantize_codes(_rand(1, 1, 16, 64)[0, 0], bits=2, group_size=32)
-    coord.register_anchor(0, token_start=0, n_tokens=16, codes=codes, params=params)
+    coord.register_anchor(0, token_start=0, n_tokens=16, codes=codes, params=params, n_readers=1)
+    assert coord.published_tokens(0) == 16
     seg = coord.fetch_anchor(0, 0)
     assert seg is not None
     np.testing.assert_array_equal(np.array(seg.codes.tolist()), np.array(codes.tolist()))
-    assert coord.published_tokens(0) == 16
+    # Regression for #80: once the single expected reader has fetched it, the
+    # segment is reclaimed and its tokens credited back — published_tokens
+    # tracks live (unconsumed) tokens, not a lifetime total.
+    assert coord.published_tokens(0) == 0
     assert coord.fetch_anchor(0, 999) is None  # missing offset
+    assert coord.fetch_anchor(0, 0) is None  # already reclaimed
 
 
 # ---------------------------------------------------------------------------
@@ -292,7 +297,10 @@ def test_decode_synchronization():
         ko, _ = r.update_and_fetch(kd, vd)
         expected_S = 20 + step + 1
         assert ko.shape[2] == expected_S
-    assert coord.published_tokens(0) == 25
+    # Regression for #80: the sole reuse layer consumes each segment right
+    # after the anchor publishes it, so nothing stays live across steps —
+    # published_tokens tracks unconsumed tokens, not a lifetime total.
+    assert coord.published_tokens(0) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -348,3 +356,75 @@ def test_determinism():
     k2, v2 = run()
     np.testing.assert_array_equal(k1, k2)
     np.testing.assert_array_equal(v1, v2)
+
+
+# ---------------------------------------------------------------------------
+# Regression for #80: XQuantCoordinator never reclaimed published anchor
+# segments, so cumulative anchor-published tokens hit xquant_max_ctx and
+# register_anchor raised RuntimeError on every subsequent decode step, even
+# though each segment is read exactly once (one step later) and is dead
+# weight afterward.
+# ---------------------------------------------------------------------------
+def test_decode_past_max_ctx_does_not_raise():
+    """A generation whose *cumulative* anchor-published tokens exceed
+    max_ctx must not crash, as long as the reuse layer stays in lockstep
+    (the normal generate() pattern) so each segment is reclaimed before the
+    next one is published."""
+    coord = XQuantCoordinator(max_ctx=8)
+    a, r = _pair(coord)
+    # Prefill within budget.
+    a.update_and_fetch(_rand(1, 2, 4, 64), _rand(1, 2, 4, 64, seed=1))
+    r.update_and_fetch(_rand(1, 2, 4, 64), _rand(1, 2, 4, 64, seed=1))
+    # 20 decode steps of 1 token each — far more than max_ctx=8 lifetime
+    # tokens would allow under the old (never-reclaimed) accounting.
+    for step in range(20):
+        kd = _rand(1, 2, 1, 64, seed=100 + step)
+        vd = _rand(1, 2, 1, 64, seed=200 + step)
+        a.update_and_fetch(kd, vd)  # must not raise
+        r.update_and_fetch(kd, vd)
+    assert coord.published_tokens(0) == 0
+
+
+def test_group_size_three_both_reusers_consume_before_reclaim():
+    """With one anchor feeding two reusers (group_size=3), the coordinator
+    must not reclaim a segment until *both* reusers have fetched it — and
+    must reclaim (not leak) once they have."""
+    coord = XQuantCoordinator()
+    cfg = _cfg(xquant_base_bits=2)
+    a = XQuantKVCache(cfg, role="anchor", group_id=0, coordinator=coord, n_readers=2)
+    r1 = XQuantKVCache(cfg, role="reuse", group_id=0, coordinator=coord, n_readers=2)
+    r2 = XQuantKVCache(cfg, role="reuse", group_id=0, coordinator=coord, n_readers=2)
+
+    k = _rand(1, 2, 16, 64)
+    v = _rand(1, 2, 16, 64, seed=1)
+    a.update_and_fetch(k, v)
+    assert coord.published_tokens(0) == 16  # still live: 0 of 2 readers fetched
+
+    r1.update_and_fetch(k, v)
+    assert coord.published_tokens(0) == 16  # still live: 1 of 2 readers fetched
+
+    r2.update_and_fetch(k, v)
+    assert coord.published_tokens(0) == 0  # reclaimed: both readers fetched
+
+
+def test_for_model_pairing_survives_past_max_ctx():
+    """End-to-end via KVCacheBuilder.for_model: a generation whose cumulative
+    anchor tokens exceed xquant_max_ctx must not crash, matching the issue's
+    exact repro path (method="xquant" built through for_model)."""
+    model = _MockModel(n_layers=6, head_dim=64)
+    cfg = _cfg(xquant_group_size=2, xquant_max_ctx=8)
+    caches = KVCacheBuilder.for_model(model, cfg)
+    anchors_reuses = [(caches[i], caches[i + 1]) for i in range(0, 6, 2)]
+
+    k = _rand(1, 2, 4, 64)
+    v = _rand(1, 2, 4, 64, seed=1)
+    for a, r in anchors_reuses:
+        a.update_and_fetch(k, v)
+        r.update_and_fetch(k, v)
+
+    for step in range(20):
+        kd = _rand(1, 2, 1, 64, seed=300 + step)
+        vd = _rand(1, 2, 1, 64, seed=400 + step)
+        for a, r in anchors_reuses:
+            a.update_and_fetch(kd, vd)  # must not raise past max_ctx=8
+            r.update_and_fetch(kd, vd)


### PR DESCRIPTION
## Summary

Fixes #80 — `XQuantCoordinator` never reclaimed published anchor segments, so `XQuantKVCache` (`method="xquant"`) crashed at `xquant_max_ctx` (default 8192) cumulative tokens, even in routine generation.

Same root cause as #79 (`MiniCacheCoordinator`), but scoped to `XQuantCoordinator`/`XQuantKVCache` only, per the issue.

## Root cause

- `fetch_anchor` was a pure read — it never removed the entry from `_store`.
- `register_anchor`'s budget accounting (`_published_tokens[group_id]`) only ever grew.

Since every anchor `update_and_fetch` call publishes a new segment (`token_start = self._token_offset`, strictly increasing), and each segment is read exactly once — one step later, by the paired reuse layer(s) — the store leaked forever and `register_anchor` started raising `RuntimeError: ... exceeds max_ctx` on every decode step past 8192 cumulative anchor-published tokens.

## Fix

- `_Segment` now tracks `reads_remaining`, seeded from a new `n_readers` param on `register_anchor` (default 1).
- `fetch_anchor` decrements `reads_remaining` on each call; once it hits 0 the segment is dropped from `_store` and its tokens are credited back against `_published_tokens` — so `published_tokens(group_id)` now tracks *live, unconsumed* tokens rather than a lifetime total.
- `XQuantKVCache` gained an `n_readers` constructor param (defaults to 1, matching direct single-anchor/single-reuse construction), forwarded to `register_anchor` for anchor-role caches.
- `KVCacheBuilder._build_xquant` computes `n_readers` per group from `pair_layers`'s role assignment (`group_size - 1` — XQuant groups can be one anchor feeding *multiple* reusers when `xquant_group_size > 2`) and passes it through, so the coordinator knows exactly how many fetches to wait for before reclaiming. A degenerate trailing group (anchor with zero reusers, e.g. an uneven last group) gets `n_readers=0`, which `register_anchor` treats as "nothing will ever read this" and skips storing entirely, rather than leaking a segment no one will fetch.

`XKVCoordinator` (the third coordinator in this family) doesn't share this bug — its fan-in/fan-out basis-sharing happens once per group at prefill, not once per decode step, so it wasn't touched.

## Tests

- Updated 2 existing coordinator-level assertions (`test_coordinator_round_trip`, `test_decode_synchronization`) that encoded the old (buggy) "lifetime total" semantics of `published_tokens` — they now assert the correct "live/unconsumed" semantics post-fetch.
- Added 3 regression tests:
  - `test_decode_past_max_ctx_does_not_raise` — 20 decode steps through a `max_ctx=8` coordinator (anchor+reuse in lockstep) no longer raises.
  - `test_group_size_three_both_reusers_consume_before_reclaim` — one anchor feeding two reusers: segment must survive until *both* have fetched it, then reclaim.
  - `test_for_model_pairing_survives_past_max_ctx` — end-to-end via `KVCacheBuilder.for_model`, matching the issue's exact repro path.

All 19 tests in `test_xquant_cache.py` pass; full `veloxquant_mlx/tests/cache/` suite (704 tests) passes; full `veloxquant_mlx/tests/` suite passes except one pre-existing, unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`, untouched by this PR).

`ruff format --check` clean on all 4 changed files.

## Test plan

- [x] `pytest veloxquant_mlx/tests/cache/test_xquant_cache.py -q` — 19 passed
- [x] `pytest veloxquant_mlx/tests/cache/ -q` — 704 passed
- [x] `pytest veloxquant_mlx/tests/ -q` — 1654 passed, 1 pre-existing unrelated failure
- [x] `ruff format --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)