### PR TITLE
fix: PolarQuant level-1 angle range mismatch causes severe reconstruction corruption

### DIFF
--- a/veloxquant_mlx/tests/quantizers/test_polar.py
+++ b/veloxquant_mlx/tests/quantizers/test_polar.py
@@ -50,11 +50,13 @@ def test_polar_reconstruction_error() -> None:
     mx.eval(X_hat)
 
     mse = float(mx.mean(mx.sum((X_mx - X_hat) ** 2, axis=-1)).item())
-    # PolarQuant at b=3 should be reasonably accurate
-    # At b=3 (8 centroids), angle folding to [0,π/2] at levels ≥2 loses quadrant
-    # information, so reconstruction error is higher than lossless polar.
-    # Empirical value is ~1.28; allow headroom to 1.5.
-    assert mse < 1.5, f"PolarQuant b=3 MSE={mse:.4f} is too large"
+    # PolarQuant at b=3 should be reasonably accurate. With the level-1
+    # angle range fixed (#69: forward() now folds atan2's (-pi, pi] output
+    # into the [0, 2*pi) the codebook assumes), empirical MSE is ~0.055;
+    # allow headroom to 0.2. Before the fix this was ~1.28 -- if this
+    # threshold ever needs loosening back toward that range, the level-1
+    # angle convention is broken again.
+    assert mse < 0.2, f"PolarQuant b=3 MSE={mse:.4f} is too large"
 
 
 def test_polar_ip_estimation(polar_quantizer) -> None:
@@ -73,5 +75,110 @@ def test_polar_ip_estimation(polar_quantizer) -> None:
     est_ips = np.array(polar_quantizer.estimate_inner_product(q_mx, ev))
 
     corr = float(np.corrcoef(true_ips, est_ips)[0, 1])
-    # Angle-folding at b=2 loses quadrant info; correlation is positive but modest.
-    assert corr > 0.3, f"PolarQuant IP correlation {corr:.3f} is too low"
+    # With the level-1 angle range fixed (#69), correlation at b=2 is ~0.94.
+    # Before the fix this was only ~0.3-0.4 (level-1 angles quantized against
+    # a codebook covering the wrong range).
+    assert corr > 0.8, f"PolarQuant IP correlation {corr:.3f} is too low"
+
+
+class TestLevel1AngleRange:
+    """Regression for #69: level-1 angles must land in [0, 2*pi), matching
+    the range polar_angle_pdf/PolarAngleSamplingStrategy assume when
+    building the level-1 codebook -- atan2's native range is (-pi, pi]."""
+
+    def test_level1_angles_are_never_negative(self) -> None:
+        import mlx.core as mx
+
+        from veloxquant_mlx.transforms.polar import RecursivePolarTransform
+
+        d = 32
+        rng = np.random.default_rng(2)
+        x = mx.array(rng.standard_normal((300, d)).astype(np.float32).astype(np.float16))
+
+        transform = RecursivePolarTransform(n_levels=2)
+        result = transform.forward(x)
+        level1_angles = np.array(result.angles[0])
+
+        assert (level1_angles >= 0.0).all(), (
+            f"level-1 angles must be in [0, 2*pi), found negative values: min={level1_angles.min()}"
+        )
+        # fp16 storage of values near true 2*pi can round to/past fp16's
+        # nearest representable 2*pi (~6.28125) -- allow a small tolerance
+        # rather than asserting a mathematically exact open interval.
+        assert (level1_angles < 2 * math.pi + 1e-2).all(), level1_angles.max()
+
+    def test_level1_angles_actually_span_full_circle(self) -> None:
+        """A zero-mean rotated input should produce angles spread across
+        the whole [0, 2*pi) range, not clustered in (0, pi] -- otherwise
+        the fold could be silently mapping negative angles to a narrow band
+        instead of the correct symmetric range."""
+        import mlx.core as mx
+
+        from veloxquant_mlx.transforms.polar import RecursivePolarTransform
+
+        d = 32
+        rng = np.random.default_rng(3)
+        x = mx.array(rng.standard_normal((2000, d)).astype(np.float32).astype(np.float16))
+
+        transform = RecursivePolarTransform(n_levels=1)
+        result = transform.forward(x)
+        level1_angles = np.array(result.angles[0]).reshape(-1)
+
+        # Roughly uniform on [0, 2*pi): a healthy fraction should exceed pi.
+        frac_above_pi = float((level1_angles > math.pi).mean())
+        assert 0.3 < frac_above_pi < 0.7, (
+            f"expected ~half of level-1 angles above pi, got {frac_above_pi:.2f} "
+            f"-- level-1 angles may not be using the full [0, 2*pi) range"
+        )
+
+    def test_level1_codebook_range_matches_transform_output_range(self) -> None:
+        """The level-1 codebook's centroid range and the actual angles
+        produced by forward() must live in the same convention."""
+        import mlx.core as mx
+
+        from veloxquant_mlx.codebooks.base import CodebookFactory
+        from veloxquant_mlx.transforms.polar import RecursivePolarTransform
+
+        d = 32
+        rng = np.random.default_rng(4)
+        x = mx.array(rng.standard_normal((500, d)).astype(np.float32).astype(np.float16))
+
+        transform = RecursivePolarTransform(n_levels=1)
+        result = transform.forward(x)
+        level1_angles = np.array(result.angles[0]).reshape(-1)
+
+        cb = CodebookFactory.create("polar_level", b=4, d=d, polar_level=1)
+        centroids = np.asarray(cb.centroids_numpy())
+
+        assert centroids.min() >= 0.0
+        assert centroids.max() < 2 * math.pi
+
+        idx = cb.quantize(result.angles[0])
+        dequant = np.array(cb.dequantize(idx)).reshape(-1)
+        mean_angle_err = np.mean(np.abs(level1_angles - dequant))
+        # At b=4 (16 centroids) over a 2*pi range, a well-matched codebook
+        # should give error well under 2*pi/16 ~= 0.39. Before the fix this
+        # was ~0.9 (angles quantized against a mismatched-range codebook).
+        assert mean_angle_err < 0.3, f"mean level-1 angle quant error {mean_angle_err:.4f}"
+
+    def test_reconstruction_error_decreases_with_bit_width(self) -> None:
+        """Error should shrink monotonically as bit-width grows -- the kind
+        of quantitative check that would have caught #69 immediately."""
+        import mlx.core as mx
+
+        d = 32
+        rng = np.random.default_rng(5)
+        x = mx.array(rng.standard_normal((300, d)).astype(np.float32).astype(np.float16))
+
+        errors = []
+        for b in (2, 4, 6, 8):
+            q = QuantizerFactory.create("polar", d=d, b=b, n_levels=2, seed=0)
+            ev = q.encode(x)
+            x_hat = q.decode(ev)
+            err = float(mx.mean(mx.abs(x.astype(mx.float32) - x_hat.astype(mx.float32))))
+            errors.append(err)
+
+        assert errors == sorted(errors, reverse=True), f"errors not decreasing: {errors}"
+        # At b=4, error should be small relative to signal magnitude (~0.78
+        # for unit-Gaussian coordinates), not comparable to it.
+        assert errors[1] < 0.2, f"b=4 mean abs error {errors[1]:.4f} too large"

--- a/veloxquant_mlx/transforms/polar.py
+++ b/veloxquant_mlx/transforms/polar.py
@@ -74,8 +74,15 @@ class RecursivePolarTransform(Transform):
             # Compute angle: atan2(y, x)
             a = mx.arctan2(r_pairs[:, :, 1], r_pairs[:, :, 0])  # (batch, n_pairs)
 
-            # For level >= 2, fold angles into [0, pi/2]
-            if ell >= 1:
+            if ell == 0:
+                # Level 1: atan2's native range is (-pi, pi], but the
+                # level-1 codebook/PDF (distributions.py, strategies.py)
+                # assume [0, 2*pi) -- fold negative angles up so forward()
+                # actually produces the range the rest of the pipeline
+                # expects (#69).
+                a = a % (2 * math.pi)
+            else:
+                # For level >= 2, fold angles into [0, pi/2]
                 a = mx.abs(a % (math.pi / 2))
 
             angles.append(a.astype(x.dtype))


### PR DESCRIPTION
## Summary
`RecursivePolarTransform.forward()` produces level-1 angles via raw `mx.arctan2`, whose native range is `(-pi, pi]`. But the level-1 codebook (`PolarAngleSamplingStrategy`) and its PDF (`polar_angle_pdf`) both assume `[0, 2*pi)` support — the docstring on `forward()` itself already claims level-1 angles are `[0, 2*pi)`, but the code never actually folded them there (only levels ≥ 2 got a fold, into `[0, pi/2]`).

Every negative level-1 angle (~49% of them, for zero-mean rotated input) was quantized against an all-positive codebook and snapped to whichever centroid happened to be least-wrong — nowhere near the true value. This affects every `PolarQuantizer` use, since `n_levels >= 1` always includes a level-1 stage.

## Fix
`forward()` now folds level-1 angles via `a % (2 * math.pi)` (MLX's `%` follows Python/numpy sign-of-divisor semantics, so this always lands in `[0, 2*pi)`), matching the convention the codebook/PDF already assume. `inverse()` needs no change — `cos`/`sin` are periodic and don't care what range the stored angle came from.

## Verification (issue's exact repro)
```
d=16, b=4, n_levels=2:
  mean abs reconstruction error: 0.773 -> 0.086   (was ~= mean signal magnitude, i.e. garbage)
  level-1 angle quant error:     ~0.9 rad -> ~0.098 rad  (well under the 2*pi/16 ~= 0.39 bound at b=4)
```
Reconstruction MSE at b=3, d=64 (existing `test_polar_reconstruction_error` fixture): `1.28 -> 0.055`. IP-estimation correlation at b=2: `0.39 -> 0.945`.

## Tests
- Tightened the two existing threshold-based tests in `test_polar.py` (`test_polar_reconstruction_error`, `test_polar_ip_estimation`) — their old thresholds (MSE < 1.5, corr > 0.3) were loose enough to pass with the bug present, so they never caught it. New thresholds (MSE < 0.2, corr > 0.8) reflect the fixed, correct behavior and would fail again if the level-1 convention regresses.
- Added `TestLevel1AngleRange` with 4 new tests: angles never negative / actually span the full circle (not just folded into a narrow band), codebook range matches transform output range + angle-quantization-error bound, and reconstruction error decreases monotonically with bit-width.
- **Verified all these tests actually catch the bug**: reverted `polar.py` only and reran — 6 of 8 tests in the file fail against the old code (only the two pure-shape tests still pass), confirming they're genuine regression guards.

Full suite: `1705 passed, 1 failed` — the 1 failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`) is pre-existing and unrelated to this change.

Fixes #69