### PR TITLE
fix(vecinfer): 3D per-head K/q no longer silently averaged across heads (#74)

### DIFF
--- a/veloxquant_mlx/allocators/vecinfer.py
+++ b/veloxquant_mlx/allocators/vecinfer.py
@@ -110,8 +110,13 @@ def apply_dual_transform_keys(K: mx.array, smooth: mx.array, H: mx.array) -> mx.
     elif smooth.ndim == 2:
         # smooth: [n_heads, head_dim]
         # K: [..., head_dim] (last axis is always head_dim).
-        # For 4D [B, H, S, D], broadcast smooth [H, D] -> [H, 1, D].
-        if K.ndim >= 4 and K.shape[-3] == smooth.shape[0]:
+        # The head axis is always -3, whether K is 3D [H, S, D] (single
+        # batch item) or 4D [B, H, S, D] -- checking K.ndim >= 4 used ndim
+        # as a proxy for "has a head axis" and silently fell through to the
+        # averaging branch for genuine 3D per-head input (#74). Require
+        # only that a -3 axis exists (ndim >= 3) and that it matches
+        # smooth's head count.
+        if K.ndim >= 3 and K.shape[-3] == smooth.shape[0]:
             sm = smooth[:, None, :].astype(K.dtype)
             K_sm = K / sm
         elif K.shape[-1] == smooth.shape[-1]:
@@ -144,7 +149,9 @@ def apply_dual_transform_queries(q: mx.array, smooth: mx.array, H: mx.array) -> 
     if smooth.ndim == 1:
         q_sm = q * smooth.astype(q.dtype)
     elif smooth.ndim == 2:
-        if q.ndim >= 4 and q.shape[-3] == smooth.shape[0]:
+        # See apply_dual_transform_keys for why this checks ndim >= 3, not
+        # >= 4 (#74).
+        if q.ndim >= 3 and q.shape[-3] == smooth.shape[0]:
             sm = smooth[:, None, :].astype(q.dtype)
             q_sm = q * sm
         elif q.shape[-1] == smooth.shape[-1]:

--- a/veloxquant_mlx/tests/allocators/test_vecinfer.py
+++ b/veloxquant_mlx/tests/allocators/test_vecinfer.py
@@ -158,3 +158,79 @@ def test_dual_transform_with_1d_smooth() -> None:
     orig = np.asarray(q @ K.T)
     new = np.asarray(q_t @ K_t.T)
     assert np.allclose(orig, new, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Regression for #74: a genuine 3D per-head layout [n_heads, seq, head_dim]
+# (a natural single-batch-item shape, matching the head axis at -3 the same
+# as 4D [B, H, S, D]) used to require K.ndim >= 4 to reach the per-head
+# broadcast branch, so it silently fell into the GQA head-averaging branch
+# instead -- producing a plausible-looking but numerically wrong result with
+# no error.
+# ---------------------------------------------------------------------------
+def test_dual_transform_keys_3d_per_head_matches_per_head_math() -> None:
+    d, n_heads, seq = 8, 3, 5
+    rng = np.random.default_rng(1)
+    K3d = mx.array(rng.standard_normal((n_heads, seq, d)).astype(np.float32))
+    smooth2d = mx.array(rng.uniform(0.5, 2.0, size=(n_heads, d)).astype(np.float32))
+    H = walsh_hadamard_matrix(d)
+
+    out = apply_dual_transform_keys(K3d, smooth2d, H)
+
+    correct = (np.asarray(K3d) / np.asarray(smooth2d)[:, None, :]) @ np.asarray(H)
+    assert np.allclose(correct, np.asarray(out), atol=1e-5)
+
+    # Must NOT match the (incorrect) averaged-across-heads result.
+    averaged = (np.asarray(K3d) / np.asarray(smooth2d).mean(axis=0)) @ np.asarray(H)
+    assert not np.allclose(averaged, np.asarray(out), atol=1e-5)
+
+
+def test_dual_transform_queries_3d_per_head_matches_per_head_math() -> None:
+    d, n_heads, seq = 8, 3, 5
+    rng = np.random.default_rng(2)
+    q3d = mx.array(rng.standard_normal((n_heads, seq, d)).astype(np.float32))
+    smooth2d = mx.array(rng.uniform(0.5, 2.0, size=(n_heads, d)).astype(np.float32))
+    H = walsh_hadamard_matrix(d)
+
+    out = apply_dual_transform_queries(q3d, smooth2d, H)
+
+    correct = (np.asarray(q3d) * np.asarray(smooth2d)[:, None, :]) @ np.asarray(H)
+    assert np.allclose(correct, np.asarray(out), atol=1e-5)
+
+    averaged = (np.asarray(q3d) * np.asarray(smooth2d).mean(axis=0)) @ np.asarray(H)
+    assert not np.allclose(averaged, np.asarray(out), atol=1e-5)
+
+
+def test_dual_transform_keys_3d_per_head_preserves_inner_product() -> None:
+    """End-to-end: 3D per-head K/q with the dual transform still preserves
+    q @ K.T per head, the actual invariant the transform exists for."""
+    d, n_heads, seq = 16, 4, 6
+    rng = np.random.default_rng(3)
+    K3d = mx.array(rng.standard_normal((n_heads, seq, d)).astype(np.float32))
+    q3d = mx.array(rng.standard_normal((n_heads, 1, d)).astype(np.float32))
+    smooth2d = mx.array(rng.uniform(0.5, 2.0, size=(n_heads, d)).astype(np.float32))
+    H = walsh_hadamard_matrix(d)
+
+    K_t = apply_dual_transform_keys(K3d, smooth2d, H)
+    q_t = apply_dual_transform_queries(q3d, smooth2d, H)
+
+    for h in range(n_heads):
+        orig = np.asarray(q3d[h] @ K3d[h].T)
+        transformed = np.asarray(q_t[h] @ K_t[h].T)
+        assert np.allclose(orig, transformed, atol=1e-3), f"head {h} mismatch"
+
+
+def test_dual_transform_keys_genuine_gqa_head_mismatch_still_averages() -> None:
+    """A real head-count mismatch (e.g. GQA: smooth has more heads than K)
+    must still fall through to the averaging branch -- this is the case the
+    branch is actually for, and must not regress."""
+    d, n_kv_heads, n_q_heads, seq = 8, 2, 6, 5
+    rng = np.random.default_rng(4)
+    K3d = mx.array(rng.standard_normal((n_kv_heads, seq, d)).astype(np.float32))
+    smooth2d = mx.array(rng.uniform(0.5, 2.0, size=(n_q_heads, d)).astype(np.float32))
+    H = walsh_hadamard_matrix(d)
+
+    out = apply_dual_transform_keys(K3d, smooth2d, H)
+
+    averaged = (np.asarray(K3d) / np.asarray(smooth2d).mean(axis=0)) @ np.asarray(H)
+    assert np.allclose(averaged, np.asarray(out), atol=1e-5)


### PR DESCRIPTION
## Summary
Fixes #74. `apply_dual_transform_keys`/`apply_dual_transform_queries` (`veloxquant_mlx/allocators/vecinfer.py`) gated the per-head broadcast branch on `K.ndim >= 4`, using `ndim` as a proxy for "K has a head axis at -3." A genuine 3D per-head layout `[n_heads, seq, head_dim]` — a completely natural single-batch-item shape, and one the module's own docstring's "Pipeline (key cache)" usage pattern invites external callers to produce — skipped that branch and fell through to the GQA head-count-mismatch fallback instead, silently averaging the smooth factors across heads with no error.

## Fix
Changed the guard from `K.ndim >= 4` to `K.ndim >= 3` (and the matching check in `apply_dual_transform_queries`), so the head axis at `-3` is validated whenever it's actually present, regardless of whether there's also a leading batch dim. The averaging branch is now reserved for genuine head-count mismatches (e.g. GQA: smooth calibrated on more/fewer heads than K/q has), which is what it was originally intended for.

Verified the one internal caller (`cache/vecinfer_cache.py`) always passes 4D `[B, H, S, D]` tensors, so this is purely an API-correctness fix for direct/external callers — no change in behavior for existing internal call paths (confirmed by full test suite passing unchanged).

## Tests
Added to `veloxquant_mlx/tests/allocators/test_vecinfer.py`:
- `test_dual_transform_keys_3d_per_head_matches_per_head_math` — issue's exact repro, 3D `K` now matches true per-head math and does *not* match the old averaged result.
- `test_dual_transform_queries_3d_per_head_matches_per_head_math` — same for queries.
- `test_dual_transform_keys_3d_per_head_preserves_inner_product` — end-to-end: `q_tilde @ K_tilde.T == q @ K.T` per head still holds for 3D input.
- `test_dual_transform_keys_genuine_gqa_head_mismatch_still_averages` — guards against regressing the actual GQA averaging case the fallback branch exists for.

## Test plan
- [x] `pytest veloxquant_mlx/tests/allocators/test_vecinfer.py` — 13 passed
- [x] Full suite: `pytest veloxquant_mlx/` — 1679 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`, out of scope)
- [x] `ruff format --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)