### PR TITLE
fix(landing): remove proof-of-maintenance section (#101)

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -821,40 +821,7 @@
 
   <div class="divider"></div>
 
-  <!-- ── §11 PROOF OF MAINTENANCE ── -->
-  <section id="proof">
-    <div class="section-head-center">
-      <p class="section-label">Is it maintained?</p>
-      <h2 class="section-title">Verifiable, not asserted</h2>
-    </div>
-    <div class="proof-row">
-      <a class="proof-item fade-in" href="https://github.com/rajveer43/VeloxQuant-MLX/actions" target="_blank" rel="noopener">
-        <div class="proof-val"><span data-count>1484</span> / 1484</div>
-        <div class="proof-label">tests passing in CI</div>
-      </a>
-      <a class="proof-item fade-in" href="https://github.com/rajveer43/VeloxQuant-MLX/blob/master/CHANGELOG.md" target="_blank" rel="noopener">
-        <div class="proof-val">v0.42.1</div>
-        <div class="proof-label">released, semantic-release</div>
-      </a>
-      <a class="proof-item fade-in" href="https://doi.org/10.5281/zenodo.20647294" target="_blank" rel="noopener">
-        <div class="proof-val">DOI</div>
-        <div class="proof-label">10.5281/zenodo.20647294 — citable</div>
-      </a>
-      <a class="proof-item fade-in" href="https://github.com/rajveer43/VeloxQuant-MLX/tree/master/benchmark_scripts" target="_blank" rel="noopener">
-        <div class="proof-val"><span data-count>12</span> models</div>
-        <div class="proof-label">validated end-to-end</div>
-      </a>
-    </div>
-    <p class="section-desc" style="margin-top:1.5rem;font-size:0.85rem;opacity:0.75">
-      Built on 40+ peer-reviewed &amp; preprint methods — SIGMOD, ICLR, ICML, NeurIPS and more.
-      Methods marked <strong class="t-strong">"-adapted"</strong> deviate from their source paper in a
-      documented way. <a href="/docs/algorithms/overview" class="t-accent">Algorithm reference →</a>
-    </p>
-  </section>
-
-  <div class="divider"></div>
-
-  <!-- ── §12 INSTALL ── -->
+  <!-- ── §11 INSTALL ── -->
   <section id="install">
     <p class="section-label">Installation</p>
     <h2 class="section-title">Get started in seconds</h2>


### PR DESCRIPTION
## Summary
Removes the §11 "Verifiable, not asserted" (proof-of-maintenance) section from the landing page, per #101.

## Fix
- Removed `<section id="proof">...</section>` (`landing/index.html`) along with the 4 `.proof-item` cards (tests-passing count, release version, DOI, models-validated count) and the "Built on 40+ peer-reviewed..." footnote paragraph.
- Removed one of the two surrounding `<div class="divider"></div>` elements, keeping a single divider between the benchmarks and install sections (no doubled/missing spacing).
- Renumbered the following `<!-- ── §12 INSTALL ── -->` comment to `§11` so the section numbering stays sequential now that §11 (proof) no longer exists.

## Verified no dangling references
- No nav or in-page anchor links pointed to `#proof`.
- `landing/assets/main.js`'s proof-item/`data-count` counter logic is reached only via `document.querySelectorAll('.fade-in')` iteration and null-checks the `[data-count]` child (`if (val && !val.dataset.animated)`) — with the markup gone, it simply never matches those elements. No dangling selector or runtime error.
- `.proof-row`/`.proof-item`/`.proof-val`/`.proof-label` CSS rules in `styles.css` become unused but were left in place — out of scope for this issue (markup-only removal), and harmless as dead CSS.
- `.section-head-center` (shared by other sections) is untouched and still used elsewhere.

## Test plan
- [x] Verified tag balance (`<section>`/`<div>` open/close counts match) after the edit.
- [x] Verified zero remaining occurrences of "proof" in `landing/index.html`.
- [x] Full test suite: 1679 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`, out of scope).

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)