### PR TITLE
fix(quantizers): store group_size on ZipCacheState, use it in reconstruct (#78)

### DIFF
--- a/veloxquant_mlx/quantizers/zipcache.py
+++ b/veloxquant_mlx/quantizers/zipcache.py
@@ -64,6 +64,9 @@ class ZipCacheState(NamedTuple):
         lo_bits:   int bit-width for non-salient tokens.
         seq_len:   int original token count (= S).
         head_dim:  int feature dimension (= D).
+        group_size: int token group size used for min/max quantization at
+            compress time; must be reused by ``zipcache_reconstruct`` for the
+            dequant grouping to match.
     """
 
     hi_codes: mx.array
@@ -77,6 +80,7 @@ class ZipCacheState(NamedTuple):
     lo_bits: int
     seq_len: int
     head_dim: int
+    group_size: int
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +248,7 @@ def zipcache_compress(
         lo_bits=lo_bits,
         seq_len=S,
         head_dim=D,
+        group_size=group_size,
     )
 
 
@@ -255,8 +260,7 @@ def zipcache_reconstruct(state: ZipCacheState) -> mx.array:
     """
     S = state.seq_len
     D = state.head_dim
-    gs = 32  # group_size is not stored in state; use 32 (the only value used)
-    # Use scales shape to derive actual group_size used at compress time
+    gs = state.group_size
     n_hi = int(state.hi_codes.shape[0]) if state.hi_codes.shape[0] > 0 else 0
     n_lo = int(state.lo_codes.shape[0]) if state.lo_codes.shape[0] > 0 else 0
 

--- a/veloxquant_mlx/tests/quantizers/test_zipcache.py
+++ b/veloxquant_mlx/tests/quantizers/test_zipcache.py
@@ -167,6 +167,38 @@ def test_hi_fraction_one_no_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Regression for #78: zipcache_reconstruct hardcoded group_size=32, silently
+# desyncing dequant grouping from the group_size actually used at compress
+# time for any non-default zipcache_group_size.
+# ---------------------------------------------------------------------------
+
+
+def test_state_stores_compress_time_group_size() -> None:
+    x = _rand((40, 8))
+    state = zipcache_compress(x, hi_bits=4, lo_bits=2, hi_fraction=0.2, group_size=8)
+    assert state.group_size == 8
+
+
+def test_reconstruct_uses_matching_group_size_not_hardcoded_32() -> None:
+    """A non-default group_size must reconstruct with error comparable to the
+    default group_size=32 case, not the ~2.6x-higher error a hardcoded
+    mismatched grouping produces (the exact repro from #78)."""
+    x = _rand((40, 8), seed=0)
+
+    state_gs8 = zipcache_compress(x, hi_bits=4, lo_bits=2, hi_fraction=0.2, group_size=8)
+    recon_gs8 = zipcache_reconstruct(state_gs8)
+    mse_gs8 = _mse(recon_gs8, x)
+
+    state_gs32 = zipcache_compress(x, hi_bits=4, lo_bits=2, hi_fraction=0.2, group_size=32)
+    recon_gs32 = zipcache_reconstruct(state_gs32)
+    mse_gs32 = _mse(recon_gs32, x)
+
+    # Both are ordinary quantization noise, same order of magnitude — not the
+    # inflated error a group_size mismatch produces.
+    assert mse_gs8 < mse_gs32 * 2
+
+
+# ---------------------------------------------------------------------------
 # Byte accounting
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #78. `zipcache_reconstruct` hardcoded `gs = 32` instead of reading the `group_size` actually used at compress time, silently desyncing the dequant grouping from the stored `scales`/`zeros` whenever `zipcache_group_size` (a normal, documented, user-facing `KVCacheConfig` knob) was set to anything other than the default 32.

## Root cause

`ZipCacheState` didn't store `group_size`, and `zipcache_reconstruct(state)` is called with no `group_size` argument anywhere (`cache/zipcache_cache.py`), so it had no way to recover the true value — it just hardcoded 32. `channel_dequant`'s padding/broadcast logic tolerates a mismatched `gs` without raising, so the bug was silent: no crash, no shape mismatch, just degraded reconstruction quality (~1.6x higher mean error, ~2.6x higher max error in the issue's repro with `group_size=8`).

## Fix

- Added `group_size: int` to `ZipCacheState`, populated by `zipcache_compress`.
- `zipcache_reconstruct` reads `state.group_size` instead of the hardcoded `32`.
- `zipcache_bytes` was already correct — its only call site (`cache/zipcache_cache.py`) passes `group_size` explicitly — left untouched.

## Test coverage

Added to `veloxquant_mlx/tests/quantizers/test_zipcache.py` (16 → 18 tests):
- `test_state_stores_compress_time_group_size` — `state.group_size` matches what was passed to `zipcache_compress`.
- `test_reconstruct_uses_matching_group_size_not_hardcoded_32` — `group_size=8` reconstructs with error comparable to `group_size=32` (both ordinary quantization noise), not the inflated error a mismatched grouping produces — this is the issue's exact repro shape (`[40, 8]`, `group_size=8`).

## Test plan

- [x] `pytest veloxquant_mlx/tests/quantizers/test_zipcache.py veloxquant_mlx/tests/cache/test_zipcache_cache.py -q` — 33 passed
- [x] `pytest veloxquant_mlx/tests/ -q` — 1660 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest` — untouched by this change)
- [x] `ruff format --check` clean on both changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>