### PR TITLE
fix: is_hadamard_compatible(d) rejects bare m values (12, 20, 28) that crash MLX

### DIFF
--- a/veloxquant_mlx/math/rotation.py
+++ b/veloxquant_mlx/math/rotation.py
@@ -11,8 +11,13 @@ _HADAMARD_VALID_M = {1, 12, 20, 28}
 def is_hadamard_compatible(d: int) -> bool:
     """Return True if d is supported by mx.hadamard_transform.
 
-    MLX requires d = m * 2^k where m in {1, 12, 20, 28} and k >= 0.
-    All powers of 2 work (m=1). Examples that do NOT work: 576=9*64, 192=3*64.
+    MLX requires d = m * 2^k where m in {1, 12, 20, 28} and k >= 0 -- except
+    for the bare non-trivial m values (d == 12, 20, 28 exactly, i.e. k=0),
+    which crash mx.hadamard_transform during Metal shader compilation on the
+    installed MLX version (0.32.0) rather than raising a catchable, sensible
+    error (#67). k=0 with m=1 (d=1) is unaffected and works fine, since it's
+    just the identity transform. All powers of 2 work (m=1, k>=0). Examples
+    that do NOT work: 576=9*64, 192=3*64.
     """
     if d < 1:
         return False
@@ -20,6 +25,8 @@ def is_hadamard_compatible(d: int) -> bool:
         if d % m == 0:
             remainder = d // m
             if remainder & (remainder - 1) == 0:  # power of 2
+                if m != 1 and remainder == 1:
+                    continue
                 return True
     return False
 

--- a/veloxquant_mlx/tests/math/test_rotation.py
+++ b/veloxquant_mlx/tests/math/test_rotation.py
@@ -1,0 +1,68 @@
+"""Tests for is_hadamard_compatible, including the bare-m regression for #67."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from veloxquant_mlx.math.rotation import is_hadamard_compatible
+
+
+class TestBareMValuesAreRejected:
+    """Regression for #67: d exactly equal to a non-trivial m in
+    {12, 20, 28} (i.e. k=0 doublings) crashes mx.hadamard_transform during
+    Metal shader compilation and must be reported as incompatible."""
+
+    @pytest.mark.parametrize("d", [12, 20, 28])
+    def test_bare_m_is_not_compatible(self, d: int) -> None:
+        assert not is_hadamard_compatible(d)
+
+    @pytest.mark.parametrize("d", [12, 20, 28])
+    def test_bare_m_actually_crashes_mlx(self, d: int) -> None:
+        """Confirms the premise: mx.hadamard_transform really does fail for
+        these inputs on the installed MLX version, so the gate must reject
+        them. If this test starts failing (transform succeeds), the MLX
+        version's kernel constraints have changed and the gate can be
+        relaxed accordingly."""
+        import mlx.core as mx
+
+        x = mx.array(np.random.randn(d).astype(np.float32))
+        with pytest.raises(RuntimeError):
+            y = mx.hadamard_transform(x)
+            mx.eval(y)
+
+
+class TestDoubledMValuesAreAccepted:
+    """d = m * 2^k for k >= 1 must remain compatible -- these work fine."""
+
+    @pytest.mark.parametrize("d", [24, 48, 96, 40, 80, 56, 112])
+    def test_doubled_m_is_compatible(self, d: int) -> None:
+        assert is_hadamard_compatible(d)
+
+    @pytest.mark.parametrize("d", [24, 40, 56])
+    def test_doubled_m_actually_works_in_mlx(self, d: int) -> None:
+        import mlx.core as mx
+
+        x = mx.array(np.random.randn(d).astype(np.float32))
+        y = mx.hadamard_transform(x)
+        mx.eval(y)
+
+
+class TestPowersOfTwoAreAccepted:
+    @pytest.mark.parametrize("d", [1, 2, 4, 8, 16, 32, 64, 128, 256])
+    def test_power_of_two_is_compatible(self, d: int) -> None:
+        assert is_hadamard_compatible(d)
+
+    @pytest.mark.parametrize("d", [1, 2, 64, 128])
+    def test_power_of_two_actually_works_in_mlx(self, d: int) -> None:
+        import mlx.core as mx
+
+        x = mx.array(np.random.randn(d).astype(np.float32))
+        y = mx.hadamard_transform(x)
+        mx.eval(y)
+
+
+class TestIncompatibleValues:
+    @pytest.mark.parametrize("d", [0, -1, -12, 3, 5, 9])
+    def test_incompatible_or_invalid_d_returns_false(self, d: int) -> None:
+        assert not is_hadamard_compatible(d)


### PR DESCRIPTION
## Summary
`is_hadamard_compatible(d)` returned `True` for `d == 12, 20, 28` (a bare `m` with zero doublings, `k=0`, since `remainder=1` passes the power-of-2 check). But `mx.hadamard_transform` crashes for exactly these inputs on the installed MLX version (0.32.0) -- a `RuntimeError` from a division-by-zero (`num_steps = logN / logR`) during Metal shader compilation, not a graceful, catchable rejection at the point of call.

Verified empirically:
```
mx.hadamard_transform(mx.array(...)) for d in {12, 20, 28}  -> RuntimeError (Metal compile failure)
mx.hadamard_transform(mx.array(...)) for d in {24, 40, 56}  -> OK (k>=1 doublings)
mx.hadamard_transform(mx.array(...)) for d == 1              -> OK (m=1, identity transform)
```

`d` here is `head_dim`, supplied from real model configs at call sites in `rabitq.py`, `turboquant_prod.py`, `turboquant_mse.py`, `polarquant.py`, `turboquant_rvq.py`, `weight/quantized_linear.py`, and `cache/nsnquant_cache.py`.

## Fix
`is_hadamard_compatible()` now excludes `remainder == 1` for `m != 1` -- i.e. bare `d in {12, 20, 28}` is rejected, while `d == 1` (`m=1, k=0`, the identity transform) is still accepted since it works fine in MLX. Doubled values (`d = m * 2^k` for `k >= 1`) and all powers of 2 are unaffected.

Confirmed by sweeping `d` from 1-64 plus a range of larger multiples against actual `mx.hadamard_transform` calls -- the gate now matches MLX's real behavior for every value checked, except for a pre-existing, out-of-scope false-negative at `d=576` and `d=960` (the function is overly conservative there in a way unrelated to this issue -- those already return `False` on master and still do; not touched here).

## Tests
New `veloxquant_mlx/tests/math/test_rotation.py` (35 tests):
- `d in {12, 20, 28}` reported incompatible, and confirmed via a live `mx.hadamard_transform` call that they really do raise `RuntimeError` (so if MLX's kernel constraints ever change, this test documents why the gate would need updating)
- Doubled `m` values (`24, 40, 56, 96, ...`) remain compatible, confirmed live for several
- Powers of 2 (`1, 2, 4, ..., 256`) remain compatible, confirmed live for a few
- Invalid/incompatible `d` (`0, -1, -12, 3, 5, 9`) return `False`

Confirmed the 3 core regression tests fail against the pre-fix code (`git stash` of just the source fix, rerun, `git stash pop`).

Full suite: `1746 passed, 1 failed` -- the 1 failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`) is pre-existing and unrelated to this change.

Fixes #67