### PR TITLE
fix(spectral): distribute remainder in water_fill_bits' zero-eigenvalue fallback (#75)

### DIFF
--- a/veloxquant_mlx/spectral/bit_allocator.py
+++ b/veloxquant_mlx/spectral/bit_allocator.py
@@ -31,63 +31,68 @@ def water_fill_bits(
     ev_sum = ev.sum()
 
     if ev_sum < 1e-12 or total_bit_budget <= 0:
+        # No signal to water-fill proportionally to (or nothing to allocate):
+        # start from a uniform allocation and fall through to the same
+        # "final fix" remainder-distribution below, rather than returning
+        # floor(total_bit_budget / d) directly -- that silently dropped
+        # total_bit_budget % d bits whenever it didn't divide evenly (#75).
         uniform = max(min_bits, min(max_bits, total_bit_budget // d))
-        return np.full(d, uniform, dtype=np.int32)
+        bits = np.full(d, uniform, dtype=np.int32)
+    else:
+        # Iterative water-filling: proportionally allocate, then redistribute
+        # bits from capped dims to uncapped dims until convergence.
+        bits = np.full(d, min_bits, dtype=np.int32)
+        remaining_budget = total_bit_budget - d * min_bits
+        active = np.ones(d, dtype=bool)  # dims that can still receive more bits
 
-    # Iterative water-filling: proportionally allocate, then redistribute
-    # bits from capped dims to uncapped dims until convergence.
-    bits = np.full(d, min_bits, dtype=np.int32)
-    remaining_budget = total_bit_budget - d * min_bits
-    active = np.ones(d, dtype=bool)  # dims that can still receive more bits
-
-    for _ in range(d + 2):  # at most d iterations to converge
-        if remaining_budget <= 0:
-            break
-        active_ev = ev.copy()
-        active_ev[~active] = 0.0
-        active_sum = active_ev.sum()
-        if active_sum < 1e-12:
-            # Distribute remaining bits uniformly across still-active dims
-            active_indices = np.where(active)[0]
-            if len(active_indices) == 0:
+        for _ in range(d + 2):  # at most d iterations to converge
+            if remaining_budget <= 0:
                 break
-            per_dim = remaining_budget // len(active_indices)
-            for i in active_indices:
-                add = min(per_dim, max_bits - bits[i])
-                bits[i] += add
-                remaining_budget -= add
-            break
-
-        proportions = active_ev / active_sum
-        alloc = proportions * remaining_budget
-        proposed = bits.copy()
-        proposed[active] += np.round(alloc[active]).astype(np.int32)
-        proposed = np.clip(proposed, min_bits, max_bits)
-
-        # Find newly capped dims
-        newly_capped = active & (proposed >= max_bits)
-        bits[newly_capped] = max_bits
-        remaining_budget -= int((bits * newly_capped).sum()) - int(
-            (bits * ~active * newly_capped).sum()
-        )
-
-        # Recompute remaining budget from scratch
-        bits = np.where(newly_capped, max_bits, bits)
-        remaining_budget = total_bit_budget - int(bits.sum())
-        active[newly_capped] = False
-
-        if not newly_capped.any():
-            # No new caps: do final allocation
-            active_ev2 = ev.copy()
-            active_ev2[~active] = 0.0
-            s2 = active_ev2.sum()
-            if s2 > 1e-12:
-                raw = active_ev2 / s2 * remaining_budget
-                for i in np.where(active)[0]:
-                    add = int(round(raw[i]))
-                    add = max(0, min(add, max_bits - bits[i]))
+            active_ev = ev.copy()
+            active_ev[~active] = 0.0
+            active_sum = active_ev.sum()
+            if active_sum < 1e-12:
+                # Distribute remaining bits uniformly across still-active dims
+                active_indices = np.where(active)[0]
+                if len(active_indices) == 0:
+                    break
+                per_dim = remaining_budget // len(active_indices)
+                for i in active_indices:
+                    add = min(per_dim, max_bits - bits[i])
                     bits[i] += add
-            break
+                    remaining_budget -= add
+                break
+
+            proportions = active_ev / active_sum
+            alloc = proportions * remaining_budget
+            proposed = bits.copy()
+            proposed[active] += np.round(alloc[active]).astype(np.int32)
+            proposed = np.clip(proposed, min_bits, max_bits)
+
+            # Find newly capped dims
+            newly_capped = active & (proposed >= max_bits)
+            bits[newly_capped] = max_bits
+            remaining_budget -= int((bits * newly_capped).sum()) - int(
+                (bits * ~active * newly_capped).sum()
+            )
+
+            # Recompute remaining budget from scratch
+            bits = np.where(newly_capped, max_bits, bits)
+            remaining_budget = total_bit_budget - int(bits.sum())
+            active[newly_capped] = False
+
+            if not newly_capped.any():
+                # No new caps: do final allocation
+                active_ev2 = ev.copy()
+                active_ev2[~active] = 0.0
+                s2 = active_ev2.sum()
+                if s2 > 1e-12:
+                    raw = active_ev2 / s2 * remaining_budget
+                    for i in np.where(active)[0]:
+                        add = int(round(raw[i]))
+                        add = max(0, min(add, max_bits - bits[i]))
+                        bits[i] += add
+                break
 
     # Final fix: exact budget correction with greedy adjustment
     diff = total_bit_budget - int(bits.sum())

--- a/veloxquant_mlx/tests/spectral/test_bit_allocator.py
+++ b/veloxquant_mlx/tests/spectral/test_bit_allocator.py
@@ -1,0 +1,84 @@
+"""Tests for water_fill_bits (spectral/bit_allocator.py).
+
+Covers the budget-exactness contract: the allocation sums to
+total_bit_budget whenever that's feasible under min/max caps, for both
+the main iterative (non-degenerate eigenvalues) path and the near-zero
+eigenvalue / non-positive budget early-exit path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from veloxquant_mlx.spectral.bit_allocator import water_fill_bits
+
+
+# ---------------------------------------------------------------------------
+# Regression for #75: the near-zero-eigenvalue early-exit branch used floor
+# division with no remainder distribution, silently dropping
+# total_bit_budget % d bits whenever d didn't evenly divide the budget.
+# ---------------------------------------------------------------------------
+def test_zero_eigenvalues_exact_budget_issue_repro():
+    """Issue #75's exact repro: sum must equal the requested budget, not
+    floor(budget / d)."""
+    bits = water_fill_bits(np.array([0.0, 0.0]), total_bit_budget=5, min_bits=1, max_bits=6)
+    assert bits.sum() == 5
+    assert list(bits) in ([3, 2], [2, 3])  # remainder goes to one dim, either is valid
+
+
+def test_zero_eigenvalues_exact_budget_sweep():
+    """Broader sweep over d, budget, and min/max caps -- all-zero eigenvalues
+    must still hit the exact feasible budget."""
+    for d in range(2, 12):
+        for budget in range(0, d * 6 + 3):
+            bits = water_fill_bits(np.zeros(d), total_bit_budget=budget, min_bits=1, max_bits=6)
+            feasible = max(d * 1, min(d * 6, budget))
+            assert bits.sum() == feasible, (d, budget, bits.tolist())
+            assert np.all(bits >= 1) and np.all(bits <= 6)
+
+
+def test_near_zero_eigenvalues_exact_budget():
+    """Eigenvalues just under the 1e-12 near-zero threshold hit the same
+    early-exit branch and must still be budget-exact."""
+    ev = np.full(7, 1e-13)
+    bits = water_fill_bits(ev, total_bit_budget=20, min_bits=1, max_bits=8)
+    assert bits.sum() == 20
+
+
+def test_non_positive_budget_still_respects_min_bits_floor():
+    """total_bit_budget <= 0 also hits the early-exit branch: the achievable
+    result is d * min_bits (can't go below the floor), not the (infeasible)
+    requested budget -- this is correct, not a regression."""
+    bits = water_fill_bits(np.zeros(4), total_bit_budget=0, min_bits=2, max_bits=8)
+    assert bits.sum() == 4 * 2
+    assert np.all(bits == 2)
+
+    bits_neg = water_fill_bits(np.zeros(4), total_bit_budget=-10, min_bits=2, max_bits=8)
+    assert bits_neg.sum() == 4 * 2
+
+
+def test_zero_eigenvalues_randomized_budget_feasibility_sweep():
+    """Randomized sweep mirroring the issue's 2000-trial check: across d,
+    min_bits/max_bits, and budget, the near-zero-eigenvalue path must hit
+    exactly the feasible target (budget clamped to [d*min_bits, d*max_bits])."""
+    rng = np.random.default_rng(0)
+    for _ in range(500):
+        d = int(rng.integers(2, 40))
+        min_bits = int(rng.integers(0, 3))
+        max_bits = int(rng.integers(min_bits + 1, min_bits + 10))
+        budget = int(rng.integers(0, d * max_bits + 1))
+        bits = water_fill_bits(np.zeros(d), budget, min_bits=min_bits, max_bits=max_bits)
+        feasible = max(d * min_bits, min(d * max_bits, budget))
+        assert bits.sum() == feasible, (d, min_bits, max_bits, budget, bits.tolist())
+        assert np.all(bits >= min_bits) and np.all(bits <= max_bits)
+
+
+# ---------------------------------------------------------------------------
+# Non-degenerate path stays exact too (already correct pre-fix; guards
+# against a regression from routing the zero-eigenvalue case through the
+# shared "final fix" correction block).
+# ---------------------------------------------------------------------------
+def test_nondegenerate_eigenvalues_exact_budget():
+    ev = np.array([10.0, 5.0, 1.0, 0.1])
+    bits = water_fill_bits(ev, total_bit_budget=11, min_bits=1, max_bits=8)
+    assert bits.sum() == 11


### PR DESCRIPTION
## Summary

Fixes #75. `water_fill_bits()`'s early-exit branch (near-zero eigenvalues, or `total_bit_budget <= 0`) returned `total_bit_budget // d` per dimension via floor division with no remainder distribution, silently dropping `total_bit_budget % d` bits whenever `d` didn't evenly divide the budget — violating the function's own documented "sums to total_bit_budget (subject to min/max caps)" contract.

## Root cause

```python
if ev_sum < 1e-12 or total_bit_budget <= 0:
    uniform = max(min_bits, min(max_bits, total_bit_budget // d))
    return np.full(d, uniform, dtype=np.int32)
```

`water_fill_bits([0.0, 0.0], total_bit_budget=5)` → `5 // 2 = 2` per dim → `[2, 2]`, sum 4, dropping 1 of the requested 5 bits. The main iterative (non-degenerate eigenvalue) path already has a "final fix: exact budget correction with greedy adjustment" block that distributes any leftover diff bit-by-bit — this early-exit branch bypassed it entirely by returning directly.

## Fix

Rather than duplicating remainder-distribution logic, the early-exit branch now builds its uniform starting allocation and falls through to the same shared "final fix" correction block the iterative path already uses, instead of returning immediately. Both paths now get exact-budget correction from one place. Verified `total_bit_budget <= 0` still correctly resolves to `d * min_bits` (the greedy correction respects the per-dim floor) — the closest feasible allocation, not a regression.

## Test coverage

New `veloxquant_mlx/tests/spectral/test_bit_allocator.py` (6 tests) — no dedicated test file existed for this module before (only indirect coverage via one ablation test on the non-degenerate path):
- The issue's exact repro (`[0.0, 0.0]`, budget=5 → sum must be 5).
- A dense sweep over `d`/`budget` combinations with all-zero eigenvalues.
- The near-`1e-12`-threshold boundary.
- `total_bit_budget <= 0` correctly floors at `d * min_bits`.
- A 500-trial randomized feasibility sweep (mirroring the issue's own 2000-trial check).
- A non-degenerate-path regression guard (already correct pre-fix; confirms routing through the shared correction block didn't disturb it).

## Test plan

- [x] `pytest veloxquant_mlx/tests/spectral/test_bit_allocator.py -q` — 6 passed
- [x] `pytest veloxquant_mlx/tests/spectral/ -q` — 37 passed (31 baseline + 6 new)
- [x] `pytest veloxquant_mlx/tests/ -q` — 1675 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest` — untouched by this change)
- [x] Manually verified against the issue's exact repro: `water_fill_bits([0.0, 0.0], total_bit_budget=5)` now sums to 5 (was 4); 0/2000 mismatches in a randomized sweep (matching the issue's methodology)
- [x] `ruff format --check` clean on both changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>