### PR TITLE
fix: DistortionObserver.report() computes sample-weighted MSE, not unweighted mean-of-batch-means

### DIFF
--- a/veloxquant_mlx/observers/distortion.py
+++ b/veloxquant_mlx/observers/distortion.py
@@ -83,13 +83,18 @@ class DistortionObserver(QuantizationObserver):
         x_orig = np.asarray(x_orig, dtype=np.float64)
         x_recon = np.asarray(x_recon, dtype=np.float64)
         diff = x_orig - x_recon
-        self._mse_sum += float(np.sum(diff**2, axis=-1).mean())
-        self._n += 1
+        # atleast_1d: a single unbatched vector (shape (d,)) reduces to a
+        # 0-d scalar under axis=-1 reduction otherwise, and still counts as
+        # one sample.
+        per_sample_sq_err = np.atleast_1d(np.sum(diff**2, axis=-1))  # shape (batch,)
+        batch_n = per_sample_sq_err.shape[0]
+        self._mse_sum += float(per_sample_sq_err.sum())
+        self._n += batch_n
 
         if self._query is not None:
-            true_ip = x_orig @ self._query
-            approx_ip = x_recon @ self._query
-            self._ip_sq_sum += float(np.mean((true_ip - approx_ip) ** 2))
+            true_ip = np.atleast_1d(x_orig @ self._query)
+            approx_ip = np.atleast_1d(x_recon @ self._query)
+            self._ip_sq_sum += float(np.sum((true_ip - approx_ip) ** 2))
 
     @staticmethod
     def theoretical_mse_upper(b: int) -> float:

--- a/veloxquant_mlx/tests/observers/test_distortion.py
+++ b/veloxquant_mlx/tests/observers/test_distortion.py
@@ -1,0 +1,143 @@
+"""Tests for DistortionObserver, including the sample-weighting regression for #70."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from veloxquant_mlx.observers.base import QuantizationEvent
+from veloxquant_mlx.observers.distortion import DistortionObserver
+
+
+def _event(x_orig: np.ndarray, x_recon: np.ndarray) -> QuantizationEvent:
+    return QuantizationEvent(
+        stage="test",
+        input_shape=x_orig.shape,
+        metadata={"x_original": x_orig, "x_reconstructed": x_recon},
+    )
+
+
+class TestReportEmptyState:
+    def test_report_with_no_events_is_zero(self) -> None:
+        obs = DistortionObserver(b=2, d=4)
+        report = obs.report()
+        assert report.empirical_mse == 0.0
+        assert report.empirical_ip_distortion == 0.0
+        assert report.n_samples == 0
+
+
+class TestSampleWeightedMSE:
+    """Regression for #70: report() must be a sample-weighted mean, not a
+    mean of per-event batch means."""
+
+    def test_single_batch_matches_plain_mse(self) -> None:
+        rng = np.random.default_rng(0)
+        x = rng.standard_normal((50, 8))
+        x_hat = x + rng.standard_normal((50, 8)) * 0.1
+        obs = DistortionObserver(b=2, d=8)
+        obs.on_event(_event(x, x_hat))
+        report = obs.report()
+        expected = float(np.mean(np.sum((x - x_hat) ** 2, axis=-1)))
+        assert report.empirical_mse == pytest.approx(expected)
+        assert report.n_samples == 50
+
+    def test_varying_batch_sizes_are_sample_weighted_not_event_averaged(self) -> None:
+        """The issue's exact reproduction: a large low-error batch and a
+        tiny high-error batch must combine via sample-weighted mean, not
+        an unweighted mean-of-batch-means."""
+        obs = DistortionObserver(b=2, d=4)
+
+        x1 = np.zeros((1000, 4))
+        x1_hat = x1 + 0.01
+        obs.on_event(_event(x1, x1_hat))
+
+        x2 = np.zeros((2, 4))
+        x2_hat = x2 + 100.0
+        obs.on_event(_event(x2, x2_hat))
+
+        report = obs.report()
+
+        true_mse = (np.sum((x1 - x1_hat) ** 2) + np.sum((x2 - x2_hat) ** 2)) / (1000 + 2)
+        assert report.empirical_mse == pytest.approx(true_mse)
+        assert report.n_samples == 1002
+
+        # The old (buggy) unweighted mean-of-means would have been ~20000,
+        # ~250x the correct value -- assert we're nowhere near that.
+        assert report.empirical_mse < 100.0
+
+    def test_equal_batch_sizes_unaffected(self) -> None:
+        """When all batches are the same size, sample-weighted and
+        event-averaged means coincide -- this must not regress."""
+        rng = np.random.default_rng(1)
+        obs = DistortionObserver(b=2, d=4)
+        batches = [rng.standard_normal((10, 4)) for _ in range(5)]
+        recons = [b + rng.standard_normal((10, 4)) * 0.2 for b in batches]
+        for b, r in zip(batches, recons, strict=True):
+            obs.on_event(_event(b, r))
+
+        report = obs.report()
+        all_orig = np.concatenate(batches)
+        all_recon = np.concatenate(recons)
+        expected = float(np.mean(np.sum((all_orig - all_recon) ** 2, axis=-1)))
+        assert report.empirical_mse == pytest.approx(expected)
+        assert report.n_samples == 50
+
+    def test_single_unbatched_vector_counts_as_one_sample(self) -> None:
+        """A 1D (d,) event (no batch axis) must not crash and must count
+        as exactly one sample."""
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        x_hat = np.array([1.1, 2.1, 3.1, 4.1])
+        obs = DistortionObserver(b=2, d=4)
+        obs.on_event(_event(x, x_hat))
+        report = obs.report()
+        assert report.n_samples == 1
+        assert report.empirical_mse == pytest.approx(float(np.sum((x - x_hat) ** 2)))
+
+
+class TestSampleWeightedIPDistortion:
+    def test_ip_distortion_is_sample_weighted(self) -> None:
+        query = np.array([1.0, 0.0, 0.0, 0.0])
+        obs = DistortionObserver(b=2, d=4, query=query)
+
+        x1 = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (100, 1))
+        x1_hat = x1 + np.array([0.01, 0, 0, 0])
+        obs.on_event(_event(x1, x1_hat))
+
+        x2 = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (1, 1))
+        x2_hat = x2 + np.array([10.0, 0, 0, 0])
+        obs.on_event(_event(x2, x2_hat))
+
+        report = obs.report()
+        true_ip = x1 @ query
+        approx_ip = x1_hat @ query
+        true_ip2 = x2 @ query
+        approx_ip2 = x2_hat @ query
+        expected = (np.sum((true_ip - approx_ip) ** 2) + np.sum((true_ip2 - approx_ip2) ** 2)) / (
+            100 + 1
+        )
+        assert report.empirical_ip_distortion == pytest.approx(expected)
+
+    def test_no_query_gives_zero_ip_distortion(self) -> None:
+        obs = DistortionObserver(b=2, d=4)
+        obs.on_event(_event(np.zeros((5, 4)), np.ones((5, 4))))
+        report = obs.report()
+        assert report.empirical_ip_distortion == 0.0
+
+
+class TestMissingMetadata:
+    def test_event_missing_metadata_is_ignored(self) -> None:
+        obs = DistortionObserver(b=2, d=4)
+        obs.on_event(QuantizationEvent(stage="s", input_shape=(1, 4), metadata={}))
+        report = obs.report()
+        assert report.n_samples == 0
+
+
+class TestReset:
+    def test_reset_clears_accumulated_state(self) -> None:
+        obs = DistortionObserver(b=2, d=4)
+        obs.on_event(_event(np.zeros((10, 4)), np.ones((10, 4))))
+        assert obs.report().n_samples == 10
+        obs.reset()
+        report = obs.report()
+        assert report.n_samples == 0
+        assert report.empirical_mse == 0.0


### PR DESCRIPTION
## Summary
`DistortionObserver.on_event()` accumulated the **mean** squared error of each call's batch into `_mse_sum`, and `report()` divided that sum by `_n`, the number of `on_event()` calls — not the number of samples. This is an unweighted "mean of per-event means," which is only correct when every event carries the same batch size. With realistic varying batch sizes (different prefill lengths per request, a smaller trailing batch, etc.) a small high-error batch gets the same weight as a large low-error one and can badly skew the aggregate distortion statistic that `mse_ratio` is built on.

The same bug applied to `_ip_sq_sum` (inner-product distortion).

## Fix
`on_event()` now accumulates the **sum** of per-sample squared errors (`per_sample_sq_err.sum()`) and increments `_n` by the batch size, not by 1. `report()`'s `self._mse_sum / self._n` is then a true sample-weighted mean — no changes needed there. Same treatment for the IP-distortion accumulator. `report().n_samples` now also correctly reflects "number of vectors observed" (as its docstring already claimed) instead of the number of `on_event()` calls.

Also handled an edge case introduced by switching from `.mean()` to `.sum()` + explicit count: a single unbatched vector (shape `(d,)`, no batch axis) reduces to a 0-d scalar under `axis=-1`, which would raise `IndexError` on `.shape[0]` — wrapped in `np.atleast_1d()` so it still counts as exactly one sample, matching the old code's (accidental) leniency on that shape.

## Tests
New `veloxquant_mlx/tests/observers/test_distortion.py` (no prior test file existed for this observer):
- `test_varying_batch_sizes_are_sample_weighted_not_event_averaged` — the issue's exact repro (1000-sample low-error batch + 2-sample huge-error batch), asserts the sample-weighted value (~79.8), not the old buggy ~20000.
- `test_equal_batch_sizes_unaffected` — confirms no regression when batch sizes are uniform (sample-weighted and event-averaged coincide there).
- `test_single_unbatched_vector_counts_as_one_sample` — covers the 1D-input edge case.
- `test_ip_distortion_is_sample_weighted` — same bug/fix for the IP-distortion path.
- Plus empty-state, missing-metadata, and `reset()` coverage.

Full suite: `1701 passed, 1 failed` — the 1 failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`) is pre-existing and unrelated to this change.

Fixes #70