### PR TITLE
fix(quantizers): renormalize pyramid_budgets so mean holds for beta > 2.0 (#76)

### DIFF
--- a/veloxquant_mlx/quantizers/pyramidkv.py
+++ b/veloxquant_mlx/quantizers/pyramidkv.py
@@ -69,7 +69,15 @@ def pyramid_budgets(
     (every layer gets ``avg_budget`` → reduces to uniform H2O).
 
     The minimum budget is floored at ``n_sink + 1`` so every layer can always
-    hold its sinks plus at least one token.
+    hold its sinks plus at least one token. For ``beta > 2.0`` the raw linear
+    taper's low end would fall below this floor; naively clamping only the
+    low layers up (with no compensating reduction elsewhere) would silently
+    inflate the realized mean above ``avg_budget`` (#76). Instead, any excess
+    from floor-clamping is redistributed away from the *unclamped* layers —
+    proportional to their slack above the floor, iterated until stable — so
+    the taper shape (steeper for larger ``beta``) is preserved while the mean
+    is pulled back to (approximately, subject to integer rounding)
+    ``avg_budget`` for every ``beta >= 1.0``, not just ``beta <= 2.0``.
 
     Args:
         n_layers:   Number of attention-bearing layers.
@@ -79,7 +87,7 @@ def pyramid_budgets(
 
     Returns:
         Length-``n_layers`` list of per-layer budgets (ints), decreasing, whose
-        mean is approximately ``avg_budget``.
+        mean is approximately ``avg_budget`` regardless of ``beta``.
     """
     if n_layers <= 0:
         return []
@@ -90,17 +98,42 @@ def pyramid_budgets(
 
     floor = n_sink + 1
     # Half-width of the taper around the mean: at beta=2 the top layer gets
-    # 2*avg above floor-adjusted centre; symmetric linear ramp keeps the mean.
+    # 2*avg above floor-adjusted centre; symmetric linear ramp keeps the mean
+    # (before floor-clamping is applied below).
     span = (avg_budget - floor) * (beta - 1.0)
     hi = avg_budget + span
     lo = avg_budget - span
 
-    budgets: list[int] = []
+    values = []
     for i in range(n_layers):
         frac = i / (n_layers - 1)  # 0.0 at layer 0 → 1.0 at last layer
         b = hi + (lo - hi) * frac  # linear taper hi → lo
-        budgets.append(max(int(round(b)), floor))
-    return budgets
+        values.append(b)
+
+    # Water-filling renormalization: clamp sub-floor layers up to floor, then
+    # remove the resulting total excess (above avg_budget * n_layers) from
+    # the still-unclamped layers, proportional to their slack above floor.
+    # Reclamping can push additional layers to the floor, so repeat until no
+    # layer's value moves below floor between iterations (at most one newly
+    # clamped layer per pass, hence n_layers passes always suffice).
+    target_total = float(avg_budget) * n_layers
+    clamped = [False] * n_layers
+    for _ in range(n_layers):
+        for i in range(n_layers):
+            if values[i] < floor:
+                values[i] = float(floor)
+                clamped[i] = True
+        excess = sum(values) - target_total
+        if excess <= 1e-9:
+            break
+        free_idx = [i for i in range(n_layers) if not clamped[i]]
+        free_slack_total = sum(values[i] - floor for i in free_idx)
+        if not free_idx or free_slack_total <= 1e-9:
+            break
+        for i in free_idx:
+            values[i] -= excess * (values[i] - floor) / free_slack_total
+
+    return [max(int(round(v)), floor) for v in values]
 
 
 @dataclass

--- a/veloxquant_mlx/tests/quantizers/test_pyramidkv.py
+++ b/veloxquant_mlx/tests/quantizers/test_pyramidkv.py
@@ -97,6 +97,45 @@ def test_budgets_beta_below_1_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Regression for #76: mean must stay ~avg_budget for beta > 2.0, not just
+# beta <= 2.0 -- the floor clamp used to only pull the low end up with no
+# compensating reduction, silently inflating the mean (up to +17.5% at
+# beta=3.0 in the issue's exact repro).
+# ---------------------------------------------------------------------------
+def test_budgets_mean_approx_avg_for_beta_above_two() -> None:
+    """Issue #76's exact repro shape: mean must stay within a tight tolerance
+    of avg_budget for beta in (2.0, 3.0], not drift up to +17.5%."""
+    for beta in [2.1, 2.5, 3.0]:
+        b = pyramid_budgets(n_layers=8, avg_budget=128, n_sink=2, beta=beta)
+        mean = sum(b) / len(b)
+        assert abs(mean - 128) / 128 < 0.01, f"beta={beta}: mean {mean} vs avg 128"
+
+
+def test_budgets_mean_approx_avg_across_beta_sweep() -> None:
+    """Broader sweep: mean tracks avg_budget for every beta from flat to
+    very steep, across several (n_layers, avg_budget, n_sink) combinations."""
+    for n_layers, avg, n_sink in [(8, 128, 2), (16, 256, 4), (32, 512, 8), (6, 64, 1)]:
+        for beta in [1.0, 1.5, 2.0, 2.5, 3.0, 5.0, 10.0]:
+            b = pyramid_budgets(n_layers=n_layers, avg_budget=avg, n_sink=n_sink, beta=beta)
+            mean = sum(b) / len(b)
+            assert abs(mean - avg) / avg < 0.05, (
+                f"n_layers={n_layers} avg={avg} n_sink={n_sink} beta={beta}: "
+                f"mean {mean} vs avg {avg}"
+            )
+
+
+def test_budgets_still_monotonic_and_floored_for_steep_beta() -> None:
+    """The water-filling renormalization must not break monotonicity or the
+    floor guarantee it's layered on top of."""
+    n_sink = 4
+    for beta in [2.5, 3.0, 5.0, 10.0]:
+        b = pyramid_budgets(n_layers=16, avg_budget=128, n_sink=n_sink, beta=beta)
+        assert all(x >= n_sink + 1 for x in b), (beta, b)
+        for i in range(len(b) - 1):
+            assert b[i] >= b[i + 1], (beta, i, b)
+
+
+# ---------------------------------------------------------------------------
 # init_pyramid_state
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #76. `pyramid_budgets()` is documented to produce a per-layer schedule "whose mean is approximately `avg_budget`," independent of `beta`. That contract silently broke for any `beta > 2.0`, worsening as `beta` grows — up to +17.5% over budget at `beta=3.0` in the issue's repro.

## Root cause

The taper is a symmetric linear ramp from `hi` to `lo` around `avg_budget`, then each value is clamped up to `floor = n_sink + 1`. At `beta <= 2.0`, `lo >= floor` always, so no clamping happens and the symmetric ramp keeps the mean exact. For `beta > 2.0`, `lo` falls below `floor` — several deep layers get clamped *up*, while `hi` (unclamped, symmetrically elevated by the same amount `lo` undershot) stays put. Only the low side gets corrected, so the mean drifts upward with no compensation.

## Fix

Replaced the one-sided clamp with a water-filling renormalization: after clamping sub-floor layers to `floor`, the resulting excess over `avg_budget * n_layers` is redistributed away from the *unclamped* layers, proportional to each one's slack above `floor`, and the clamp/redistribute step repeats until stable (at most one newly-clamped layer per pass, so `n_layers` passes always suffice). This preserves the taper's shape — steeper `beta` still means a bigger first-layer/last-layer gap — while keeping the realized mean within integer-rounding noise of `avg_budget` for every `beta`, not just `beta <= 2.0`. Behavior for `beta <= 2.0` is numerically unchanged (no layer is ever pre-floor there, so the water-filling loop is a no-op).

## Test coverage

Added to `veloxquant_mlx/tests/quantizers/test_pyramidkv.py` (27 → 30 tests):
- `test_budgets_mean_approx_avg_for_beta_above_two` — the issue's exact repro shape (`n_layers=8, avg_budget=128, n_sink=2`), mean within 1% of `avg_budget` for `beta` in `[2.1, 2.5, 3.0]`.
- `test_budgets_mean_approx_avg_across_beta_sweep` — broader sweep across `(n_layers, avg_budget, n_sink)` combinations and `beta` from flat (1.0) to very steep (10.0).
- `test_budgets_still_monotonic_and_floored_for_steep_beta` — confirms the renormalization doesn't break monotonicity or the floor guarantee it's layered on top of.

## Test plan

- [x] `pytest veloxquant_mlx/tests/quantizers/test_pyramidkv.py -q` — 30 passed
- [x] `pytest veloxquant_mlx/tests/cache/ veloxquant_mlx/tests/quantizers/ -q` — 1262 passed
- [x] `pytest veloxquant_mlx/tests/ -q` — 1669 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest` — untouched by this change)
- [x] Manually verified against the issue's exact repro: mean is now 128.0 / 127.875 / 128.25 / 128.0 for `beta = 2.0 / 2.1 / 2.5 / 3.0` (was 128.0 / 129.62 / 137.0 / 150.38)
- [x] `ruff format --check` clean on both changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>