### PR TITLE
fix: allocate_bits_ratequant respects non-contiguous bit_choices membership

### DIFF
--- a/veloxquant_mlx/allocators/ratequant.py
+++ b/veloxquant_mlx/allocators/ratequant.py
@@ -224,11 +224,11 @@ def allocate_bits_ratequant(
     target_total = int(round(target_avg_bits * N))
     current_total = sum(alloc)
 
-    def _next_choice(value: int) -> Optional[int]:
+    def _next_choice(value: int) -> int | None:
         idx = choices_sorted.index(value)
         return choices_sorted[idx + 1] if idx + 1 < len(choices_sorted) else None
 
-    def _prev_choice(value: int) -> Optional[int]:
+    def _prev_choice(value: int) -> int | None:
         idx = choices_sorted.index(value)
         return choices_sorted[idx - 1] if idx > 0 else None
 

--- a/veloxquant_mlx/allocators/ratequant.py
+++ b/veloxquant_mlx/allocators/ratequant.py
@@ -204,33 +204,60 @@ def allocate_bits_ratequant(
     if not bit_choices:
         raise ValueError("bit_choices must be non-empty.")
 
+    choices_sorted = sorted(set(int(c) for c in bit_choices))
+
     N = w.size
     log_w = np.log(w)
     log_w_bar = float(log_w.mean())
     b_continuous = target_avg_bits + (log_w - log_w_bar) / max(np.log(beta), 1e-6)
 
-    b_min, b_max = min(bit_choices), max(bit_choices)
+    b_min, b_max = choices_sorted[0], choices_sorted[-1]
     b_clamped = np.clip(b_continuous, b_min, b_max)
-    alloc = [int(round(b)) for b in b_clamped]
+
+    def _nearest_choice(value: float) -> int:
+        return min(choices_sorted, key=lambda c: abs(c - value))
+
+    # Snap to the nearest *member* of bit_choices, not the nearest integer --
+    # bit_choices may be a non-contiguous set (e.g. (0, 1, 2, 4, 6, 8)).
+    alloc = [_nearest_choice(b) for b in b_clamped]
 
     target_total = int(round(target_avg_bits * N))
     current_total = sum(alloc)
 
-    # Greedy re-balance to hit exact integer budget
+    def _next_choice(value: int) -> Optional[int]:
+        idx = choices_sorted.index(value)
+        return choices_sorted[idx + 1] if idx + 1 < len(choices_sorted) else None
+
+    def _prev_choice(value: int) -> Optional[int]:
+        idx = choices_sorted.index(value)
+        return choices_sorted[idx - 1] if idx > 0 else None
+
+    # Greedy re-balance to hit exact integer budget, always stepping to the
+    # actual next/previous member of bit_choices (never a bare +1/-1).
     while current_total < target_total:
-        deficits = [(b_continuous[i] - alloc[i], i) for i in range(N) if alloc[i] < b_max]
-        if not deficits:
+        candidates = [
+            (b_continuous[i] - alloc[i], i, _next_choice(alloc[i]))
+            for i in range(N)
+            if alloc[i] < b_max
+        ]
+        candidates = [(score, i, nxt) for score, i, nxt in candidates if nxt is not None]
+        if not candidates:
             break
-        _, i = max(deficits)
-        alloc[i] += 1
-        current_total += 1
+        _, i, nxt = max(candidates, key=lambda t: t[0])
+        current_total += nxt - alloc[i]
+        alloc[i] = nxt
 
     while current_total > target_total:
-        surplus = [(alloc[i] - b_continuous[i], i) for i in range(N) if alloc[i] > b_min]
-        if not surplus:
+        candidates = [
+            (alloc[i] - b_continuous[i], i, _prev_choice(alloc[i]))
+            for i in range(N)
+            if alloc[i] > b_min
+        ]
+        candidates = [(score, i, prv) for score, i, prv in candidates if prv is not None]
+        if not candidates:
             break
-        _, i = max(surplus)
-        alloc[i] -= 1
-        current_total -= 1
+        _, i, prv = max(candidates, key=lambda t: t[0])
+        current_total += prv - alloc[i]
+        alloc[i] = prv
 
     return alloc

--- a/veloxquant_mlx/tests/allocators/test_ratequant.py
+++ b/veloxquant_mlx/tests/allocators/test_ratequant.py
@@ -51,6 +51,28 @@ class TestAllocateBitsRateQuant:
         alloc = allocate_bits_ratequant(w, target_avg_bits=2.0, bit_choices=(2, 4))
         assert all(b in (2, 4) for b in alloc)
 
+    def test_non_contiguous_bit_choices_membership(self) -> None:
+        """Regression for #72: every allocated value must be an actual member
+        of a non-contiguous bit_choices set, not merely within [min, max]."""
+        sensitivities = [1.0, 5.0, 0.2, 3.0, 0.5]
+        choices = (0, 1, 2, 4, 6, 8)
+        alloc = allocate_bits_ratequant(
+            sensitivities, target_avg_bits=2.6, bit_choices=choices
+        )
+        assert all(a in choices for a in alloc), alloc
+
+    def test_non_contiguous_bit_choices_membership_randomized(self) -> None:
+        """Broader sweep over random sparse bit_choices sets and targets."""
+        rng = np.random.default_rng(0)
+        for _ in range(200):
+            n = int(rng.integers(2, 12))
+            w = rng.lognormal(0, 1.0, n).tolist()
+            target = float(rng.uniform(0.5, 7.0))
+            pool = rng.choice(9, size=int(rng.integers(2, 6)), replace=False)
+            choices = tuple(sorted(set(int(c) for c in pool)))
+            alloc = allocate_bits_ratequant(w, target_avg_bits=target, bit_choices=choices)
+            assert all(a in choices for a in alloc), (choices, alloc)
+
     def test_negative_weight_raises(self) -> None:
         with pytest.raises(ValueError, match="strictly positive"):
             allocate_bits_ratequant([1.0, -0.5, 2.0], target_avg_bits=1.5)

--- a/veloxquant_mlx/tests/allocators/test_ratequant.py
+++ b/veloxquant_mlx/tests/allocators/test_ratequant.py
@@ -56,9 +56,7 @@ class TestAllocateBitsRateQuant:
         of a non-contiguous bit_choices set, not merely within [min, max]."""
         sensitivities = [1.0, 5.0, 0.2, 3.0, 0.5]
         choices = (0, 1, 2, 4, 6, 8)
-        alloc = allocate_bits_ratequant(
-            sensitivities, target_avg_bits=2.6, bit_choices=choices
-        )
+        alloc = allocate_bits_ratequant(sensitivities, target_avg_bits=2.6, bit_choices=choices)
         assert all(a in choices for a in alloc), alloc
 
     def test_non_contiguous_bit_choices_membership_randomized(self) -> None:


### PR DESCRIPTION
## Summary
`allocate_bits_ratequant()`'s docstring promises the result is "rounded to the nearest integer in `bit_choices`," implying every returned bit-width is a member of `bit_choices`. The implementation only respected the min/max **range** though — initial rounding used `round()` to the nearest integer, and the greedy rebalance loop stepped by bare `±1`. For a non-contiguous set like `(0, 1, 2, 4, 6, 8)` (the same sparse shape used by `kvtc_dp.py`'s `DEFAULT_BIT_CHOICES`), both paths could land on a value that isn't actually in `bit_choices`.

## Fix
- Initial rounding now snaps each continuous value to the nearest actual member of `bit_choices` (`_nearest_choice`), not the nearest integer.
- The greedy rebalance loop now steps to the actual next/previous member of the sorted choice set (`_next_choice`/`_prev_choice`) instead of assuming `alloc[i] ± 1` is itself a valid choice.
- Default contiguous `bit_choices=(1, 2, 3)` behavior is unchanged (verified: existing `test_target_is_exactly_hit` and `test_uniform_weights_collapse_to_target` still pass unmodified).

## Tests
Added to `TestAllocateBitsRateQuant` in `veloxquant_mlx/tests/allocators/test_ratequant.py`:
- `test_non_contiguous_bit_choices_membership` — the issue's exact reproduction case (`bit_choices=(0,1,2,4,6,8)`, `target_avg_bits=2.6`).
- `test_non_contiguous_bit_choices_membership_randomized` — 200 randomized trials over sparse `bit_choices` subsets of `{0..8}`, random layer counts, and random targets, asserting full membership every time.

Full suite: `1684 passed, 1 failed` — the 1 failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`) is pre-existing and unrelated to this change.

Fixes #72