### PR TITLE
fix: EncodedVector.memory_bytes() undercounts outlier_idx

### DIFF
--- a/veloxquant_mlx/core/context.py
+++ b/veloxquant_mlx/core/context.py
@@ -127,6 +127,7 @@ class EncodedVector:
         total += _arr_bytes(self.signs)
         total += _arr_bytes(self.residual_norm)
         total += _arr_bytes(self.final_radius)
+        total += _arr_bytes(self.outlier_idx)
         if self.angles:
             for a in self.angles:
                 total += _arr_bytes(a)

--- a/veloxquant_mlx/tests/core/test_context.py
+++ b/veloxquant_mlx/tests/core/test_context.py
@@ -1,0 +1,109 @@
+"""Tests for EncodedVector.memory_bytes(), including the outlier_idx
+undercounting regression for #65."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from veloxquant_mlx.core.context import EncodedVector
+
+
+class TestMemoryBytesOutlierIdx:
+    """Regression for #65: outlier_idx (populated by CompositeQuantizer)
+    was silently excluded from memory_bytes()'s total."""
+
+    def test_outlier_idx_contributes_to_total(self) -> None:
+        outlier_idx = np.array([1, 5, 9, 20], dtype=np.int32)
+        ev_with = EncodedVector(
+            quantizer_type="composite",
+            batch_size=1,
+            dim=64,
+            indices=np.zeros((1, 64), dtype=np.uint8),
+            outlier_idx=outlier_idx,
+        )
+        ev_without = EncodedVector(
+            quantizer_type="composite",
+            batch_size=1,
+            dim=64,
+            indices=np.zeros((1, 64), dtype=np.uint8),
+            outlier_idx=None,
+        )
+        assert ev_with.memory_bytes() - ev_without.memory_bytes() == outlier_idx.nbytes
+
+    def test_exact_byte_count_matches_int32_itemsize(self) -> None:
+        outlier_idx = np.arange(10, dtype=np.int32)
+        ev = EncodedVector(
+            quantizer_type="composite", batch_size=1, dim=64, outlier_idx=outlier_idx
+        )
+        assert ev.memory_bytes() == 10 * 4
+
+    def test_shape_matching_composite_encode_output_counts_outlier_idx(self) -> None:
+        """An EncodedVector shaped like CompositeQuantizer.encode()'s actual
+        output (outlier_idx + nested outlier/inlier_encoded, per
+        composite.py:58-65) must include the outlier_idx bytes."""
+        outlier_idx = np.array([0, 2, 4, 6, 8, 10, 12, 14], dtype=np.int32)
+        outlier_encoded = EncodedVector(
+            quantizer_type="polar",
+            batch_size=4,
+            dim=8,
+            angles=None,
+            final_radius=np.zeros(4, dtype=np.float16),
+        )
+        inlier_encoded = EncodedVector(
+            quantizer_type="polar",
+            batch_size=4,
+            dim=8,
+            angles=None,
+            final_radius=np.zeros(4, dtype=np.float16),
+        )
+        ev = EncodedVector(
+            quantizer_type="composite",
+            batch_size=4,
+            dim=16,
+            outlier_idx=outlier_idx,
+            outlier_encoded=outlier_encoded,
+            inlier_encoded=inlier_encoded,
+        )
+
+        without_outlier = ev.memory_bytes() - outlier_idx.nbytes
+        ev.outlier_idx = None
+        assert ev.memory_bytes() == without_outlier
+
+
+class TestMemoryBytesFieldCombinations:
+    def test_all_none_fields_is_zero(self) -> None:
+        ev = EncodedVector(quantizer_type="empty", batch_size=1, dim=4)
+        assert ev.memory_bytes() == 0
+
+    def test_angles_list_contributes_per_level(self) -> None:
+        import mlx.core as mx
+
+        angles = [mx.zeros((2, 4), dtype=mx.float16), mx.zeros((2, 2), dtype=mx.float16)]
+        ev = EncodedVector(quantizer_type="polar", batch_size=2, dim=8, angles=angles)
+        assert ev.memory_bytes() == (2 * 4 + 2 * 2) * 2
+
+    def test_nested_outlier_and_inlier_encoded_are_summed_recursively(self) -> None:
+        inner_outlier = EncodedVector(
+            quantizer_type="polar",
+            batch_size=1,
+            dim=3,
+            indices=np.zeros((1, 3), dtype=np.uint8),
+        )
+        inner_inlier = EncodedVector(
+            quantizer_type="polar",
+            batch_size=1,
+            dim=13,
+            indices=np.zeros((1, 13), dtype=np.uint8),
+        )
+        outer = EncodedVector(
+            quantizer_type="composite",
+            batch_size=1,
+            dim=16,
+            outlier_idx=np.array([0, 5, 9], dtype=np.int32),
+            outlier_encoded=inner_outlier,
+            inlier_encoded=inner_inlier,
+        )
+        expected = (
+            inner_outlier.memory_bytes() + inner_inlier.memory_bytes() + outer.outlier_idx.nbytes
+        )
+        assert outer.memory_bytes() == expected


### PR DESCRIPTION
## Summary
`memory_bytes()` summed `indices`, `norm`, `signs`, `residual_norm`, and `final_radius`, but never `outlier_idx` -- an `Optional[np.ndarray]` field that `CompositeQuantizer.encode()` populates on every `EncodedVector` it returns (`quantizers/composite.py:62`). Any memory-footprint reporting for composite-quantized (outlier-split) caches silently under-reported by `len(outlier_idx) * 4` bytes (int32 channel indices).

## Fix
```python
total += _arr_bytes(self.outlier_idx)
```

## Related gap
The issue also flagged that `veloxquant_mlx/tests/` had no `core/` subfolder at all -- a test asserting `memory_bytes()` correctness would have caught this. Added `veloxquant_mlx/tests/core/test_context.py` with focused coverage:
- `outlier_idx` contributes to the total; exact byte count matches `int32` itemsize
- A `CompositeQuantizer.encode()`-shaped `EncodedVector` (outlier_idx + nested `outlier_encoded`/`inlier_encoded`, matching `composite.py:58-65`) includes the outlier bytes
- All-`None` fields sum to zero; `angles` list contributes per-level; nested `outlier_encoded`/`inlier_encoded` sum recursively

(Left the registry-collision test suggestion from the issue's "Related gap" section as a separate follow-up -- out of scope for this specific bug.)

Confirmed 4 of 6 new tests fail against the pre-fix code (`git stash` of just the source fix, rerun, `git stash pop`).

Full suite: `1752 passed, 1 failed` -- the 1 failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`) is pre-existing and unrelated to this change.

Fixes #65