### PR TITLE
fix(cache): reclaim MiniCache coordinator entries once consumed (#79)

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -1069,6 +1069,15 @@ class KVCacheBuilder:
         role_by_layer: dict[int, tuple[str, int]] = {
             attn_layer_idx[k]: roles[k] for k in range(len(attn_layer_idx))
         }
+        # Each primary's published entry is consumed by every merge layer in
+        # its group before the coordinator can reclaim it (#79). Seed every
+        # group at 0 first so a standalone primary (no merge partners, e.g.
+        # an early layer below minicache_start_frac) doesn't fall through to
+        # some other group's reader count.
+        n_readers_by_group: dict[int, int] = {group_id: 0 for _, group_id in roles}
+        for role, group_id in roles:
+            if role == "merge":
+                n_readers_by_group[group_id] += 1
 
         caches = []
         for i, layer in enumerate(layers):
@@ -1088,7 +1097,13 @@ class KVCacheBuilder:
                 minicache_max_ctx=config.minicache_max_ctx,
             )
             caches.append(
-                MiniCacheKVCache(layer_cfg, role=role, group_id=group_id, coordinator=coordinator)
+                MiniCacheKVCache(
+                    layer_cfg,
+                    role=role,
+                    group_id=group_id,
+                    coordinator=coordinator,
+                    n_readers=n_readers_by_group[group_id],
+                )
             )
         return caches
 

--- a/veloxquant_mlx/cache/minicache_cache.py
+++ b/veloxquant_mlx/cache/minicache_cache.py
@@ -50,6 +50,9 @@ class MiniCacheKVCache(_MLXKVCache):
         role: ``"primary"`` or ``"merge"`` (default ``"primary"``).
         group_id: Cross-layer merge group this layer belongs to.
         coordinator: Shared :class:`MiniCacheCoordinator` (None → degenerate).
+        n_readers: Number of merge layers in this primary's group (group_size - 1).
+            Only meaningful for ``role="primary"``; tells the coordinator how many
+            fetches to expect before a published entry can be reclaimed.
     """
 
     def __init__(
@@ -58,11 +61,13 @@ class MiniCacheKVCache(_MLXKVCache):
         role: str = "primary",
         group_id: int = 0,
         coordinator: Optional[MiniCacheCoordinator] = None,
+        n_readers: int = 1,
     ) -> None:
         super().__init__()
         self._role = role if coordinator is not None else "primary"
         self._group_id = int(group_id)
         self._coord = coordinator
+        self._n_readers = int(n_readers)
         self._ret = float(getattr(config, "minicache_retention_threshold", 0.9))
         self._t = float(getattr(config, "minicache_slerp_t", 0.5))
 
@@ -159,7 +164,9 @@ class MiniCacheKVCache(_MLXKVCache):
         else:
             # primary: store true KV for the merge partner, reconstruct losslessly
             if self._coord is not None:
-                self._coord.publish_primary(self._group_id, tok_start, S, keys, values)
+                self._coord.publish_primary(
+                    self._group_id, tok_start, S, keys, values, n_readers=self._n_readers
+                )
             k_out, v_out = keys, values
             self._account_primary(B, H, S, D)
 

--- a/veloxquant_mlx/cache/minicache_coordinator.py
+++ b/veloxquant_mlx/cache/minicache_coordinator.py
@@ -21,6 +21,14 @@ cache only sees its *own* layer at ``update_and_fetch`` time. So the protocol is
 State is keyed by ``(group_id, token_start)`` so a merge layer fetches exactly
 the segment its paired primary wrote for the same step. Single-threaded by
 construction (mlx generate is sequential).
+
+Each published write is consumed by a fixed number of merge layers (one per
+non-primary member of the group — usually 1, but ``minicache_group_size > 2``
+means one primary feeds multiple mergers). ``fetch_primary`` counts reads per
+entry and only reclaims it (dropping it from ``_store`` and crediting its
+tokens back against ``_published_tokens``) once every expected reader has
+consumed it — so ``_published_tokens`` tracks live, unconsumed tokens rather
+than a lifetime total, and a long generation no longer exhausts ``max_ctx`` (#79).
 """
 
 from __future__ import annotations
@@ -33,13 +41,21 @@ import mlx.core as mx
 class _PrimaryWrite:
     """A primary layer's stored KV for a token range, awaiting its merge partner."""
 
-    __slots__ = ("token_start", "n_tokens", "keys", "values")
+    __slots__ = ("token_start", "n_tokens", "keys", "values", "reads_remaining")
 
-    def __init__(self, token_start: int, n_tokens: int, keys: mx.array, values: mx.array):
+    def __init__(
+        self,
+        token_start: int,
+        n_tokens: int,
+        keys: mx.array,
+        values: mx.array,
+        n_readers: int,
+    ):
         self.token_start = token_start
         self.n_tokens = n_tokens
         self.keys = keys  # [B, H, S, D] fp16 — the primary layer's true KV
         self.values = values
+        self.reads_remaining = n_readers
 
 
 class MiniCacheCoordinator:
@@ -66,8 +82,19 @@ class MiniCacheCoordinator:
         n_tokens: int,
         keys: mx.array,
         values: mx.array,
+        n_readers: int = 1,
     ) -> None:
-        """Primary layer stores its true KV for a token range."""
+        """Primary layer stores its true KV for a token range.
+
+        Args:
+            group_id: Group this primary owns.
+            token_start: Offset of the first token in this write.
+            n_tokens: Number of tokens in this write.
+            keys: Primary layer's true keys.
+            values: Primary layer's true values.
+            n_readers: Number of merge layers expected to fetch this entry
+                before it is reclaimed (group_size - 1; default 1).
+        """
         published = self._published_tokens.get(group_id, 0)
         if published + n_tokens > self._max_ctx:
             raise RuntimeError(
@@ -75,14 +102,36 @@ class MiniCacheCoordinator:
                 f"{self._max_ctx} (have {published}, +{n_tokens}). "
                 f"Increase minicache_max_ctx."
             )
+        if n_readers <= 0:
+            # Degenerate primary (no merge partners in its group, e.g. an
+            # early standalone layer below minicache_start_frac): nothing
+            # will ever call fetch_primary for this entry, so storing it
+            # would leak forever. No-op — the caller doesn't need it back.
+            return
         self._store.setdefault(group_id, {})[token_start] = _PrimaryWrite(
-            token_start, n_tokens, keys, values
+            token_start, n_tokens, keys, values, n_readers
         )
         self._published_tokens[group_id] = published + n_tokens
 
     def fetch_primary(self, group_id: int, token_start: int) -> Optional[_PrimaryWrite]:
-        """Merge layer fetches its paired primary's KV for this token range."""
-        return self._store.get(group_id, {}).get(token_start)
+        """Merge layer fetches its paired primary's KV for this token range.
+
+        Once every expected reader (``n_readers`` passed to ``publish_primary``)
+        has fetched an entry, it is reclaimed: dropped from the store and its
+        tokens credited back against ``_published_tokens``, so a long-running
+        generation never exhausts ``max_ctx`` on live-but-consumed entries (#79).
+        """
+        group_store = self._store.get(group_id, {})
+        entry = group_store.get(token_start)
+        if entry is None:
+            return None
+        entry.reads_remaining -= 1
+        if entry.reads_remaining <= 0:
+            del group_store[token_start]
+            self._published_tokens[group_id] = (
+                self._published_tokens.get(group_id, 0) - entry.n_tokens
+            )
+        return entry
 
     def published_tokens(self, group_id: int) -> int:
         return self._published_tokens.get(group_id, 0)

--- a/veloxquant_mlx/tests/cache/test_minicache_cache.py
+++ b/veloxquant_mlx/tests/cache/test_minicache_cache.py
@@ -207,6 +207,63 @@ def test_coordinator_max_ctx_guard() -> None:
         coord.publish_primary(0, 0, 16, K, V)
 
 
+# ------------------------------------------------------------------
+# Regression for #79: coordinator must reclaim published entries once
+# consumed, or long generations exhaust minicache_max_ctx and crash.
+# ------------------------------------------------------------------
+
+
+def test_coordinator_round_trip_reclaims() -> None:
+    coord = MiniCacheCoordinator()
+    K, V = _kv(16)
+    coord.publish_primary(0, token_start=0, n_tokens=16, keys=K, values=V, n_readers=1)
+    assert coord.published_tokens(0) == 16
+    entry = coord.fetch_primary(0, 0)
+    assert entry is not None
+    np.testing.assert_array_equal(np.array(entry.keys.tolist()), np.array(K.tolist()))
+    # Once the single expected reader has fetched it, the entry is reclaimed
+    # and its tokens credited back — published_tokens tracks live (unconsumed)
+    # tokens, not a lifetime total.
+    assert coord.published_tokens(0) == 0
+    assert coord.fetch_primary(0, 999) is None  # missing offset
+    assert coord.fetch_primary(0, 0) is None  # already reclaimed
+
+
+def test_publish_past_max_ctx_does_not_raise_after_reclaim() -> None:
+    coord = MiniCacheCoordinator(max_ctx=8)
+    for i in range(20):
+        K, V = _kv(1, seed=i)
+        coord.publish_primary(0, token_start=i, n_tokens=1, keys=K, values=V, n_readers=1)
+        coord.fetch_primary(0, i)
+    assert coord.published_tokens(0) == 0
+
+
+def test_group_size_three_both_mergers_consume_before_reclaim() -> None:
+    coord = MiniCacheCoordinator()
+    K, V = _kv(16)
+    coord.publish_primary(0, token_start=0, n_tokens=16, keys=K, values=V, n_readers=2)
+    assert coord.published_tokens(0) == 16  # still live: 0 of 2 readers fetched
+
+    coord.fetch_primary(0, 0)
+    assert coord.published_tokens(0) == 16  # still live: 1 of 2 readers fetched
+
+    coord.fetch_primary(0, 0)
+    assert coord.published_tokens(0) == 0  # reclaimed: both readers fetched
+
+
+def test_for_model_decode_past_max_ctx_does_not_raise() -> None:
+    """End-to-end via for_model: decode past minicache_max_ctx must not raise,
+    for both simple pairs and group_size=3 (one primary : two mergers)."""
+    for group_size in (2, 3):
+        caches = _build(
+            6, minicache_start_frac=0.0, minicache_group_size=group_size, minicache_max_ctx=8
+        )
+        for _ in range(20):
+            K, V = _kv(1)
+            for c in caches:
+                c.update_and_fetch(K, V)
+
+
 def test_determinism() -> None:
     c1 = _build(8, seed=11)
     c2 = _build(8, seed=11)


### PR DESCRIPTION
## Summary

Fixes #79. `MiniCacheCoordinator` accumulated one `_PrimaryWrite` per decode step forever and never decremented `published_tokens`, so `publish_primary` raised `RuntimeError` once cumulative primary tokens crossed `minicache_max_ctx` (default 8192) — hit by any sufficiently long `method="minicache"` generation via the standard `KVCacheBuilder.for_model()` path, using the default config.

## Root cause

`fetch_primary` was a pure read — it never removed the entry from `_store`, and `_published_tokens` only ever grew in `publish_primary`. Every decode step's primary write stayed "published" forever even though its merge partner consumes it one step later and it's then dead weight — same bug class as #80 (XQuant), fixed earlier in this repo.

## Fix

Mirrors the #80 fix's design rather than the issue's suggested naive pop-on-first-fetch: `minicache_group_size` can exceed 2 (`pair_layers_depth` lets one primary feed `group_size - 1` merge layers), so a plain pop would silently break `group_size > 2` — the second merger's `fetch_primary` would return `None` and fall back to lossless self-passthrough instead of the intended merge.

- `_PrimaryWrite` gains `reads_remaining`, seeded from a new `n_readers` param on `publish_primary`.
- `fetch_primary` decrements `reads_remaining` per call and only reclaims the entry (drop from `_store`, credit tokens back) once it hits 0 — so `published_tokens` tracks live, unconsumed tokens rather than a lifetime total.
- `n_readers` is derived per group in `KVCacheBuilder._build_minicache` from `pair_layers_depth`'s role assignment (count of `"merge"` roles per `group_id`), seeded to `0` for every `group_id` up front so a standalone primary (no merge partner — e.g. an early layer below `minicache_start_frac`) is a no-op publish (nothing will ever fetch it) instead of leaking forever, which a naive `.get(group_id, 1)` default would have reintroduced.

## Test coverage

Added to `veloxquant_mlx/tests/cache/test_minicache_cache.py` (11 → 15 tests):
- `test_coordinator_round_trip_reclaims` — single fetch reclaims and credits tokens back; already-reclaimed/missing offsets return `None`.
- `test_publish_past_max_ctx_does_not_raise_after_reclaim` — 20 publish+fetch decode steps through `max_ctx=8`, must not raise.
- `test_group_size_three_both_mergers_consume_before_reclaim` — with `n_readers=2`, tokens stay live until both readers have fetched.
- `test_for_model_decode_past_max_ctx_does_not_raise` — end-to-end via `for_model`, 20 decode steps past `max_ctx=8`, for both `group_size=2` and `group_size=3`.

## Test plan

- [x] `pytest veloxquant_mlx/tests/cache/test_minicache_cache.py -q` — 15 passed
- [x] `pytest veloxquant_mlx/tests/cache/ -q` — 708 passed (704 baseline + 4 new)
- [x] `pytest veloxquant_mlx/tests/ -q` — 1658 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest` — untouched by this change, confirmed via `git log`)
- [x] `ruff format --check` clean on all 4 changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>