### PR TITLE
fix: restore model.make_cache via try/finally in calibrate_layer_sensitivities

### DIFF
--- a/veloxquant_mlx/allocators/ratequant.py
+++ b/veloxquant_mlx/allocators/ratequant.py
@@ -108,17 +108,20 @@ def calibrate_layer_sensitivities(
     original = getattr(model, "make_cache", None)
     model.make_cache = lambda *_a, **_k: probes
 
-    for i, prompt in enumerate(prompts):
-        toks = tokenizer.encode(prompt)
-        if len(toks) > seq_len:
-            toks = toks[:seq_len]
-        toks_mx = mx.array(toks).reshape(1, -1)
-        _ = model(toks_mx, cache=probes)
-        if verbose:
-            print(f"  [calib] {i + 1}/{len(prompts)} (len={len(toks)})")
-
-    if original is not None:
-        model.make_cache = original
+    try:
+        for i, prompt in enumerate(prompts):
+            toks = tokenizer.encode(prompt)
+            if len(toks) > seq_len:
+                toks = toks[:seq_len]
+            toks_mx = mx.array(toks).reshape(1, -1)
+            _ = model(toks_mx, cache=probes)
+            if verbose:
+                print(f"  [calib] {i + 1}/{len(prompts)} (len={len(toks)})")
+    finally:
+        if original is not None:
+            model.make_cache = original
+        elif hasattr(model, "make_cache"):
+            del model.make_cache
 
     weights = [max(p.sensitivity, 1e-6) for p in probes]
     return weights

--- a/veloxquant_mlx/tests/allocators/test_ratequant.py
+++ b/veloxquant_mlx/tests/allocators/test_ratequant.py
@@ -11,6 +11,7 @@ from veloxquant_mlx import (
     KVCacheFactory,
     QuantizerConfigError,
     allocate_bits_ratequant,
+    calibrate_layer_sensitivities,
     fit_distortion_curve,
 )
 
@@ -139,3 +140,57 @@ class TestForModelPerLayer:
         cfg = KVCacheConfig(method="turboquant_rvq", bit_width_inlier=[1, 1, 1], seed=0)
         with pytest.raises(QuantizerConfigError, match="length"):
             KVCacheBuilder.for_model(model, cfg)
+
+
+class _FakeTokenizer:
+    def encode(self, prompt: str) -> list[int]:
+        return [ord(c) % 100 for c in prompt][:16]
+
+
+class TestCalibrateLayerSensitivitiesRestoresMakeCache:
+    """Regression for #73: a raising forward pass must not permanently leave
+    model.make_cache pointed at the calibration lambda."""
+
+    class _RaisingModel:
+        def __init__(self) -> None:
+            self.layers = [1, 2, 3]
+            self.make_cache = "original_make_cache"
+
+        def __call__(self, *_a, **_k):
+            raise RuntimeError("simulated forward-pass failure")
+
+    class _RaisingModelNoOriginal:
+        """A model that never had its own make_cache attribute."""
+
+        def __init__(self) -> None:
+            self.layers = [1, 2]
+
+        def __call__(self, *_a, **_k):
+            raise RuntimeError("simulated forward-pass failure")
+
+    def test_restores_original_make_cache_after_forward_pass_raises(self) -> None:
+        model = self._RaisingModel()
+        with pytest.raises(RuntimeError, match="simulated forward-pass failure"):
+            calibrate_layer_sensitivities(model, _FakeTokenizer(), prompts=["hello world"])
+        assert model.make_cache == "original_make_cache"
+
+    def test_deletes_patched_make_cache_after_raise_when_no_original(self) -> None:
+        model = self._RaisingModelNoOriginal()
+        with pytest.raises(RuntimeError, match="simulated forward-pass failure"):
+            calibrate_layer_sensitivities(model, _FakeTokenizer(), prompts=["hello world"])
+        assert not hasattr(model, "make_cache")
+
+    def test_deletes_patched_make_cache_after_success_when_no_original(self) -> None:
+        """Even on the success path, a model with no original make_cache must
+        not be left with the calibration lambda attached."""
+
+        class _SucceedingModel:
+            def __init__(self) -> None:
+                self.layers = [1, 2]
+
+            def __call__(self, *_a, **_k):
+                return None
+
+        model = _SucceedingModel()
+        calibrate_layer_sensitivities(model, _FakeTokenizer(), prompts=["hi"])
+        assert not hasattr(model, "make_cache")


### PR DESCRIPTION
## Summary
`calibrate_layer_sensitivities()` monkey-patches `model.make_cache` to a lambda returning fixed calibration-probe caches, then only restores the original **after** the calibration loop completes. If any forward pass in the loop raises (OOM, shape mismatch, interrupted run, etc.), the exception propagates but `model.make_cache` is left permanently pointed at the calibration lambda — silently corrupting all later inference on that (expensive, reused) model instance.

## Fix
Wrap the calibration loop in `try/finally` so `model.make_cache` is always restored, whether the loop succeeds or raises. Also fixes the pre-existing bug in the success path: when `model` never had its own `make_cache` attribute to begin with (`original is None`), the old code skipped restoration entirely and left the lambda attached even on success — now `del model.make_cache` falls back to the class's own method in that case.

## Tests
Added `TestCalibrateLayerSensitivitiesRestoresMakeCache` in `veloxquant_mlx/tests/allocators/test_ratequant.py`:
- Forward-pass raises + model had an original `make_cache` → restored after the exception propagates.
- Forward-pass raises + model had no original `make_cache` → attribute deleted (falls back to class default) after the exception propagates.
- Forward pass succeeds + model had no original `make_cache` → attribute deleted (regression guard for the success-path bug noted above).

Full suite: `1682 passed, 1 failed` — the 1 failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`) is pre-existing and unrelated to this change.

Fixes #73