### PR TITLE
refactor: extract inline MSL kernel strings into standalone .metal files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ mlx-kv-quant = "veloxquant_mlx.__main__:main"
 where = ["."]
 include = ["veloxquant_mlx*"]
 
+[tool.setuptools.package-data]
+veloxquant_mlx = ["metal/src/*.metal"]
+
 [tool.pytest.ini_options]
 testpaths = ["veloxquant_mlx/tests"]
 addopts = "-v"

--- a/veloxquant_mlx/metal/_bit_packing.py
+++ b/veloxquant_mlx/metal/_bit_packing.py
@@ -15,7 +15,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -28,20 +36,7 @@ _cache: dict = {}
 # to B_BITS, shifts into position, and writes one packed uint8.
 # ELEMS_PER_BYTE is a compile-time constant (template), so the loop unrolls.
 
-_PACK_SRC = r"""
-    constexpr int  ELEMS_PER_BYTE = 8 / B_BITS;
-    constexpr uint MASK           = (1u << B_BITS) - 1u;
-
-    uint byte_idx = thread_position_in_grid.x;
-    uint base     = byte_idx * ELEMS_PER_BYTE;
-
-    uint packed_byte = 0u;
-    for (int i = 0; i < ELEMS_PER_BYTE; ++i) {
-        uint val = uint(indices[base + i]) & MASK;
-        packed_byte |= (val << (i * B_BITS));
-    }
-    packed[byte_idx] = uint8_t(packed_byte);
-"""
+_PACK_SRC = _read_kernel_source("bit_pack.metal")
 
 
 # ===========================================================================
@@ -50,16 +45,7 @@ _PACK_SRC = r"""
 # Grid: (N_elements, 1, 1) — one thread per output index.
 # Each thread computes its source byte and bit offset, extracts B_BITS, writes.
 
-_UNPACK_SRC = r"""
-    constexpr int  ELEMS_PER_BYTE = 8 / B_BITS;
-    constexpr uint MASK           = (1u << B_BITS) - 1u;
-
-    uint elem_idx = thread_position_in_grid.x;
-    uint byte_idx = elem_idx / ELEMS_PER_BYTE;
-    uint bit_off  = (elem_idx % ELEMS_PER_BYTE) * B_BITS;
-
-    indices[elem_idx] = uint8_t((uint(packed[byte_idx]) >> bit_off) & MASK);
-"""
+_UNPACK_SRC = _read_kernel_source("bit_unpack.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_comm_vq.py
+++ b/veloxquant_mlx/metal/_comm_vq.py
@@ -18,7 +18,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -40,72 +48,7 @@ _cache: dict = {}
 # Output:
 #   out [N, D] fp16
 
-_COMM_VQ_DECODE_SRC = r"""
-    uint flat = thread_position_in_grid.x;
-
-    uint N = uint(indices_shape[0]);
-    uint D = uint(N_CB) * uint(SUB_DIM);
-
-    uint b_idx = flat / D;
-    uint d_i   = flat % D;
-
-    if (b_idx >= N) return;
-
-    // Which sub-codebook owns dimension d_i?
-    uint cb_i   = d_i / uint(SUB_DIM);
-    uint comp_i = d_i % uint(SUB_DIM);
-
-    // Gather centroid value (additive: one sub-codebook per segment)
-    uint idx_val = uint(indices[b_idx * uint(N_CB) + cb_i]);
-    uint cb_off  = cb_i * uint(CB_SIZE) * uint(SUB_DIM)
-                 + idx_val * uint(SUB_DIM)
-                 + comp_i;
-    float x_val = float(codebook[cb_off]);
-
-    // Apply RoPE: operate on paired dimensions (d_i, d_i + D/2) or (d_i - D/2, d_i)
-    uint half_D = D / 2;
-    uint pos    = uint(positions[b_idx]);
-    uint freq_i = d_i % half_D;   // which frequency dimension
-
-    float inv_f  = inv_freq[freq_i];
-    float angle  = float(pos) * inv_f;
-    float cos_v  = metal::cos(angle);
-    float sin_v  = metal::sin(angle);
-
-    // Partner dimension index
-    uint partner_i = (d_i < half_D) ? (d_i + half_D) : (d_i - half_D);
-
-    // We need the partner's pre-RoPE value. For the fused kernel we need a
-    // two-phase approach: write pre-RoPE first, then apply RoPE.
-    // Since we can't synchronise across threads for different d_i here, we
-    // instead write the pre-RoPE value and let a second pass (or the caller)
-    // apply RoPE. This is still a net win: we fuse the gather (O(N*D) reads
-    // from a large indices array) into one dispatch.
-    //
-    // For the full fused path (gather + RoPE in one pass) the standard trick
-    // is to have each thread compute BOTH halves of its dimension pair. We do
-    // that here: thread for d_i < half_D also reads the codebook for d_i+half_D
-    // and writes both rotated outputs. Threads for d_i >= half_D skip (output
-    // already written by their lower-half partner).
-
-    if (d_i < half_D) {
-        // This thread handles the pair (d_i, d_i + half_D)
-        uint cb_i2   = partner_i / uint(SUB_DIM);
-        uint comp_i2 = partner_i % uint(SUB_DIM);
-        uint idx2    = uint(indices[b_idx * uint(N_CB) + cb_i2]);
-        uint cb_off2 = cb_i2 * uint(CB_SIZE) * uint(SUB_DIM)
-                     + idx2 * uint(SUB_DIM)
-                     + comp_i2;
-        float x2 = float(codebook[cb_off2]);
-
-        float out0 = x_val * cos_v - x2 * sin_v;
-        float out1 = x_val * sin_v + x2 * cos_v;
-
-        out[b_idx * D + d_i]            = half(out0);
-        out[b_idx * D + partner_i]      = half(out1);
-    }
-    // threads with d_i >= half_D do nothing — already written above
-"""
+_COMM_VQ_DECODE_SRC = _read_kernel_source("comm_vq_decode.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_qjl.py
+++ b/veloxquant_mlx/metal/_qjl.py
@@ -17,7 +17,15 @@ set ``grid = n_threadgroups * 32`` accordingly.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -38,57 +46,7 @@ _cache: dict = {}
 #
 # packed_signs layout: [B, ceil(m/8)] uint8, LSB-first bit order.
 
-_QJL_ENCODE_SRC = r"""
-    uint flat_tg          = threadgroup_position_in_grid.x;
-    uint lane             = thread_index_in_simdgroup;
-    uint m                = uint(S_shape[0]);
-    uint d                = uint(S_shape[1]);
-    uint n_simd_per_batch = (m + 31u) / 32u;
-
-    uint b_idx    = flat_tg / n_simd_per_batch;
-    uint simd_blk = flat_tg % n_simd_per_batch;
-    uint sketch_j = simd_blk * 32u + lane;
-
-    // Dot product dot(S[sketch_j, :], x[b, :])
-    float dot_val = 0.0f;
-    if (sketch_j < m) {
-        uint S_row = sketch_j * d;
-        uint x_row = b_idx   * d;
-        for (uint i = 0; i < d; ++i) {
-            dot_val += float(S[S_row + i]) * float(x[x_row + i]);
-        }
-    }
-
-    // Norm — only simd_blk 0 computes this; all 32 lanes share work via simd_sum
-    if (simd_blk == 0) {
-        float x_sq = 0.0f;
-        uint  x_row = b_idx * d;
-        for (uint i = lane; i < d; i += 32u) {
-            float v = float(x[x_row + i]);
-            x_sq += v * v;
-        }
-        float norm_sq = simd_sum(x_sq);
-        if (lane == 0) {
-            norms[b_idx] = half(metal::sqrt(norm_sq));
-        }
-    }
-
-    // Pack 32 sign bits into 4 bytes (8 lanes → 1 byte, LSB-first)
-    uint sign_bit    = (dot_val >= 0.0f) ? 1u : 0u;
-    uint byte_in_blk = lane / 8u;
-    uint bit_in_byte = lane % 8u;
-
-    uint packed_byte = 0u;
-    for (uint bit = 0; bit < 8u; ++bit) {
-        uint src = byte_in_blk * 8u + bit;
-        packed_byte |= (simd_shuffle(sign_bit, src) << bit);
-    }
-
-    if (bit_in_byte == 0 && sketch_j < m) {
-        uint out_byte = b_idx * ((m + 7u) / 8u) + simd_blk * 4u + byte_in_blk;
-        packed_signs[out_byte] = uint8_t(packed_byte);
-    }
-"""
+_QJL_ENCODE_SRC = _read_kernel_source("qjl_encode.metal")
 
 
 # ===========================================================================
@@ -103,38 +61,7 @@ _QJL_ENCODE_SRC = r"""
 #
 # Bit unpacking: chunk=lane, lane+32, lane+64, … to stride across all m bits.
 
-_QJL_INNER_PRODUCT_SRC = r"""
-    constexpr float SQRT_PI_OVER_2 = 1.2533141373155002f;
-
-    uint flat_idx = threadgroup_position_in_grid.x;
-    uint lane     = thread_index_in_simdgroup;
-    uint H        = uint(q_proj_shape[0]);
-    uint m        = uint(q_proj_shape[1]);
-    uint S_kv     = uint(norms_shape[0]);
-
-    uint h_idx = flat_idx % H;
-    uint s_idx = flat_idx / H;
-
-    float acc      = 0.0f;
-    uint  sign_row = (s_idx * H + h_idx) * ((m + 7u) / 8u);
-    uint  q_row    = h_idx * m;
-
-    for (uint chunk = lane; chunk < m; chunk += 32u) {
-        uint  byte_idx  = chunk / 8u;
-        uint  bit_pos   = chunk % 8u;
-        uint  sign_bit  = (uint(packed_signs[sign_row + byte_idx]) >> bit_pos) & 1u;
-        float sign_pm1  = (sign_bit == 1u) ? 1.0f : -1.0f;
-        acc += float(q_proj[q_row + chunk]) * sign_pm1;
-    }
-
-    float total = simd_sum(acc);
-
-    if (lane == 0) {
-        float norm  = float(norms[s_idx * H + h_idx]);
-        float scale = SQRT_PI_OVER_2 / float(m);
-        scores[h_idx * S_kv + s_idx] = half(scale * norm * total);
-    }
-"""
+_QJL_INNER_PRODUCT_SRC = _read_kernel_source("qjl_inner_product.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_rabitq.py
+++ b/veloxquant_mlx/metal/_rabitq.py
@@ -13,7 +13,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -25,25 +33,7 @@ _cache: dict = {}
 # N_BYTES = D / 8 is a compile-time template constant.
 # Metal 2.0+ provides popcount() builtin for uint.
 
-_HAMMING_SCORE_SRC = r"""
-    uint i = thread_position_in_grid.x;
-    if (i >= uint(N)) return;
-
-    // XOR + popcount over N_BYTES packed bytes
-    uint ham = 0u;
-    uint base = i * uint(N_BYTES);
-    for (uint b = 0; b < uint(N_BYTES); b++) {
-        uint8_t xr = qbits[b] ^ bits[base + b];
-        // popcount via bit manipulation (portable across Metal versions)
-        uint v = uint(xr);
-        v = v - ((v >> 1u) & 0x55u);
-        v = (v & 0x33u) + ((v >> 2u) & 0x33u);
-        v = (v + (v >> 4u)) & 0x0Fu;
-        ham += v;
-    }
-
-    scores[i] = float(ham) * scale[0] + Cx[i];
-"""
+_HAMMING_SCORE_SRC = _read_kernel_source("rabitq_hamming_score.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_rabitq_attend.py
+++ b/veloxquant_mlx/metal/_rabitq_attend.py
@@ -28,7 +28,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -63,120 +71,7 @@ _cache: dict = {}
 # and summed; empty SIMD-groups (S_kv < NSG_C) carry m_sg = -INF and
 # d_sg = 0, so their rescale factor is exp(-INF) = 0 and they drop out.
 
-_RABITQ_ATTEND_SRC = r"""
-    uint tg   = threadgroup_position_in_grid.x;
-    uint lane = thread_position_in_threadgroup.x;
-    uint sg   = thread_position_in_threadgroup.y;
-
-    uint B    = uint(q_shape[0]);
-    uint H    = uint(q_shape[1]);
-    uint S_q  = uint(q_shape[2]);
-    uint D    = uint(q_shape[3]);
-    uint S_kv = uint(k_bits_shape[2]);
-    (void)B;
-
-    uint sq_idx = tg % S_q;
-    uint h_idx  = (tg / S_q) % H;
-    uint b_idx  = tg / (S_q * H);
-
-    uint q_base  = ((b_idx * H + h_idx) * S_q + sq_idx) * D;
-    uint kv_base = (b_idx * H + h_idx) * S_kv;
-
-    // Binarize the query once: lane j packs byte j (little-endian bit order,
-    // q >= 0 -> bit 1, matching _pack_signs in the RaBitQ quantizer).
-    uint my_qbyte = 0u;
-    if (lane < uint(N_BYTES)) {
-        for (uint t = 0; t < 8u; ++t) {
-            float qv = float(q[q_base + lane * 8u + t]);
-            my_qbyte |= (qv >= 0.0f ? 1u : 0u) << t;
-        }
-    }
-
-    float qs = q_scale[(b_idx * H + h_idx) * S_q + sq_idx];
-
-    float running_m = -INFINITY;
-    float running_d = 0.0f;
-
-    // Per-lane output accumulator; max 8 slots (D=256, 32 lanes)
-    float my_out[8];
-    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
-    uint n_owned = (D + 31u) / 32u;
-
-    for (uint sk = sg; sk < S_kv; sk += uint(NSG_C)) {
-        // 1. Hamming distance via XOR + popcount — keys stay packed.
-        uint partial_ham = 0u;
-        if (lane < uint(N_BYTES)) {
-            uint xr = my_qbyte ^ uint(k_bits[(kv_base + sk) * uint(N_BYTES) + lane]);
-            // popcount via bit manipulation (portable across Metal versions)
-            uint v = xr;
-            v = v - ((v >> 1u) & 0x55u);
-            v = (v & 0x33u) + ((v >> 2u) & 0x33u);
-            v = (v + (v >> 4u)) & 0x0Fu;
-            partial_ham = v;
-        }
-        uint ham = simd_sum(partial_ham);
-
-        // 2. Affine score: <q, k> estimate = (D - 2*ham) * m_q * m_k + bias.
-        float score = (float(D) - 2.0f * float(ham)) * qs * k_mag[kv_base + sk]
-                    + k_const[kv_base + sk];
-
-        // 3. Online softmax update
-        float m_new  = metal::max(running_m, score);
-        float factor = metal::exp(running_m - m_new);
-        float w      = metal::exp(score     - m_new);
-        running_d    = running_d * factor + w;
-        running_m    = m_new;
-
-        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
-
-        // 4. 4-bit value codebook gather + weighted accumulate.
-        // V_PACKED is a compile-time constant, so the branch folds away:
-        // packed stores two 4-bit indices per byte (lo nibble = even dim).
-        for (uint i = lane; i < D; i += 32u) {
-            uint idx;
-            if (V_PACKED != 0) {
-                uint byte = uint(v_idx[(kv_base + sk) * (D >> 1u) + (i >> 1u)]);
-                idx = (i & 1u) ? (byte >> 4u) : (byte & 0xFu);
-            } else {
-                idx = uint(v_idx[(kv_base + sk) * D + i]);
-            }
-            float vi = v_cents[idx];
-            my_out[(i - lane) / 32u] += w * vi;
-        }
-    }
-
-    // Publish per-SIMD-group partials, then merge across SIMD-groups.
-    threadgroup float tg_m[NSG_C];
-    threadgroup float tg_d[NSG_C];
-    threadgroup float tg_out[NSG_C * MAX_D];
-
-    if (lane == 0u) {
-        tg_m[sg] = running_m;
-        tg_d[sg] = running_d;
-    }
-    for (uint i = lane; i < D; i += 32u) {
-        tg_out[sg * uint(MAX_D) + i] = my_out[(i - lane) / 32u];
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    float m_star = -INFINITY;
-    for (uint s = 0; s < uint(NSG_C); ++s) {
-        m_star = metal::max(m_star, tg_m[s]);
-    }
-    float d_star = 0.0f;
-    for (uint s = 0; s < uint(NSG_C); ++s) {
-        d_star += metal::exp(tg_m[s] - m_star) * tg_d[s];
-    }
-
-    uint flat = sg * 32u + lane;
-    for (uint i = flat; i < D; i += 32u * uint(NSG_C)) {
-        float acc = 0.0f;
-        for (uint s = 0; s < uint(NSG_C); ++s) {
-            acc += metal::exp(tg_m[s] - m_star) * tg_out[s * uint(MAX_D) + i];
-        }
-        out[q_base + i] = half(acc / d_star);
-    }
-"""
+_RABITQ_ATTEND_SRC = _read_kernel_source("rabitq_attend.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_rabitq_encode.py
+++ b/veloxquant_mlx/metal/_rabitq_encode.py
@@ -21,7 +21,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -45,59 +53,7 @@ _cache: dict = {}
 #   5. L1 via simd_sum, then a cross-SIMD-group reduction in threadgroup
 #      memory (canonical two-stage pattern, MSL spec Sec. 6.9.2.1).
 
-_RABITQ_ENCODE_SRC = r"""
-    threadgroup float buf[MAX_D];
-    threadgroup float l1_partials[32];
-
-    uint n    = threadgroup_position_in_grid.x;
-    uint lane = thread_position_in_threadgroup.x;
-    uint D    = uint(MAX_D);
-
-    // 1. Load + diagonal sign flip
-    float v = float(keys[n * D + lane]) * diag[lane];
-    buf[lane] = v;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // 2. In-place WHT: range-based parallel butterfly
-    for (uint stride = 1; stride < D; stride <<= 1) {
-        uint local    = lane % (stride << 1u);
-        bool is_upper = local >= stride;
-        uint partner  = is_upper ? (lane - stride) : (lane + stride);
-        float a = buf[lane];
-        float b = buf[partner];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        buf[lane] = is_upper ? (b - a) : (a + b);
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    // 3. Scale
-    float y = buf[lane] * metal::rsqrt(float(D));
-
-    // 4. Sign bits: one ballot per SIMD-group = 4 packed bytes
-    uint sg = lane / 32u;
-    uint sl = lane % 32u;
-    simd_vote ballot = simd_ballot(y >= 0.0f);
-    uint mask = uint(static_cast<simd_vote::vote_t>(ballot));
-
-    if (sl == 0u) {
-        uint start = sg * 4u;
-        for (uint j = 0u; j < 4u && (start + j) < uint(N_BYTES); ++j) {
-            k_bits[n * uint(N_BYTES) + start + j] = uint8_t((mask >> (8u * j)) & 0xFFu);
-        }
-    }
-
-    // 5. L1 magnitude: simd_sum, then combine SIMD-group partials
-    float partial = simd_sum(metal::abs(y));
-    if (sl == 0u) l1_partials[sg] = partial;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    if (lane == 0u) {
-        uint n_sg = (D + 31u) / 32u;
-        float total = 0.0f;
-        for (uint s = 0; s < n_sg; ++s) total += l1_partials[s];
-        k_mag[n] = total / float(D);
-    }
-"""
+_RABITQ_ENCODE_SRC = _read_kernel_source("rabitq_encode.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_rabitq_prefill.py
+++ b/veloxquant_mlx/metal/_rabitq_prefill.py
@@ -27,7 +27,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -61,166 +69,7 @@ _cache: dict = {}
 # output accumulator and softmax state are float. ~28 KB threadgroup
 # memory at D=128; all-float tiles would exceed the 32 KB budget.
 
-_RABITQ_PREFILL_SRC = r"""
-    constexpr uint D  = uint(MAX_D);
-    constexpr uint BQ = 8u;                                 // rows per SIMD-group
-    constexpr uint BK = 8u;                                 // kv slots per chunk
-    constexpr uint NB = uint(N_BYTES);
-
-    threadgroup half  q_tile[NSG_C * BQ * MAX_D];           // 32 scale-folded rows
-    threadgroup half  kv_tile[BK * MAX_D];                  // shared K̂, then V̂
-    threadgroup half  s_tile[NSG_C][BQ * BK];               // raw QK̂ᵀ scores
-    threadgroup half  w_tile[NSG_C][BQ * BK];               // softmax weights
-    threadgroup half  p_tile[NSG_C][BQ * BK];               // W·V̂ chunk partial
-    threadgroup float out_tile[NSG_C][BQ * MAX_D];          // running output
-    threadgroup float m_run[NSG_C][BQ];
-    threadgroup float d_run[NSG_C][BQ];
-    threadgroup float f_row[NSG_C][BQ];
-
-    uint tgx  = threadgroup_position_in_grid.x;
-    uint lane = thread_position_in_threadgroup.x;
-    uint sg   = thread_position_in_threadgroup.y;
-    uint tid  = sg * 32u + lane;
-    constexpr uint N_THREADS = 32u * uint(NSG_C);
-
-    uint B      = uint(q_shape[0]);
-    uint H      = uint(q_shape[1]);
-    uint S_q    = uint(q_shape[2]);
-    uint S_kv   = uint(k_bits_shape[2]);
-    uint BQ_TG  = uint(NSG_C) * BQ;                          // 32 rows / threadgroup
-    uint n_qblk = (S_q + BQ_TG - 1u) / BQ_TG;
-    (void)B;
-
-    uint qblk  = tgx % n_qblk;
-    uint h_idx = (tgx / n_qblk) % H;
-    uint b_idx = tgx / (n_qblk * H);
-
-    uint q_base  = ((b_idx * H + h_idx) * S_q) * D;
-    uint kv_base = (b_idx * H + h_idx) * S_kv;
-    float sc     = scale[0];
-
-    // ---- Stage the 32-row Q block (scale folded; rows past S_q zeroed) ----
-    for (uint idx = tid; idx < BQ_TG * D; idx += N_THREADS) {
-        uint gq = qblk * BQ_TG + idx / D;
-        q_tile[idx] = (gq < S_q)
-            ? half(float(q[q_base + gq * D + (idx % D)]) * sc)
-            : half(0.0f);
-    }
-    // ---- Init this sg's accumulator + softmax state ----
-    for (uint idx = lane; idx < BQ * D; idx += 32u) out_tile[sg][idx] = 0.0f;
-    if (lane < BQ) { m_run[sg][lane] = -INFINITY; d_run[sg][lane] = 0.0f; }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    const threadgroup half *my_q = q_tile + sg * BQ * D;
-
-    uint n_chunks = (S_kv + BK - 1u) / BK;
-    for (uint c = 0; c < n_chunks; ++c) {
-        uint s0 = c * BK;
-
-        // 1. Decode K̂ chunk ONCE, byte-wise: one byte -> 8 dims of +-m_k.
-        for (uint idx = tid; idx < BK * NB; idx += N_THREADS) {
-            uint j = idx / NB, bcol = idx % NB, slot = s0 + j;
-            uint base = j * D + bcol * 8u;
-            if (slot < S_kv) {
-                uint  byte = uint(k_bits[(kv_base + slot) * NB + bcol]);
-                float mag  = k_mag[kv_base + slot];
-                for (uint t = 0; t < 8u; ++t) {
-                    kv_tile[base + t] =
-                        half(((byte >> t) & 1u) != 0u ? mag : -mag);
-                }
-            } else {
-                for (uint t = 0; t < 8u; ++t) kv_tile[base + t] = half(0.0f);
-            }
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-
-        // 2. QK̂ᵀ on the matrix units: acc(8 rows x 8 slots) over D/8 tiles.
-        simdgroup_half8x8 acc = make_filled_simdgroup_matrix<half, 8, 8>(half(0.0f));
-        for (uint kt = 0; kt < D / 8u; ++kt) {
-            simdgroup_half8x8 qf, kf;
-            simdgroup_load(qf, my_q + kt * 8u, ulong(D));
-            simdgroup_load(kf, kv_tile + kt * 8u, ulong(D), ulong2(0, 0), true);
-            simdgroup_multiply_accumulate(acc, qf, kf, acc);
-        }
-        simdgroup_store(acc, &s_tile[sg][0], ulong(BK));
-        simdgroup_barrier(mem_flags::mem_threadgroup);
-
-        // 3. Online softmax (lanes 0..7 each own one of this sg's rows).
-        if (lane < BQ) {
-            uint r = lane;
-            float s_j[8];
-            float chunk_max = -INFINITY;
-            for (uint j = 0; j < BK; ++j) {
-                uint slot = s0 + j;
-                s_j[j] = (slot < S_kv)
-                    ? float(s_tile[sg][r * BK + j]) + k_const[kv_base + slot]
-                    : -INFINITY;
-                chunk_max = metal::max(chunk_max, s_j[j]);
-            }
-            float m_old  = m_run[sg][r];
-            float m_new  = metal::max(m_old, chunk_max);
-            float factor = metal::exp(m_old - m_new);
-            float wsum   = 0.0f;
-            for (uint j = 0; j < BK; ++j) {
-                float w = metal::exp(s_j[j] - m_new);
-                w_tile[sg][r * BK + j] = half(w);
-                wsum += w;
-            }
-            d_run[sg][r] = d_run[sg][r] * factor + wsum;
-            m_run[sg][r] = m_new;
-            f_row[sg][r] = factor;
-        }
-        simdgroup_barrier(mem_flags::mem_threadgroup);
-
-        // 4. Rescale the running output rows by this chunk's factor.
-        for (uint idx = lane; idx < BQ * D; idx += 32u) {
-            out_tile[sg][idx] *= f_row[sg][idx / D];
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-
-        // 5. Decode V̂ chunk ONCE over the same tile: one byte -> 2 dims.
-        for (uint idx = tid; idx < BK * (D >> 1u); idx += N_THREADS) {
-            uint j = idx / (D >> 1u), bcol = idx % (D >> 1u), slot = s0 + j;
-            uint base = j * D + bcol * 2u;
-            if (slot < S_kv) {
-                uint byte = uint(v_idx[(kv_base + slot) * (D >> 1u) + bcol]);
-                kv_tile[base]      = half(v_cents[byte & 0xFu]);
-                kv_tile[base + 1u] = half(v_cents[byte >> 4u]);
-            } else {
-                kv_tile[base]      = half(0.0f);
-                kv_tile[base + 1u] = half(0.0f);
-            }
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-
-        // 6. W·V̂ on the matrix units, per 8-column block; chunk partials
-        //    (8-term dots, safe in half) accumulate into the float tile.
-        for (uint dt = 0; dt < D / 8u; ++dt) {
-            simdgroup_half8x8 wf, vf;
-            simdgroup_half8x8 pacc = make_filled_simdgroup_matrix<half, 8, 8>(half(0.0f));
-            simdgroup_load(wf, &w_tile[sg][0], ulong(BK));
-            simdgroup_load(vf, kv_tile + dt * 8u, ulong(D));
-            simdgroup_multiply_accumulate(pacc, wf, vf, pacc);
-            simdgroup_store(pacc, &p_tile[sg][0], ulong(BK));
-            simdgroup_barrier(mem_flags::mem_threadgroup);
-            for (uint idx = lane; idx < BQ * BK; idx += 32u) {
-                uint r = idx / BK, dc = idx % BK;
-                out_tile[sg][r * D + dt * 8u + dc] += float(p_tile[sg][idx]);
-            }
-            simdgroup_barrier(mem_flags::mem_threadgroup);
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    // ---- Each SIMD-group owns distinct rows — write them out directly ----
-    for (uint idx = lane; idx < BQ * D; idx += 32u) {
-        uint r  = idx / D;
-        uint gq = qblk * BQ_TG + sg * BQ + r;
-        if (gq >= S_q) continue;
-        out[q_base + gq * D + (idx % D)] =
-            half(out_tile[sg][idx] / d_run[sg][r]);
-    }
-"""
+_RABITQ_PREFILL_SRC = _read_kernel_source("rabitq_prefill.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_rabitq_values.py
+++ b/veloxquant_mlx/metal/_rabitq_values.py
@@ -15,7 +15,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -26,12 +34,7 @@ _cache: dict = {}
 # Grid: (N_out, 1, 1) — one thread per output byte. Indices are masked
 # to 4 bits so out-of-range inputs can never corrupt a neighbour nibble.
 
-_PACK_VALUES_SRC = r"""
-    uint j = thread_position_in_grid.x;
-    uint lo = uint(v_idx[2u * j])     & 0xFu;
-    uint hi = uint(v_idx[2u * j + 1u]) & 0xFu;
-    packed[j] = uint8_t(lo | (hi << 4u));
-"""
+_PACK_VALUES_SRC = _read_kernel_source("rabitq_pack_values.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_rvq_attend.py
+++ b/veloxquant_mlx/metal/_rvq_attend.py
@@ -11,7 +11,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -41,81 +49,7 @@ _cache: dict = {}
 # Template parameters B_BITS1, B_BITS2, B_BITS_V are carried for future
 # compile-time dispatch on centroid table size; currently unused in the body.
 
-_FUSED_RVQ_ATTEND_SRC = r"""
-    constexpr int N_CENTS1  = 1 << B_BITS1;
-    constexpr int N_CENTS2  = 1 << B_BITS2;
-    constexpr int N_CENTS_V = 1 << B_BITS_V;
-
-    uint tg      = threadgroup_position_in_grid.x;
-    uint tg_lane = thread_position_in_threadgroup.x;
-
-    uint B     = uint(q_shape[0]);
-    uint H     = uint(q_shape[1]);
-    uint S_q   = uint(q_shape[2]);
-    uint D     = uint(q_shape[3]);
-    uint S_kv  = uint(k_indices1_shape[2]);
-    uint V_SUB = uint(v_codebook_shape[1]);
-    uint n_sub_v = D / V_SUB;
-
-    uint sq_idx = tg % S_q;
-    uint h_idx  = (tg / S_q) % H;
-    uint b_idx  = tg / (S_q * H);
-
-    float inv_sqrt_d = metal::rsqrt(float(D));
-    uint  TG         = threads_per_threadgroup.x;
-
-    float running_m = -INFINITY;
-    float running_d = 0.0f;
-
-    // Per-lane output accumulator; max 8 slots (D=256, TG=32)
-    float my_out[8];
-    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
-    uint n_owned = (D + TG - 1) / TG;
-
-    uint q_base    = ((b_idx * H + h_idx) * S_q + sq_idx) * D;
-    uint k_base_bh = (b_idx * H + h_idx) * S_kv;
-    uint v_base_bh = (b_idx * H + h_idx) * S_kv;
-
-    for (uint sk = 0; sk < S_kv; ++sk) {
-        // Decode key + partial dot product (each lane covers its strided dims)
-        float partial_dot = 0.0f;
-        for (uint i = tg_lane; i < D; i += TG) {
-            uint  k_off = (k_base_bh + sk) * D + i;
-            float ki    = centroids1[uint(k_indices1[k_off])]
-                        + centroids2[uint(k_indices2[k_off])];
-            partial_dot += float(q[q_base + i]) * ki;
-        }
-        float score = simd_sum(partial_dot) * inv_sqrt_d;
-
-        // Online softmax update
-        float m_new  = metal::max(running_m, score);
-        float factor = metal::exp(running_m - m_new);
-        float w      = metal::exp(score     - m_new);
-        running_d    = running_d * factor + w;
-        running_m    = m_new;
-
-        // Rescale accumulated output
-        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
-
-        // Decode value + weighted accumulate
-        for (uint i = tg_lane; i < D; i += TG) {
-            uint  sub_i  = i / V_SUB;
-            uint  comp_i = i % V_SUB;
-            uint  v_off  = (v_base_bh + sk) * n_sub_v + sub_i;
-            uint  cb_off = uint(v_indices[v_off]) * V_SUB + comp_i;
-            float vi     = float(v_codebook[cb_off]);
-            uint  out_i  = (i - tg_lane) / TG;
-            my_out[out_i] += w * vi;
-        }
-    }
-
-    // Normalize and write
-    for (uint i = tg_lane; i < D; i += TG) {
-        uint out_i   = (i - tg_lane) / TG;
-        uint out_off = ((b_idx * H + h_idx) * S_q + sq_idx) * D + i;
-        out[out_off] = half(my_out[out_i] / running_d);
-    }
-"""
+_FUSED_RVQ_ATTEND_SRC = _read_kernel_source("rvq_attend_fused.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_scalar_attend.py
+++ b/veloxquant_mlx/metal/_scalar_attend.py
@@ -43,7 +43,15 @@ Public API:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -70,108 +78,7 @@ _cache: dict = {}
 # the group size G are read from the passed shapes / a param, so one
 # compiled kernel serves any (S_kv, D, g).
 
-_SCALAR_AFFINE_ATTEND_SRC = r"""
-    uint tg   = threadgroup_position_in_grid.x;
-    uint lane = thread_position_in_threadgroup.x;
-    uint sg   = thread_position_in_threadgroup.y;
-
-    uint B    = uint(q_shape[0]);
-    uint H    = uint(q_shape[1]);
-    uint S_q  = uint(q_shape[2]);
-    uint D    = uint(q_shape[3]);
-    uint S_kv = uint(k_codes_shape[2]);
-    uint GK   = uint(k_scale_shape[2]);   // key groups along tokens
-    uint GV   = uint(v_scale_shape[3]);   // value groups along channels
-    (void)B;
-
-    uint G        = uint(gsize[0]);       // group size
-    float scale   = scale_arr[0];
-    uint  NSG     = uint(NSG_C);
-
-    uint sq_idx = tg % S_q;
-    uint h_idx  = (tg / S_q) % H;
-    uint b_idx  = tg / (S_q * H);
-
-    uint q_base   = ((b_idx * H + h_idx) * S_q + sq_idx) * D;
-    uint bh       = b_idx * H + h_idx;
-
-    // ----- per-lane online-softmax state for this SIMD-group -----
-    float running_m = -INFINITY;
-    float running_d = 0.0f;
-    float my_out[8];                       // D/32 <= 256/32 = 8
-    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
-    uint n_owned = (D + 31u) / 32u;
-
-    // ----- main loop: this SIMD-group strides kv by NSG -----
-    for (uint sk = sg; sk < S_kv; sk += NSG) {
-        // key group index along tokens for this slot
-        uint kg = sk / G;
-
-        // partial dot product over lane-owned dims
-        float partial_dot = 0.0f;
-        for (uint d = lane; d < D; d += 32u) {
-            uint  code_off = (bh * S_kv + sk) * D + d;
-            uint  ks_off   = (bh * GK + kg) * D + d;
-            float k_hat = float(k_codes[code_off]) * k_scale[ks_off]
-                        + k_zero[ks_off];
-            partial_dot += float(q[q_base + d]) * k_hat;
-        }
-        float score = simd_sum(partial_dot) * scale;
-
-        // online softmax update (every lane holds identical score)
-        float m_new  = metal::max(running_m, score);
-        float factor = metal::exp(running_m - m_new);
-        float w      = metal::exp(score      - m_new);
-        running_d    = running_d * factor + w;
-        running_m    = m_new;
-        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
-
-        // value decode + weighted accumulate (per-token groups over channels)
-        for (uint d = lane; d < D; d += 32u) {
-            uint  vg      = d / G;
-            uint  code_off = (bh * S_kv + sk) * D + d;
-            uint  vs_off   = (bh * S_kv + sk) * GV + vg;
-            float v_hat = float(v_codes[code_off]) * v_scale[vs_off]
-                        + v_zero[vs_off];
-            uint  out_i = (d - lane) / 32u;
-            my_out[out_i] += w * v_hat;
-        }
-    }
-
-    // ----- merge the NSG partial softmaxes through threadgroup memory -----
-    // sh_o layout: [NSG_C][8][32]  (SIMD-group, owned-slot, lane).
-    threadgroup float sh_m[NSG_C];         // one slot per SIMD-group
-    threadgroup float sh_d[NSG_C];
-    threadgroup float sh_o[NSG_C * 8 * 32];
-
-    // stash this SIMD-group's per-lane partials
-    for (uint i = 0; i < n_owned; ++i) {
-        sh_o[(sg * 8u + i) * 32u + lane] = my_out[i];
-    }
-    if (lane == 0) { sh_m[sg] = running_m; sh_d[sg] = running_d; }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // SIMD-group 0 reduces across all groups
-    if (sg == 0) {
-        float gm = -INFINITY;
-        for (uint s = 0; s < NSG; ++s) gm = metal::max(gm, sh_m[s]);
-        float gd = 0.0f;
-        for (uint s = 0; s < NSG; ++s) gd += sh_d[s] * metal::exp(sh_m[s] - gm);
-
-        for (uint i = 0; i < n_owned; ++i) {
-            float acc = 0.0f;
-            for (uint s = 0; s < NSG; ++s) {
-                acc += sh_o[(s * 8 + i) * 32 + lane]
-                     * metal::exp(sh_m[s] - gm);
-            }
-            uint d = lane + i * 32u;
-            if (d < D) {
-                uint out_off = ((b_idx * H + h_idx) * S_q + sq_idx) * D + d;
-                out[out_off] = half(acc / gd);
-            }
-        }
-    }
-"""
+_SCALAR_AFFINE_ATTEND_SRC = _read_kernel_source("scalar_affine_attend.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_scalar_quant.py
+++ b/veloxquant_mlx/metal/_scalar_quant.py
@@ -11,7 +11,15 @@ TurboQuantMSE, TurboQuantRVQ, and the Hadamard preconditioner:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 _cache: dict = {}
 
@@ -25,21 +33,7 @@ _cache: dict = {}
 # Template <int B_BITS> lets the compiler statically unroll the centroid scan
 # (max 16 centroids for b=4, all fit in registers).
 
-_SCALAR_QUANTIZE_SRC = r"""
-    constexpr int N_CENTS = 1 << B_BITS;
-
-    uint  elem     = thread_position_in_grid.x;
-    float val      = float(x[elem]);
-    int   best     = 0;
-    float best_dist = INFINITY;
-
-    for (int j = 0; j < N_CENTS; ++j) {
-        float d    = val - centroids[j];
-        float dist = d * d;
-        if (dist < best_dist) { best_dist = dist; best = j; }
-    }
-    indices[elem] = uint8_t(best);
-"""
+_SCALAR_QUANTIZE_SRC = _read_kernel_source("scalar_quantize.metal")
 
 
 # ===========================================================================
@@ -48,10 +42,7 @@ _SCALAR_QUANTIZE_SRC = r"""
 # Grid: (N, 1, 1) — one thread per element.
 # Simple gather: x_hat[i] = fp16(centroids[indices[i]]).
 
-_SCALAR_DEQUANTIZE_SRC = r"""
-    uint elem    = thread_position_in_grid.x;
-    x_hat[elem]  = half(centroids[uint(indices[elem])]);
-"""
+_SCALAR_DEQUANTIZE_SRC = _read_kernel_source("scalar_dequantize.metal")
 
 
 # ===========================================================================
@@ -71,46 +62,7 @@ _SCALAR_DEQUANTIZE_SRC = r"""
 #   3. Scale by 1/√D (rsqrt for speed).
 #   4. Nearest-centroid argmin in registers → write uint8 index.
 
-_HADAMARD_QUANTIZE_SRC = r"""
-    constexpr int N_CENTS = 1 << B_BITS;
-
-    threadgroup float buf[MAX_D];
-
-    uint tg   = threadgroup_position_in_grid.x;
-    uint lane = thread_position_in_threadgroup.x;
-    uint D    = uint(MAX_D);
-
-    // 1. Load + diagonal sign flip
-    float v = float(x[tg * D + lane]);
-    v *= float(diag[lane]);
-    buf[lane] = v;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // 2. In-place WHT: range-based parallel butterfly
-    for (uint stride = 1; stride < D; stride <<= 1) {
-        uint local    = lane % (stride << 1u);
-        bool is_upper = local >= stride;
-        uint partner  = is_upper ? (lane - stride) : (lane + stride);
-        float a = buf[lane];
-        float b = buf[partner];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        buf[lane] = is_upper ? (b - a) : (a + b);
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    // 3. Scale
-    float y = buf[lane] * metal::rsqrt(float(D));
-
-    // 4. Nearest-centroid argmin (register-local scan)
-    int   best      = 0;
-    float best_dist = INFINITY;
-    for (int j = 0; j < N_CENTS; ++j) {
-        float d    = y - centroids[j];
-        float dist = d * d;
-        if (dist < best_dist) { best_dist = dist; best = j; }
-    }
-    indices[tg * D + lane] = uint8_t(best);
-"""
+_HADAMARD_QUANTIZE_SRC = _read_kernel_source("hadamard_quantize.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/_vecinfer.py
+++ b/veloxquant_mlx/metal/_vecinfer.py
@@ -12,9 +12,16 @@ Phase 2 (fused encode+decode):
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
 
 # ---------------------------------------------------------------------------
 # Shared kernel cache (keyed by (tag, *shape_params))
@@ -28,20 +35,7 @@ _cache: dict = {}
 # Grid: (N_total, 1, 1) — one thread per input index.
 # Each thread copies sub_dim contiguous centroid components to the output.
 
-_DEQUANT_SRC = r"""
-    uint flat_idx = thread_position_in_grid.x;
-    uint N_total  = indices_shape[0];
-    if (flat_idx >= N_total) return;
-
-    uint sub_dim  = codebook_shape[1];
-    uint code_idx = indices[flat_idx];
-    uint cb_base  = code_idx * sub_dim;
-    uint out_base = flat_idx * sub_dim;
-
-    for (uint i = 0; i < sub_dim; ++i) {
-        out[out_base + i] = codebook[cb_base + i];
-    }
-"""
+_DEQUANT_SRC = _read_kernel_source("vecinfer_dequant.metal")
 
 
 # ===========================================================================
@@ -51,29 +45,7 @@ _DEQUANT_SRC = r"""
 # Accumulated squared distance stays in registers; only the winning index
 # is written → peak memory O(N) instead of O(N * n_centroids * sub_dim).
 
-_QUANTIZE_SRC = r"""
-    uint vec_idx = thread_position_in_grid.x;
-    uint N_total = x_shape[0];
-    if (vec_idx >= N_total) return;
-
-    uint n_centroids = codebook_shape[0];
-    uint sub_dim     = codebook_shape[1];
-    uint x_base      = vec_idx * sub_dim;
-
-    float best_dist = INFINITY;
-    uint  best_idx  = 0;
-
-    for (uint c = 0; c < n_centroids; ++c) {
-        uint  cb_base = c * sub_dim;
-        float dist    = 0.0f;
-        for (uint i = 0; i < sub_dim; ++i) {
-            float d = float(x[x_base + i]) - float(codebook[cb_base + i]);
-            dist += d * d;
-        }
-        if (dist < best_dist) { best_dist = dist; best_idx = c; }
-    }
-    out[vec_idx] = best_idx;
-"""
+_QUANTIZE_SRC = _read_kernel_source("vecinfer_quantize.metal")
 
 
 # ===========================================================================
@@ -87,105 +59,7 @@ _QUANTIZE_SRC = r"""
 #   float buf_tg[MAX_D]   — WHT output / inv-WHT output
 #   uint  idx[MAX_N_SUB]  — winning centroid per sub-vector
 
-_ENCODE_DECODE_FULL_SRC = r"""
-    threadgroup float buf_in[MAX_D];
-    threadgroup float buf_tg[MAX_D];
-    threadgroup uint  idx[MAX_N_SUB];
-
-    uint tg_idx  = threadgroup_position_in_grid.x;
-    uint lane    = thread_position_in_threadgroup.x;
-
-    uint H           = params[1];
-    uint S           = params[2];
-    uint D           = params[3];
-    uint n_sub       = params[4];
-    uint sub_dim     = params[5];
-    uint n_cents     = params[6];
-    uint has_smooth  = params[7];
-    uint smooth_rows = params[8];
-
-    uint s_idx = tg_idx % S;
-    uint h_idx = (tg_idx / S) % H;
-    uint b_idx = tg_idx / (S * H);
-
-    uint key_base    = ((b_idx * H + h_idx) * S + s_idx) * D;
-    uint smooth_base = (has_smooth ? (h_idx % smooth_rows) * D : 0);
-
-    // Phase A: load + optional smooth divide
-    float val = float(keys[key_base + lane]);
-    if (has_smooth) {
-        float s = float(smooth[smooth_base + lane]);
-        val = (s > 1e-8f) ? val / s : val;
-    }
-    buf_in[lane] = val;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // Phase B: WHT via matvec — thread lane computes dot(H_mat[lane, :], buf_in)
-    {
-        float dot = 0.0f;
-        uint row_base = lane * D;
-        for (uint c = 0; c < D; ++c) {
-            dot += float(H_mat[row_base + c]) * buf_in[c];
-        }
-        buf_tg[lane] = dot;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // Phase C: quantize — one leader per sub-vector scans all centroids
-    uint my_sub  = lane / sub_dim;
-    uint my_comp = lane % sub_dim;
-
-    if (my_comp == 0 && my_sub < n_sub) {
-        float best_dist = INFINITY;
-        uint  best_c    = 0;
-        uint  x_off     = my_sub * sub_dim;
-
-        for (uint c = 0; c < n_cents; ++c) {
-            float dist    = 0.0f;
-            uint  cb_base = c * sub_dim;
-            for (uint i = 0; i < sub_dim; ++i) {
-                float d = buf_tg[x_off + i] - float(k_codebook[cb_base + i]);
-                dist += d * d;
-            }
-            if (dist < best_dist) { best_dist = dist; best_c = c; }
-        }
-        idx[my_sub] = best_c;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // Phase D: dequantize — gather winning centroid into buf_in
-    {
-        uint c       = idx[my_sub];
-        uint cb_base = c * sub_dim;
-        buf_in[lane] = float(k_codebook[cb_base + my_comp]);
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // Phase E: inv-WHT — H_mat.T[lane, c] = H_mat[c, lane]
-    {
-        float dot = 0.0f;
-        for (uint c = 0; c < D; ++c) {
-            dot += float(H_mat[c * D + lane]) * buf_in[c];
-        }
-        buf_tg[lane] = dot;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // Phase F: inverse smooth multiply
-    float out_val = buf_tg[lane];
-    if (has_smooth) {
-        float s = float(smooth[smooth_base + lane]);
-        out_val *= s;
-    }
-
-    // Phase G: write outputs
-    k_hat_out[key_base + lane] = half(out_val);
-
-    if (my_comp == 0 && my_sub < n_sub) {
-        uint idx_base = ((b_idx * H + h_idx) * S + s_idx) * n_sub;
-        idx_out[idx_base + my_sub] = idx[my_sub];
-    }
-"""
+_ENCODE_DECODE_FULL_SRC = _read_kernel_source("vecinfer_encode_decode_full.metal")
 
 
 # ===========================================================================
@@ -197,64 +71,7 @@ _ENCODE_DECODE_FULL_SRC = r"""
 # Values skip smooth/Hadamard per the VecInfer paper.
 # Threadgroup memory: float buf[MAX_D] + uint idx[MAX_N_SUB]
 
-_ENCODE_DECODE_SIMPLE_SRC = r"""
-    threadgroup float buf[MAX_D];
-    threadgroup uint  idx[MAX_N_SUB];
-
-    uint tg_idx  = threadgroup_position_in_grid.x;
-    uint lane    = thread_position_in_threadgroup.x;
-
-    uint H       = params[1];
-    uint S       = params[2];
-    uint D       = params[3];
-    uint n_sub   = params[4];
-    uint sub_dim = params[5];
-    uint n_cents = params[6];
-
-    uint s_idx = tg_idx % S;
-    uint h_idx = (tg_idx / S) % H;
-    uint b_idx = tg_idx / (S * H);
-
-    uint val_base = ((b_idx * H + h_idx) * S + s_idx) * D;
-
-    buf[lane] = float(values[val_base + lane]);
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    uint my_sub  = lane / sub_dim;
-    uint my_comp = lane % sub_dim;
-
-    if (my_comp == 0 && my_sub < n_sub) {
-        float best_dist = INFINITY;
-        uint  best_c    = 0;
-        uint  x_off     = my_sub * sub_dim;
-
-        for (uint c = 0; c < n_cents; ++c) {
-            float dist    = 0.0f;
-            uint  cb_base = c * sub_dim;
-            for (uint i = 0; i < sub_dim; ++i) {
-                float d = buf[x_off + i] - float(v_codebook[cb_base + i]);
-                dist += d * d;
-            }
-            if (dist < best_dist) { best_dist = dist; best_c = c; }
-        }
-        idx[my_sub] = best_c;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    if (my_sub < n_sub) {
-        uint c       = idx[my_sub];
-        uint cb_base = c * sub_dim;
-        buf[lane] = float(v_codebook[cb_base + my_comp]);
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    v_hat_out[val_base + lane] = half(buf[lane]);
-
-    if (my_comp == 0 && my_sub < n_sub) {
-        uint idx_base = ((b_idx * H + h_idx) * S + s_idx) * n_sub;
-        idx_out[idx_base + my_sub] = idx[my_sub];
-    }
-"""
+_ENCODE_DECODE_SIMPLE_SRC = _read_kernel_source("vecinfer_encode_decode_simple.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/fused_sdpa.py
+++ b/veloxquant_mlx/metal/fused_sdpa.py
@@ -95,9 +95,15 @@ compressed indices (16× smaller for VecInfer-1bit).
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
 
 
 # ===========================================================================
@@ -119,175 +125,7 @@ import mlx.core as mx
 #
 # Dispatch:  grid=(B*H_q*32, S_q, 1)  threadgroup=(32, 1, 1)
 #
-_FUSED_SDPA_SRC = r"""
-    // 32 lanes per threadgroup; one threadgroup per (B*H_q, S_q) output cell
-    uint q_head_idx = thread_position_in_grid.x / 32;
-    uint q_pos      = thread_position_in_grid.y;
-    uint lane       = thread_position_in_threadgroup.x;
-
-    // Unpack shape pack
-    uint H_q       = params[0];
-    uint H_kv      = params[1];
-    uint S_q       = params[2];
-    uint S_kv      = params[3];
-    uint D         = params[4];
-    uint n_sub     = params[5];
-    uint sub_dim   = params[6];
-    uint n_sub_v   = params[7];
-    uint sub_dim_v = params[8];
-    uint flags     = params[9];
-
-    bool causal       = (flags & 1u) != 0u;
-    bool use_window   = (flags & 2u) != 0u;
-    uint window_width = slide_arr[0];
-    float scale       = scale_arr[0];
-
-    if (q_pos >= S_q) { return; }
-
-    uint batch  = q_head_idx / H_q;
-    uint h_q    = q_head_idx % H_q;
-    uint h_kv   = (h_q * H_kv) / H_q;        // GQA integer div
-
-    uint q_base   = q_head_idx * S_q * D + q_pos * D;
-    uint k_base_b = batch * H_kv * S_kv;     // K row stride
-    uint out_base = q_head_idx * S_q * D + q_pos * D;
-
-    constexpr uint kNCentroids = LUT_N_CENTROIDS;     // compile-time
-    constexpr uint kMaxLut     = LUT_MAX_SIZE;        // n_sub * n_centroids
-    constexpr uint kDimsPerLane = MAX_D / 32;         // output dims owned by each lane
-
-    // LUT lives in threadgroup (shared across all lanes in the SIMD group).
-    // t_out and tg_d_shared have been replaced by lane-local registers:
-    //   my_out[kDimsPerLane]  — each lane owns D/32 output dimensions
-    //   running_d             — denominator accumulated in registers
-    threadgroup float lut[kMaxLut];
-
-    // -----------------------------------------------------------------
-    // Phase 0: fill the per-query LUT cooperatively.
-    //   lut[sub * n_centroids + c] = q_sub_vec dot k_codebook_row
-    //
-    // Stripe (sub, centroid) pairs across 32 lanes — each lane computes
-    // one dot product independently.  The pragma enables FMA contraction
-    // on the inner dot loop; relaxed still honors INF/NaN unlike fast.
-    // -----------------------------------------------------------------
-    uint lut_total = n_sub * kNCentroids;
-    for (uint idx = lane; idx < lut_total; idx += 32) {
-        uint sub = idx / kNCentroids;
-        uint c   = idx % kNCentroids;
-        uint q_sub_off = q_base + sub * sub_dim;
-        uint cb_off    = c * sub_dim;
-        float dot = 0.0f;
-        for (uint i = 0; i < sub_dim; ++i) {
-            dot += q[q_sub_off + i] * k_codebook[cb_off + i];
-        }
-        lut[idx] = dot;
-    }
-
-    // -----------------------------------------------------------------
-    // Phase 1: initialize lane-local running stats.
-    //
-    // my_out holds D/32 output floats owned by this lane.
-    // running_m and running_d are pure register scalars — no threadgroup
-    // writes needed.  The single barrier here lets all lanes finish writing
-    // the LUT before any lane reads it in Phase 2.
-    // -----------------------------------------------------------------
-    float my_out[kDimsPerLane];
-    for (uint k = 0; k < kDimsPerLane; ++k) {
-        my_out[k] = 0.0f;
-    }
-    float running_m = -INFINITY;
-    float running_d = 0.0f;
-
-    threadgroup_barrier(mem_flags::mem_threadgroup);   // sole barrier: LUT ready
-
-    // Convention: queries align to the tail of S_kv (standard decode pattern)
-    uint q_abs = (S_kv - S_q) + q_pos;
-
-    // -----------------------------------------------------------------
-    // Phase 2: tiled online softmax + V accumulation — zero additional barriers
-    // -----------------------------------------------------------------
-    for (uint tile_start = 0; tile_start < S_kv; tile_start += 32) {
-        uint k_pos = tile_start + lane;
-
-        // Per-lane mask resolution
-        float score = -INFINITY;
-        bool valid = (k_pos < S_kv);
-        if (valid && causal && k_pos > q_abs) valid = false;
-        if (valid && use_window) {
-            if (q_abs + 1u > window_width && k_pos + window_width < q_abs + 1u) {
-                valid = false;
-            }
-        }
-        if (valid) {
-            uint k_row_idx = (k_base_b + h_kv * S_kv + k_pos) * n_sub;
-            float s = 0.0f;
-            for (uint sub = 0; sub < n_sub; ++sub) {
-                uint c = k_indices[k_row_idx + sub];
-                s += lut[sub * kNCentroids + c];
-            }
-            score = s * scale;
-        }
-
-        // SIMD-wide max — broadcasts result to all lanes, no barrier
-        float tile_max = simd_max(score);
-        if (!isfinite(tile_max)) { continue; }   // whole tile masked
-
-        // Lane 0 computes the new max and rescale factor; simd_broadcast_first
-        // propagates to all lanes without a threadgroup barrier.
-        float m_old     = running_m;
-        float m_new_l0  = max(m_old, tile_max);
-        // metal::precise::exp guarantees exp(-inf)==0.0 regardless of math mode.
-        float factor_l0 = isfinite(m_old) ? metal::precise::exp(m_old - m_new_l0) : 0.0f;
-        float m_new  = simd_broadcast_first(m_new_l0);
-        float factor = simd_broadcast_first(factor_l0);
-        running_m = m_new;
-
-        float w = metal::precise::exp(score - m_new);
-        if (!valid) w = 0.0f;
-
-        // Denominator: fully register-local, synced via simd_broadcast_first.
-        // simd_sum broadcasts the tile sum to all lanes — no threadgroup write.
-        float tile_w_sum = simd_sum(w);
-        running_d = running_d * factor + simd_broadcast_first(tile_w_sum);
-
-        // Rescale lane's owned output slice and accumulate V contribution.
-        // Each lane owns output dimensions [lane*(D/32) .. (lane+1)*(D/32)-1].
-        // No threadgroup array involved — pure register arithmetic.
-        for (uint k = 0; k < kDimsPerLane; ++k) {
-            my_out[k] *= factor;
-        }
-
-        // V accumulation: lane owns kDimsPerLane contiguous output dims.
-        // Walk all 32 tile-mates via simd_shuffle to get their weights.
-        for (uint k = 0; k < kDimsPerLane; ++k) {
-            uint dim   = lane * kDimsPerLane + k;
-            uint sub_v = dim / sub_dim_v;
-            uint comp  = dim % sub_dim_v;
-            float acc = 0.0f;
-            for (uint l = 0; l < 32; ++l) {
-                uint k_l = tile_start + l;
-                if (k_l >= S_kv) break;
-                float w_l = simd_shuffle(w, l);
-                if (w_l == 0.0f) continue;
-                uint v_row_idx = (k_base_b + h_kv * S_kv + k_l) * n_sub_v;
-                uint v_c = v_indices[v_row_idx + sub_v];
-                acc += w_l * v_codebook[v_c * sub_dim_v + comp];
-            }
-            my_out[k] += acc;
-        }
-        // No threadgroup barrier — all output state is lane-local.
-    }
-
-    // -----------------------------------------------------------------
-    // Phase 3: normalize and write each lane's owned dims directly to device.
-    // running_d is identical in all lanes (kept in sync via simd_broadcast_first).
-    // -----------------------------------------------------------------
-    float inv_d = 1.0f / max(running_d, 1e-20f);
-    for (uint k = 0; k < kDimsPerLane; ++k) {
-        uint dim = lane * kDimsPerLane + k;
-        out[out_base + dim] = my_out[k] * inv_d;
-    }
-"""
+_FUSED_SDPA_SRC = _read_kernel_source("fused_sdpa.metal")
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/metal/src/bit_pack.metal
+++ b/veloxquant_mlx/metal/src/bit_pack.metal
@@ -1,0 +1,19 @@
+// bit_pack.metal
+// Extracted from veloxquant_mlx/metal/_bit_packing.py (_PACK_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    constexpr int  ELEMS_PER_BYTE = 8 / B_BITS;
+    constexpr uint MASK           = (1u << B_BITS) - 1u;
+
+    uint byte_idx = thread_position_in_grid.x;
+    uint base     = byte_idx * ELEMS_PER_BYTE;
+
+    uint packed_byte = 0u;
+    for (int i = 0; i < ELEMS_PER_BYTE; ++i) {
+        uint val = uint(indices[base + i]) & MASK;
+        packed_byte |= (val << (i * B_BITS));
+    }
+    packed[byte_idx] = uint8_t(packed_byte);

--- a/veloxquant_mlx/metal/src/bit_unpack.metal
+++ b/veloxquant_mlx/metal/src/bit_unpack.metal
@@ -1,0 +1,15 @@
+// bit_unpack.metal
+// Extracted from veloxquant_mlx/metal/_bit_packing.py (_UNPACK_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    constexpr int  ELEMS_PER_BYTE = 8 / B_BITS;
+    constexpr uint MASK           = (1u << B_BITS) - 1u;
+
+    uint elem_idx = thread_position_in_grid.x;
+    uint byte_idx = elem_idx / ELEMS_PER_BYTE;
+    uint bit_off  = (elem_idx % ELEMS_PER_BYTE) * B_BITS;
+
+    indices[elem_idx] = uint8_t((uint(packed[byte_idx]) >> bit_off) & MASK);

--- a/veloxquant_mlx/metal/src/comm_vq_decode.metal
+++ b/veloxquant_mlx/metal/src/comm_vq_decode.metal
@@ -1,0 +1,71 @@
+// comm_vq_decode.metal
+// Extracted from veloxquant_mlx/metal/_comm_vq.py (_COMM_VQ_DECODE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint flat = thread_position_in_grid.x;
+
+    uint N = uint(indices_shape[0]);
+    uint D = uint(N_CB) * uint(SUB_DIM);
+
+    uint b_idx = flat / D;
+    uint d_i   = flat % D;
+
+    if (b_idx >= N) return;
+
+    // Which sub-codebook owns dimension d_i?
+    uint cb_i   = d_i / uint(SUB_DIM);
+    uint comp_i = d_i % uint(SUB_DIM);
+
+    // Gather centroid value (additive: one sub-codebook per segment)
+    uint idx_val = uint(indices[b_idx * uint(N_CB) + cb_i]);
+    uint cb_off  = cb_i * uint(CB_SIZE) * uint(SUB_DIM)
+                 + idx_val * uint(SUB_DIM)
+                 + comp_i;
+    float x_val = float(codebook[cb_off]);
+
+    // Apply RoPE: operate on paired dimensions (d_i, d_i + D/2) or (d_i - D/2, d_i)
+    uint half_D = D / 2;
+    uint pos    = uint(positions[b_idx]);
+    uint freq_i = d_i % half_D;   // which frequency dimension
+
+    float inv_f  = inv_freq[freq_i];
+    float angle  = float(pos) * inv_f;
+    float cos_v  = metal::cos(angle);
+    float sin_v  = metal::sin(angle);
+
+    // Partner dimension index
+    uint partner_i = (d_i < half_D) ? (d_i + half_D) : (d_i - half_D);
+
+    // We need the partner's pre-RoPE value. For the fused kernel we need a
+    // two-phase approach: write pre-RoPE first, then apply RoPE.
+    // Since we can't synchronise across threads for different d_i here, we
+    // instead write the pre-RoPE value and let a second pass (or the caller)
+    // apply RoPE. This is still a net win: we fuse the gather (O(N*D) reads
+    // from a large indices array) into one dispatch.
+    //
+    // For the full fused path (gather + RoPE in one pass) the standard trick
+    // is to have each thread compute BOTH halves of its dimension pair. We do
+    // that here: thread for d_i < half_D also reads the codebook for d_i+half_D
+    // and writes both rotated outputs. Threads for d_i >= half_D skip (output
+    // already written by their lower-half partner).
+
+    if (d_i < half_D) {
+        // This thread handles the pair (d_i, d_i + half_D)
+        uint cb_i2   = partner_i / uint(SUB_DIM);
+        uint comp_i2 = partner_i % uint(SUB_DIM);
+        uint idx2    = uint(indices[b_idx * uint(N_CB) + cb_i2]);
+        uint cb_off2 = cb_i2 * uint(CB_SIZE) * uint(SUB_DIM)
+                     + idx2 * uint(SUB_DIM)
+                     + comp_i2;
+        float x2 = float(codebook[cb_off2]);
+
+        float out0 = x_val * cos_v - x2 * sin_v;
+        float out1 = x_val * sin_v + x2 * cos_v;
+
+        out[b_idx * D + d_i]            = half(out0);
+        out[b_idx * D + partner_i]      = half(out1);
+    }
+    // threads with d_i >= half_D do nothing — already written above

--- a/veloxquant_mlx/metal/src/fused_sdpa.metal
+++ b/veloxquant_mlx/metal/src/fused_sdpa.metal
@@ -1,0 +1,174 @@
+// fused_sdpa.metal
+// Extracted from veloxquant_mlx/metal/fused_sdpa.py (_FUSED_SDPA_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    // 32 lanes per threadgroup; one threadgroup per (B*H_q, S_q) output cell
+    uint q_head_idx = thread_position_in_grid.x / 32;
+    uint q_pos      = thread_position_in_grid.y;
+    uint lane       = thread_position_in_threadgroup.x;
+
+    // Unpack shape pack
+    uint H_q       = params[0];
+    uint H_kv      = params[1];
+    uint S_q       = params[2];
+    uint S_kv      = params[3];
+    uint D         = params[4];
+    uint n_sub     = params[5];
+    uint sub_dim   = params[6];
+    uint n_sub_v   = params[7];
+    uint sub_dim_v = params[8];
+    uint flags     = params[9];
+
+    bool causal       = (flags & 1u) != 0u;
+    bool use_window   = (flags & 2u) != 0u;
+    uint window_width = slide_arr[0];
+    float scale       = scale_arr[0];
+
+    if (q_pos >= S_q) { return; }
+
+    uint batch  = q_head_idx / H_q;
+    uint h_q    = q_head_idx % H_q;
+    uint h_kv   = (h_q * H_kv) / H_q;        // GQA integer div
+
+    uint q_base   = q_head_idx * S_q * D + q_pos * D;
+    uint k_base_b = batch * H_kv * S_kv;     // K row stride
+    uint out_base = q_head_idx * S_q * D + q_pos * D;
+
+    constexpr uint kNCentroids = LUT_N_CENTROIDS;     // compile-time
+    constexpr uint kMaxLut     = LUT_MAX_SIZE;        // n_sub * n_centroids
+    constexpr uint kDimsPerLane = MAX_D / 32;         // output dims owned by each lane
+
+    // LUT lives in threadgroup (shared across all lanes in the SIMD group).
+    // t_out and tg_d_shared have been replaced by lane-local registers:
+    //   my_out[kDimsPerLane]  — each lane owns D/32 output dimensions
+    //   running_d             — denominator accumulated in registers
+    threadgroup float lut[kMaxLut];
+
+    // -----------------------------------------------------------------
+    // Phase 0: fill the per-query LUT cooperatively.
+    //   lut[sub * n_centroids + c] = q_sub_vec dot k_codebook_row
+    //
+    // Stripe (sub, centroid) pairs across 32 lanes — each lane computes
+    // one dot product independently.  The pragma enables FMA contraction
+    // on the inner dot loop; relaxed still honors INF/NaN unlike fast.
+    // -----------------------------------------------------------------
+    uint lut_total = n_sub * kNCentroids;
+    for (uint idx = lane; idx < lut_total; idx += 32) {
+        uint sub = idx / kNCentroids;
+        uint c   = idx % kNCentroids;
+        uint q_sub_off = q_base + sub * sub_dim;
+        uint cb_off    = c * sub_dim;
+        float dot = 0.0f;
+        for (uint i = 0; i < sub_dim; ++i) {
+            dot += q[q_sub_off + i] * k_codebook[cb_off + i];
+        }
+        lut[idx] = dot;
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 1: initialize lane-local running stats.
+    //
+    // my_out holds D/32 output floats owned by this lane.
+    // running_m and running_d are pure register scalars — no threadgroup
+    // writes needed.  The single barrier here lets all lanes finish writing
+    // the LUT before any lane reads it in Phase 2.
+    // -----------------------------------------------------------------
+    float my_out[kDimsPerLane];
+    for (uint k = 0; k < kDimsPerLane; ++k) {
+        my_out[k] = 0.0f;
+    }
+    float running_m = -INFINITY;
+    float running_d = 0.0f;
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);   // sole barrier: LUT ready
+
+    // Convention: queries align to the tail of S_kv (standard decode pattern)
+    uint q_abs = (S_kv - S_q) + q_pos;
+
+    // -----------------------------------------------------------------
+    // Phase 2: tiled online softmax + V accumulation — zero additional barriers
+    // -----------------------------------------------------------------
+    for (uint tile_start = 0; tile_start < S_kv; tile_start += 32) {
+        uint k_pos = tile_start + lane;
+
+        // Per-lane mask resolution
+        float score = -INFINITY;
+        bool valid = (k_pos < S_kv);
+        if (valid && causal && k_pos > q_abs) valid = false;
+        if (valid && use_window) {
+            if (q_abs + 1u > window_width && k_pos + window_width < q_abs + 1u) {
+                valid = false;
+            }
+        }
+        if (valid) {
+            uint k_row_idx = (k_base_b + h_kv * S_kv + k_pos) * n_sub;
+            float s = 0.0f;
+            for (uint sub = 0; sub < n_sub; ++sub) {
+                uint c = k_indices[k_row_idx + sub];
+                s += lut[sub * kNCentroids + c];
+            }
+            score = s * scale;
+        }
+
+        // SIMD-wide max — broadcasts result to all lanes, no barrier
+        float tile_max = simd_max(score);
+        if (!isfinite(tile_max)) { continue; }   // whole tile masked
+
+        // Lane 0 computes the new max and rescale factor; simd_broadcast_first
+        // propagates to all lanes without a threadgroup barrier.
+        float m_old     = running_m;
+        float m_new_l0  = max(m_old, tile_max);
+        // metal::precise::exp guarantees exp(-inf)==0.0 regardless of math mode.
+        float factor_l0 = isfinite(m_old) ? metal::precise::exp(m_old - m_new_l0) : 0.0f;
+        float m_new  = simd_broadcast_first(m_new_l0);
+        float factor = simd_broadcast_first(factor_l0);
+        running_m = m_new;
+
+        float w = metal::precise::exp(score - m_new);
+        if (!valid) w = 0.0f;
+
+        // Denominator: fully register-local, synced via simd_broadcast_first.
+        // simd_sum broadcasts the tile sum to all lanes — no threadgroup write.
+        float tile_w_sum = simd_sum(w);
+        running_d = running_d * factor + simd_broadcast_first(tile_w_sum);
+
+        // Rescale lane's owned output slice and accumulate V contribution.
+        // Each lane owns output dimensions [lane*(D/32) .. (lane+1)*(D/32)-1].
+        // No threadgroup array involved — pure register arithmetic.
+        for (uint k = 0; k < kDimsPerLane; ++k) {
+            my_out[k] *= factor;
+        }
+
+        // V accumulation: lane owns kDimsPerLane contiguous output dims.
+        // Walk all 32 tile-mates via simd_shuffle to get their weights.
+        for (uint k = 0; k < kDimsPerLane; ++k) {
+            uint dim   = lane * kDimsPerLane + k;
+            uint sub_v = dim / sub_dim_v;
+            uint comp  = dim % sub_dim_v;
+            float acc = 0.0f;
+            for (uint l = 0; l < 32; ++l) {
+                uint k_l = tile_start + l;
+                if (k_l >= S_kv) break;
+                float w_l = simd_shuffle(w, l);
+                if (w_l == 0.0f) continue;
+                uint v_row_idx = (k_base_b + h_kv * S_kv + k_l) * n_sub_v;
+                uint v_c = v_indices[v_row_idx + sub_v];
+                acc += w_l * v_codebook[v_c * sub_dim_v + comp];
+            }
+            my_out[k] += acc;
+        }
+        // No threadgroup barrier — all output state is lane-local.
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 3: normalize and write each lane's owned dims directly to device.
+    // running_d is identical in all lanes (kept in sync via simd_broadcast_first).
+    // -----------------------------------------------------------------
+    float inv_d = 1.0f / max(running_d, 1e-20f);
+    for (uint k = 0; k < kDimsPerLane; ++k) {
+        uint dim = lane * kDimsPerLane + k;
+        out[out_base + dim] = my_out[k] * inv_d;
+    }

--- a/veloxquant_mlx/metal/src/hadamard_quantize.metal
+++ b/veloxquant_mlx/metal/src/hadamard_quantize.metal
@@ -1,0 +1,45 @@
+// hadamard_quantize.metal
+// Extracted from veloxquant_mlx/metal/_scalar_quant.py (_HADAMARD_QUANTIZE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    constexpr int N_CENTS = 1 << B_BITS;
+
+    threadgroup float buf[MAX_D];
+
+    uint tg   = threadgroup_position_in_grid.x;
+    uint lane = thread_position_in_threadgroup.x;
+    uint D    = uint(MAX_D);
+
+    // 1. Load + diagonal sign flip
+    float v = float(x[tg * D + lane]);
+    v *= float(diag[lane]);
+    buf[lane] = v;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // 2. In-place WHT: range-based parallel butterfly
+    for (uint stride = 1; stride < D; stride <<= 1) {
+        uint local    = lane % (stride << 1u);
+        bool is_upper = local >= stride;
+        uint partner  = is_upper ? (lane - stride) : (lane + stride);
+        float a = buf[lane];
+        float b = buf[partner];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        buf[lane] = is_upper ? (b - a) : (a + b);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // 3. Scale
+    float y = buf[lane] * metal::rsqrt(float(D));
+
+    // 4. Nearest-centroid argmin (register-local scan)
+    int   best      = 0;
+    float best_dist = INFINITY;
+    for (int j = 0; j < N_CENTS; ++j) {
+        float d    = y - centroids[j];
+        float dist = d * d;
+        if (dist < best_dist) { best_dist = dist; best = j; }
+    }
+    indices[tg * D + lane] = uint8_t(best);

--- a/veloxquant_mlx/metal/src/qjl_encode.metal
+++ b/veloxquant_mlx/metal/src/qjl_encode.metal
@@ -1,0 +1,56 @@
+// qjl_encode.metal
+// Extracted from veloxquant_mlx/metal/_qjl.py (_QJL_ENCODE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint flat_tg          = threadgroup_position_in_grid.x;
+    uint lane             = thread_index_in_simdgroup;
+    uint m                = uint(S_shape[0]);
+    uint d                = uint(S_shape[1]);
+    uint n_simd_per_batch = (m + 31u) / 32u;
+
+    uint b_idx    = flat_tg / n_simd_per_batch;
+    uint simd_blk = flat_tg % n_simd_per_batch;
+    uint sketch_j = simd_blk * 32u + lane;
+
+    // Dot product dot(S[sketch_j, :], x[b, :])
+    float dot_val = 0.0f;
+    if (sketch_j < m) {
+        uint S_row = sketch_j * d;
+        uint x_row = b_idx   * d;
+        for (uint i = 0; i < d; ++i) {
+            dot_val += float(S[S_row + i]) * float(x[x_row + i]);
+        }
+    }
+
+    // Norm — only simd_blk 0 computes this; all 32 lanes share work via simd_sum
+    if (simd_blk == 0) {
+        float x_sq = 0.0f;
+        uint  x_row = b_idx * d;
+        for (uint i = lane; i < d; i += 32u) {
+            float v = float(x[x_row + i]);
+            x_sq += v * v;
+        }
+        float norm_sq = simd_sum(x_sq);
+        if (lane == 0) {
+            norms[b_idx] = half(metal::sqrt(norm_sq));
+        }
+    }
+
+    // Pack 32 sign bits into 4 bytes (8 lanes → 1 byte, LSB-first)
+    uint sign_bit    = (dot_val >= 0.0f) ? 1u : 0u;
+    uint byte_in_blk = lane / 8u;
+    uint bit_in_byte = lane % 8u;
+
+    uint packed_byte = 0u;
+    for (uint bit = 0; bit < 8u; ++bit) {
+        uint src = byte_in_blk * 8u + bit;
+        packed_byte |= (simd_shuffle(sign_bit, src) << bit);
+    }
+
+    if (bit_in_byte == 0 && sketch_j < m) {
+        uint out_byte = b_idx * ((m + 7u) / 8u) + simd_blk * 4u + byte_in_blk;
+        packed_signs[out_byte] = uint8_t(packed_byte);
+    }

--- a/veloxquant_mlx/metal/src/qjl_inner_product.metal
+++ b/veloxquant_mlx/metal/src/qjl_inner_product.metal
@@ -1,0 +1,37 @@
+// qjl_inner_product.metal
+// Extracted from veloxquant_mlx/metal/_qjl.py (_QJL_INNER_PRODUCT_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    constexpr float SQRT_PI_OVER_2 = 1.2533141373155002f;
+
+    uint flat_idx = threadgroup_position_in_grid.x;
+    uint lane     = thread_index_in_simdgroup;
+    uint H        = uint(q_proj_shape[0]);
+    uint m        = uint(q_proj_shape[1]);
+    uint S_kv     = uint(norms_shape[0]);
+
+    uint h_idx = flat_idx % H;
+    uint s_idx = flat_idx / H;
+
+    float acc      = 0.0f;
+    uint  sign_row = (s_idx * H + h_idx) * ((m + 7u) / 8u);
+    uint  q_row    = h_idx * m;
+
+    for (uint chunk = lane; chunk < m; chunk += 32u) {
+        uint  byte_idx  = chunk / 8u;
+        uint  bit_pos   = chunk % 8u;
+        uint  sign_bit  = (uint(packed_signs[sign_row + byte_idx]) >> bit_pos) & 1u;
+        float sign_pm1  = (sign_bit == 1u) ? 1.0f : -1.0f;
+        acc += float(q_proj[q_row + chunk]) * sign_pm1;
+    }
+
+    float total = simd_sum(acc);
+
+    if (lane == 0) {
+        float norm  = float(norms[s_idx * H + h_idx]);
+        float scale = SQRT_PI_OVER_2 / float(m);
+        scores[h_idx * S_kv + s_idx] = half(scale * norm * total);
+    }

--- a/veloxquant_mlx/metal/src/rabitq_attend.metal
+++ b/veloxquant_mlx/metal/src/rabitq_attend.metal
@@ -1,0 +1,119 @@
+// rabitq_attend.metal
+// Extracted from veloxquant_mlx/metal/_rabitq_attend.py (_RABITQ_ATTEND_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint tg   = threadgroup_position_in_grid.x;
+    uint lane = thread_position_in_threadgroup.x;
+    uint sg   = thread_position_in_threadgroup.y;
+
+    uint B    = uint(q_shape[0]);
+    uint H    = uint(q_shape[1]);
+    uint S_q  = uint(q_shape[2]);
+    uint D    = uint(q_shape[3]);
+    uint S_kv = uint(k_bits_shape[2]);
+    (void)B;
+
+    uint sq_idx = tg % S_q;
+    uint h_idx  = (tg / S_q) % H;
+    uint b_idx  = tg / (S_q * H);
+
+    uint q_base  = ((b_idx * H + h_idx) * S_q + sq_idx) * D;
+    uint kv_base = (b_idx * H + h_idx) * S_kv;
+
+    // Binarize the query once: lane j packs byte j (little-endian bit order,
+    // q >= 0 -> bit 1, matching _pack_signs in the RaBitQ quantizer).
+    uint my_qbyte = 0u;
+    if (lane < uint(N_BYTES)) {
+        for (uint t = 0; t < 8u; ++t) {
+            float qv = float(q[q_base + lane * 8u + t]);
+            my_qbyte |= (qv >= 0.0f ? 1u : 0u) << t;
+        }
+    }
+
+    float qs = q_scale[(b_idx * H + h_idx) * S_q + sq_idx];
+
+    float running_m = -INFINITY;
+    float running_d = 0.0f;
+
+    // Per-lane output accumulator; max 8 slots (D=256, 32 lanes)
+    float my_out[8];
+    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
+    uint n_owned = (D + 31u) / 32u;
+
+    for (uint sk = sg; sk < S_kv; sk += uint(NSG_C)) {
+        // 1. Hamming distance via XOR + popcount — keys stay packed.
+        uint partial_ham = 0u;
+        if (lane < uint(N_BYTES)) {
+            uint xr = my_qbyte ^ uint(k_bits[(kv_base + sk) * uint(N_BYTES) + lane]);
+            // popcount via bit manipulation (portable across Metal versions)
+            uint v = xr;
+            v = v - ((v >> 1u) & 0x55u);
+            v = (v & 0x33u) + ((v >> 2u) & 0x33u);
+            v = (v + (v >> 4u)) & 0x0Fu;
+            partial_ham = v;
+        }
+        uint ham = simd_sum(partial_ham);
+
+        // 2. Affine score: <q, k> estimate = (D - 2*ham) * m_q * m_k + bias.
+        float score = (float(D) - 2.0f * float(ham)) * qs * k_mag[kv_base + sk]
+                    + k_const[kv_base + sk];
+
+        // 3. Online softmax update
+        float m_new  = metal::max(running_m, score);
+        float factor = metal::exp(running_m - m_new);
+        float w      = metal::exp(score     - m_new);
+        running_d    = running_d * factor + w;
+        running_m    = m_new;
+
+        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
+
+        // 4. 4-bit value codebook gather + weighted accumulate.
+        // V_PACKED is a compile-time constant, so the branch folds away:
+        // packed stores two 4-bit indices per byte (lo nibble = even dim).
+        for (uint i = lane; i < D; i += 32u) {
+            uint idx;
+            if (V_PACKED != 0) {
+                uint byte = uint(v_idx[(kv_base + sk) * (D >> 1u) + (i >> 1u)]);
+                idx = (i & 1u) ? (byte >> 4u) : (byte & 0xFu);
+            } else {
+                idx = uint(v_idx[(kv_base + sk) * D + i]);
+            }
+            float vi = v_cents[idx];
+            my_out[(i - lane) / 32u] += w * vi;
+        }
+    }
+
+    // Publish per-SIMD-group partials, then merge across SIMD-groups.
+    threadgroup float tg_m[NSG_C];
+    threadgroup float tg_d[NSG_C];
+    threadgroup float tg_out[NSG_C * MAX_D];
+
+    if (lane == 0u) {
+        tg_m[sg] = running_m;
+        tg_d[sg] = running_d;
+    }
+    for (uint i = lane; i < D; i += 32u) {
+        tg_out[sg * uint(MAX_D) + i] = my_out[(i - lane) / 32u];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float m_star = -INFINITY;
+    for (uint s = 0; s < uint(NSG_C); ++s) {
+        m_star = metal::max(m_star, tg_m[s]);
+    }
+    float d_star = 0.0f;
+    for (uint s = 0; s < uint(NSG_C); ++s) {
+        d_star += metal::exp(tg_m[s] - m_star) * tg_d[s];
+    }
+
+    uint flat = sg * 32u + lane;
+    for (uint i = flat; i < D; i += 32u * uint(NSG_C)) {
+        float acc = 0.0f;
+        for (uint s = 0; s < uint(NSG_C); ++s) {
+            acc += metal::exp(tg_m[s] - m_star) * tg_out[s * uint(MAX_D) + i];
+        }
+        out[q_base + i] = half(acc / d_star);
+    }

--- a/veloxquant_mlx/metal/src/rabitq_encode.metal
+++ b/veloxquant_mlx/metal/src/rabitq_encode.metal
@@ -1,0 +1,58 @@
+// rabitq_encode.metal
+// Extracted from veloxquant_mlx/metal/_rabitq_encode.py (_RABITQ_ENCODE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    threadgroup float buf[MAX_D];
+    threadgroup float l1_partials[32];
+
+    uint n    = threadgroup_position_in_grid.x;
+    uint lane = thread_position_in_threadgroup.x;
+    uint D    = uint(MAX_D);
+
+    // 1. Load + diagonal sign flip
+    float v = float(keys[n * D + lane]) * diag[lane];
+    buf[lane] = v;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // 2. In-place WHT: range-based parallel butterfly
+    for (uint stride = 1; stride < D; stride <<= 1) {
+        uint local    = lane % (stride << 1u);
+        bool is_upper = local >= stride;
+        uint partner  = is_upper ? (lane - stride) : (lane + stride);
+        float a = buf[lane];
+        float b = buf[partner];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        buf[lane] = is_upper ? (b - a) : (a + b);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // 3. Scale
+    float y = buf[lane] * metal::rsqrt(float(D));
+
+    // 4. Sign bits: one ballot per SIMD-group = 4 packed bytes
+    uint sg = lane / 32u;
+    uint sl = lane % 32u;
+    simd_vote ballot = simd_ballot(y >= 0.0f);
+    uint mask = uint(static_cast<simd_vote::vote_t>(ballot));
+
+    if (sl == 0u) {
+        uint start = sg * 4u;
+        for (uint j = 0u; j < 4u && (start + j) < uint(N_BYTES); ++j) {
+            k_bits[n * uint(N_BYTES) + start + j] = uint8_t((mask >> (8u * j)) & 0xFFu);
+        }
+    }
+
+    // 5. L1 magnitude: simd_sum, then combine SIMD-group partials
+    float partial = simd_sum(metal::abs(y));
+    if (sl == 0u) l1_partials[sg] = partial;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (lane == 0u) {
+        uint n_sg = (D + 31u) / 32u;
+        float total = 0.0f;
+        for (uint s = 0; s < n_sg; ++s) total += l1_partials[s];
+        k_mag[n] = total / float(D);
+    }

--- a/veloxquant_mlx/metal/src/rabitq_hamming_score.metal
+++ b/veloxquant_mlx/metal/src/rabitq_hamming_score.metal
@@ -1,0 +1,24 @@
+// rabitq_hamming_score.metal
+// Extracted from veloxquant_mlx/metal/_rabitq.py (_HAMMING_SCORE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint i = thread_position_in_grid.x;
+    if (i >= uint(N)) return;
+
+    // XOR + popcount over N_BYTES packed bytes
+    uint ham = 0u;
+    uint base = i * uint(N_BYTES);
+    for (uint b = 0; b < uint(N_BYTES); b++) {
+        uint8_t xr = qbits[b] ^ bits[base + b];
+        // popcount via bit manipulation (portable across Metal versions)
+        uint v = uint(xr);
+        v = v - ((v >> 1u) & 0x55u);
+        v = (v & 0x33u) + ((v >> 2u) & 0x33u);
+        v = (v + (v >> 4u)) & 0x0Fu;
+        ham += v;
+    }
+
+    scores[i] = float(ham) * scale[0] + Cx[i];

--- a/veloxquant_mlx/metal/src/rabitq_pack_values.metal
+++ b/veloxquant_mlx/metal/src/rabitq_pack_values.metal
@@ -1,0 +1,11 @@
+// rabitq_pack_values.metal
+// Extracted from veloxquant_mlx/metal/_rabitq_values.py (_PACK_VALUES_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint j = thread_position_in_grid.x;
+    uint lo = uint(v_idx[2u * j])     & 0xFu;
+    uint hi = uint(v_idx[2u * j + 1u]) & 0xFu;
+    packed[j] = uint8_t(lo | (hi << 4u));

--- a/veloxquant_mlx/metal/src/rabitq_prefill.metal
+++ b/veloxquant_mlx/metal/src/rabitq_prefill.metal
@@ -1,0 +1,165 @@
+// rabitq_prefill.metal
+// Extracted from veloxquant_mlx/metal/_rabitq_prefill.py (_RABITQ_PREFILL_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    constexpr uint D  = uint(MAX_D);
+    constexpr uint BQ = 8u;                                 // rows per SIMD-group
+    constexpr uint BK = 8u;                                 // kv slots per chunk
+    constexpr uint NB = uint(N_BYTES);
+
+    threadgroup half  q_tile[NSG_C * BQ * MAX_D];           // 32 scale-folded rows
+    threadgroup half  kv_tile[BK * MAX_D];                  // shared K̂, then V̂
+    threadgroup half  s_tile[NSG_C][BQ * BK];               // raw QK̂ᵀ scores
+    threadgroup half  w_tile[NSG_C][BQ * BK];               // softmax weights
+    threadgroup half  p_tile[NSG_C][BQ * BK];               // W·V̂ chunk partial
+    threadgroup float out_tile[NSG_C][BQ * MAX_D];          // running output
+    threadgroup float m_run[NSG_C][BQ];
+    threadgroup float d_run[NSG_C][BQ];
+    threadgroup float f_row[NSG_C][BQ];
+
+    uint tgx  = threadgroup_position_in_grid.x;
+    uint lane = thread_position_in_threadgroup.x;
+    uint sg   = thread_position_in_threadgroup.y;
+    uint tid  = sg * 32u + lane;
+    constexpr uint N_THREADS = 32u * uint(NSG_C);
+
+    uint B      = uint(q_shape[0]);
+    uint H      = uint(q_shape[1]);
+    uint S_q    = uint(q_shape[2]);
+    uint S_kv   = uint(k_bits_shape[2]);
+    uint BQ_TG  = uint(NSG_C) * BQ;                          // 32 rows / threadgroup
+    uint n_qblk = (S_q + BQ_TG - 1u) / BQ_TG;
+    (void)B;
+
+    uint qblk  = tgx % n_qblk;
+    uint h_idx = (tgx / n_qblk) % H;
+    uint b_idx = tgx / (n_qblk * H);
+
+    uint q_base  = ((b_idx * H + h_idx) * S_q) * D;
+    uint kv_base = (b_idx * H + h_idx) * S_kv;
+    float sc     = scale[0];
+
+    // ---- Stage the 32-row Q block (scale folded; rows past S_q zeroed) ----
+    for (uint idx = tid; idx < BQ_TG * D; idx += N_THREADS) {
+        uint gq = qblk * BQ_TG + idx / D;
+        q_tile[idx] = (gq < S_q)
+            ? half(float(q[q_base + gq * D + (idx % D)]) * sc)
+            : half(0.0f);
+    }
+    // ---- Init this sg's accumulator + softmax state ----
+    for (uint idx = lane; idx < BQ * D; idx += 32u) out_tile[sg][idx] = 0.0f;
+    if (lane < BQ) { m_run[sg][lane] = -INFINITY; d_run[sg][lane] = 0.0f; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const threadgroup half *my_q = q_tile + sg * BQ * D;
+
+    uint n_chunks = (S_kv + BK - 1u) / BK;
+    for (uint c = 0; c < n_chunks; ++c) {
+        uint s0 = c * BK;
+
+        // 1. Decode K̂ chunk ONCE, byte-wise: one byte -> 8 dims of +-m_k.
+        for (uint idx = tid; idx < BK * NB; idx += N_THREADS) {
+            uint j = idx / NB, bcol = idx % NB, slot = s0 + j;
+            uint base = j * D + bcol * 8u;
+            if (slot < S_kv) {
+                uint  byte = uint(k_bits[(kv_base + slot) * NB + bcol]);
+                float mag  = k_mag[kv_base + slot];
+                for (uint t = 0; t < 8u; ++t) {
+                    kv_tile[base + t] =
+                        half(((byte >> t) & 1u) != 0u ? mag : -mag);
+                }
+            } else {
+                for (uint t = 0; t < 8u; ++t) kv_tile[base + t] = half(0.0f);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // 2. QK̂ᵀ on the matrix units: acc(8 rows x 8 slots) over D/8 tiles.
+        simdgroup_half8x8 acc = make_filled_simdgroup_matrix<half, 8, 8>(half(0.0f));
+        for (uint kt = 0; kt < D / 8u; ++kt) {
+            simdgroup_half8x8 qf, kf;
+            simdgroup_load(qf, my_q + kt * 8u, ulong(D));
+            simdgroup_load(kf, kv_tile + kt * 8u, ulong(D), ulong2(0, 0), true);
+            simdgroup_multiply_accumulate(acc, qf, kf, acc);
+        }
+        simdgroup_store(acc, &s_tile[sg][0], ulong(BK));
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+
+        // 3. Online softmax (lanes 0..7 each own one of this sg's rows).
+        if (lane < BQ) {
+            uint r = lane;
+            float s_j[8];
+            float chunk_max = -INFINITY;
+            for (uint j = 0; j < BK; ++j) {
+                uint slot = s0 + j;
+                s_j[j] = (slot < S_kv)
+                    ? float(s_tile[sg][r * BK + j]) + k_const[kv_base + slot]
+                    : -INFINITY;
+                chunk_max = metal::max(chunk_max, s_j[j]);
+            }
+            float m_old  = m_run[sg][r];
+            float m_new  = metal::max(m_old, chunk_max);
+            float factor = metal::exp(m_old - m_new);
+            float wsum   = 0.0f;
+            for (uint j = 0; j < BK; ++j) {
+                float w = metal::exp(s_j[j] - m_new);
+                w_tile[sg][r * BK + j] = half(w);
+                wsum += w;
+            }
+            d_run[sg][r] = d_run[sg][r] * factor + wsum;
+            m_run[sg][r] = m_new;
+            f_row[sg][r] = factor;
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+
+        // 4. Rescale the running output rows by this chunk's factor.
+        for (uint idx = lane; idx < BQ * D; idx += 32u) {
+            out_tile[sg][idx] *= f_row[sg][idx / D];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // 5. Decode V̂ chunk ONCE over the same tile: one byte -> 2 dims.
+        for (uint idx = tid; idx < BK * (D >> 1u); idx += N_THREADS) {
+            uint j = idx / (D >> 1u), bcol = idx % (D >> 1u), slot = s0 + j;
+            uint base = j * D + bcol * 2u;
+            if (slot < S_kv) {
+                uint byte = uint(v_idx[(kv_base + slot) * (D >> 1u) + bcol]);
+                kv_tile[base]      = half(v_cents[byte & 0xFu]);
+                kv_tile[base + 1u] = half(v_cents[byte >> 4u]);
+            } else {
+                kv_tile[base]      = half(0.0f);
+                kv_tile[base + 1u] = half(0.0f);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // 6. W·V̂ on the matrix units, per 8-column block; chunk partials
+        //    (8-term dots, safe in half) accumulate into the float tile.
+        for (uint dt = 0; dt < D / 8u; ++dt) {
+            simdgroup_half8x8 wf, vf;
+            simdgroup_half8x8 pacc = make_filled_simdgroup_matrix<half, 8, 8>(half(0.0f));
+            simdgroup_load(wf, &w_tile[sg][0], ulong(BK));
+            simdgroup_load(vf, kv_tile + dt * 8u, ulong(D));
+            simdgroup_multiply_accumulate(pacc, wf, vf, pacc);
+            simdgroup_store(pacc, &p_tile[sg][0], ulong(BK));
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+            for (uint idx = lane; idx < BQ * BK; idx += 32u) {
+                uint r = idx / BK, dc = idx % BK;
+                out_tile[sg][r * D + dt * 8u + dc] += float(p_tile[sg][idx]);
+            }
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // ---- Each SIMD-group owns distinct rows — write them out directly ----
+    for (uint idx = lane; idx < BQ * D; idx += 32u) {
+        uint r  = idx / D;
+        uint gq = qblk * BQ_TG + sg * BQ + r;
+        if (gq >= S_q) continue;
+        out[q_base + gq * D + (idx % D)] =
+            half(out_tile[sg][idx] / d_run[sg][r]);
+    }

--- a/veloxquant_mlx/metal/src/rvq_attend_fused.metal
+++ b/veloxquant_mlx/metal/src/rvq_attend_fused.metal
@@ -1,0 +1,80 @@
+// rvq_attend_fused.metal
+// Extracted from veloxquant_mlx/metal/_rvq_attend.py (_FUSED_RVQ_ATTEND_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    constexpr int N_CENTS1  = 1 << B_BITS1;
+    constexpr int N_CENTS2  = 1 << B_BITS2;
+    constexpr int N_CENTS_V = 1 << B_BITS_V;
+
+    uint tg      = threadgroup_position_in_grid.x;
+    uint tg_lane = thread_position_in_threadgroup.x;
+
+    uint B     = uint(q_shape[0]);
+    uint H     = uint(q_shape[1]);
+    uint S_q   = uint(q_shape[2]);
+    uint D     = uint(q_shape[3]);
+    uint S_kv  = uint(k_indices1_shape[2]);
+    uint V_SUB = uint(v_codebook_shape[1]);
+    uint n_sub_v = D / V_SUB;
+
+    uint sq_idx = tg % S_q;
+    uint h_idx  = (tg / S_q) % H;
+    uint b_idx  = tg / (S_q * H);
+
+    float inv_sqrt_d = metal::rsqrt(float(D));
+    uint  TG         = threads_per_threadgroup.x;
+
+    float running_m = -INFINITY;
+    float running_d = 0.0f;
+
+    // Per-lane output accumulator; max 8 slots (D=256, TG=32)
+    float my_out[8];
+    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
+    uint n_owned = (D + TG - 1) / TG;
+
+    uint q_base    = ((b_idx * H + h_idx) * S_q + sq_idx) * D;
+    uint k_base_bh = (b_idx * H + h_idx) * S_kv;
+    uint v_base_bh = (b_idx * H + h_idx) * S_kv;
+
+    for (uint sk = 0; sk < S_kv; ++sk) {
+        // Decode key + partial dot product (each lane covers its strided dims)
+        float partial_dot = 0.0f;
+        for (uint i = tg_lane; i < D; i += TG) {
+            uint  k_off = (k_base_bh + sk) * D + i;
+            float ki    = centroids1[uint(k_indices1[k_off])]
+                        + centroids2[uint(k_indices2[k_off])];
+            partial_dot += float(q[q_base + i]) * ki;
+        }
+        float score = simd_sum(partial_dot) * inv_sqrt_d;
+
+        // Online softmax update
+        float m_new  = metal::max(running_m, score);
+        float factor = metal::exp(running_m - m_new);
+        float w      = metal::exp(score     - m_new);
+        running_d    = running_d * factor + w;
+        running_m    = m_new;
+
+        // Rescale accumulated output
+        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
+
+        // Decode value + weighted accumulate
+        for (uint i = tg_lane; i < D; i += TG) {
+            uint  sub_i  = i / V_SUB;
+            uint  comp_i = i % V_SUB;
+            uint  v_off  = (v_base_bh + sk) * n_sub_v + sub_i;
+            uint  cb_off = uint(v_indices[v_off]) * V_SUB + comp_i;
+            float vi     = float(v_codebook[cb_off]);
+            uint  out_i  = (i - tg_lane) / TG;
+            my_out[out_i] += w * vi;
+        }
+    }
+
+    // Normalize and write
+    for (uint i = tg_lane; i < D; i += TG) {
+        uint out_i   = (i - tg_lane) / TG;
+        uint out_off = ((b_idx * H + h_idx) * S_q + sq_idx) * D + i;
+        out[out_off] = half(my_out[out_i] / running_d);
+    }

--- a/veloxquant_mlx/metal/src/scalar_affine_attend.metal
+++ b/veloxquant_mlx/metal/src/scalar_affine_attend.metal
@@ -1,0 +1,107 @@
+// scalar_affine_attend.metal
+// Extracted from veloxquant_mlx/metal/_scalar_attend.py (_SCALAR_AFFINE_ATTEND_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint tg   = threadgroup_position_in_grid.x;
+    uint lane = thread_position_in_threadgroup.x;
+    uint sg   = thread_position_in_threadgroup.y;
+
+    uint B    = uint(q_shape[0]);
+    uint H    = uint(q_shape[1]);
+    uint S_q  = uint(q_shape[2]);
+    uint D    = uint(q_shape[3]);
+    uint S_kv = uint(k_codes_shape[2]);
+    uint GK   = uint(k_scale_shape[2]);   // key groups along tokens
+    uint GV   = uint(v_scale_shape[3]);   // value groups along channels
+    (void)B;
+
+    uint G        = uint(gsize[0]);       // group size
+    float scale   = scale_arr[0];
+    uint  NSG     = uint(NSG_C);
+
+    uint sq_idx = tg % S_q;
+    uint h_idx  = (tg / S_q) % H;
+    uint b_idx  = tg / (S_q * H);
+
+    uint q_base   = ((b_idx * H + h_idx) * S_q + sq_idx) * D;
+    uint bh       = b_idx * H + h_idx;
+
+    // ----- per-lane online-softmax state for this SIMD-group -----
+    float running_m = -INFINITY;
+    float running_d = 0.0f;
+    float my_out[8];                       // D/32 <= 256/32 = 8
+    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
+    uint n_owned = (D + 31u) / 32u;
+
+    // ----- main loop: this SIMD-group strides kv by NSG -----
+    for (uint sk = sg; sk < S_kv; sk += NSG) {
+        // key group index along tokens for this slot
+        uint kg = sk / G;
+
+        // partial dot product over lane-owned dims
+        float partial_dot = 0.0f;
+        for (uint d = lane; d < D; d += 32u) {
+            uint  code_off = (bh * S_kv + sk) * D + d;
+            uint  ks_off   = (bh * GK + kg) * D + d;
+            float k_hat = float(k_codes[code_off]) * k_scale[ks_off]
+                        + k_zero[ks_off];
+            partial_dot += float(q[q_base + d]) * k_hat;
+        }
+        float score = simd_sum(partial_dot) * scale;
+
+        // online softmax update (every lane holds identical score)
+        float m_new  = metal::max(running_m, score);
+        float factor = metal::exp(running_m - m_new);
+        float w      = metal::exp(score      - m_new);
+        running_d    = running_d * factor + w;
+        running_m    = m_new;
+        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
+
+        // value decode + weighted accumulate (per-token groups over channels)
+        for (uint d = lane; d < D; d += 32u) {
+            uint  vg      = d / G;
+            uint  code_off = (bh * S_kv + sk) * D + d;
+            uint  vs_off   = (bh * S_kv + sk) * GV + vg;
+            float v_hat = float(v_codes[code_off]) * v_scale[vs_off]
+                        + v_zero[vs_off];
+            uint  out_i = (d - lane) / 32u;
+            my_out[out_i] += w * v_hat;
+        }
+    }
+
+    // ----- merge the NSG partial softmaxes through threadgroup memory -----
+    // sh_o layout: [NSG_C][8][32]  (SIMD-group, owned-slot, lane).
+    threadgroup float sh_m[NSG_C];         // one slot per SIMD-group
+    threadgroup float sh_d[NSG_C];
+    threadgroup float sh_o[NSG_C * 8 * 32];
+
+    // stash this SIMD-group's per-lane partials
+    for (uint i = 0; i < n_owned; ++i) {
+        sh_o[(sg * 8u + i) * 32u + lane] = my_out[i];
+    }
+    if (lane == 0) { sh_m[sg] = running_m; sh_d[sg] = running_d; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // SIMD-group 0 reduces across all groups
+    if (sg == 0) {
+        float gm = -INFINITY;
+        for (uint s = 0; s < NSG; ++s) gm = metal::max(gm, sh_m[s]);
+        float gd = 0.0f;
+        for (uint s = 0; s < NSG; ++s) gd += sh_d[s] * metal::exp(sh_m[s] - gm);
+
+        for (uint i = 0; i < n_owned; ++i) {
+            float acc = 0.0f;
+            for (uint s = 0; s < NSG; ++s) {
+                acc += sh_o[(s * 8 + i) * 32 + lane]
+                     * metal::exp(sh_m[s] - gm);
+            }
+            uint d = lane + i * 32u;
+            if (d < D) {
+                uint out_off = ((b_idx * H + h_idx) * S_q + sq_idx) * D + d;
+                out[out_off] = half(acc / gd);
+            }
+        }
+    }

--- a/veloxquant_mlx/metal/src/scalar_dequantize.metal
+++ b/veloxquant_mlx/metal/src/scalar_dequantize.metal
@@ -1,0 +1,9 @@
+// scalar_dequantize.metal
+// Extracted from veloxquant_mlx/metal/_scalar_quant.py (_SCALAR_DEQUANTIZE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint elem    = thread_position_in_grid.x;
+    x_hat[elem]  = half(centroids[uint(indices[elem])]);

--- a/veloxquant_mlx/metal/src/scalar_quantize.metal
+++ b/veloxquant_mlx/metal/src/scalar_quantize.metal
@@ -1,0 +1,20 @@
+// scalar_quantize.metal
+// Extracted from veloxquant_mlx/metal/_scalar_quant.py (_SCALAR_QUANTIZE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    constexpr int N_CENTS = 1 << B_BITS;
+
+    uint  elem     = thread_position_in_grid.x;
+    float val      = float(x[elem]);
+    int   best     = 0;
+    float best_dist = INFINITY;
+
+    for (int j = 0; j < N_CENTS; ++j) {
+        float d    = val - centroids[j];
+        float dist = d * d;
+        if (dist < best_dist) { best_dist = dist; best = j; }
+    }
+    indices[elem] = uint8_t(best);

--- a/veloxquant_mlx/metal/src/vecinfer_dequant.metal
+++ b/veloxquant_mlx/metal/src/vecinfer_dequant.metal
@@ -1,0 +1,19 @@
+// vecinfer_dequant.metal
+// Extracted from veloxquant_mlx/metal/_vecinfer.py (_DEQUANT_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint flat_idx = thread_position_in_grid.x;
+    uint N_total  = indices_shape[0];
+    if (flat_idx >= N_total) return;
+
+    uint sub_dim  = codebook_shape[1];
+    uint code_idx = indices[flat_idx];
+    uint cb_base  = code_idx * sub_dim;
+    uint out_base = flat_idx * sub_dim;
+
+    for (uint i = 0; i < sub_dim; ++i) {
+        out[out_base + i] = codebook[cb_base + i];
+    }

--- a/veloxquant_mlx/metal/src/vecinfer_encode_decode_full.metal
+++ b/veloxquant_mlx/metal/src/vecinfer_encode_decode_full.metal
@@ -1,0 +1,104 @@
+// vecinfer_encode_decode_full.metal
+// Extracted from veloxquant_mlx/metal/_vecinfer.py (_ENCODE_DECODE_FULL_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    threadgroup float buf_in[MAX_D];
+    threadgroup float buf_tg[MAX_D];
+    threadgroup uint  idx[MAX_N_SUB];
+
+    uint tg_idx  = threadgroup_position_in_grid.x;
+    uint lane    = thread_position_in_threadgroup.x;
+
+    uint H           = params[1];
+    uint S           = params[2];
+    uint D           = params[3];
+    uint n_sub       = params[4];
+    uint sub_dim     = params[5];
+    uint n_cents     = params[6];
+    uint has_smooth  = params[7];
+    uint smooth_rows = params[8];
+
+    uint s_idx = tg_idx % S;
+    uint h_idx = (tg_idx / S) % H;
+    uint b_idx = tg_idx / (S * H);
+
+    uint key_base    = ((b_idx * H + h_idx) * S + s_idx) * D;
+    uint smooth_base = (has_smooth ? (h_idx % smooth_rows) * D : 0);
+
+    // Phase A: load + optional smooth divide
+    float val = float(keys[key_base + lane]);
+    if (has_smooth) {
+        float s = float(smooth[smooth_base + lane]);
+        val = (s > 1e-8f) ? val / s : val;
+    }
+    buf_in[lane] = val;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase B: WHT via matvec — thread lane computes dot(H_mat[lane, :], buf_in)
+    {
+        float dot = 0.0f;
+        uint row_base = lane * D;
+        for (uint c = 0; c < D; ++c) {
+            dot += float(H_mat[row_base + c]) * buf_in[c];
+        }
+        buf_tg[lane] = dot;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase C: quantize — one leader per sub-vector scans all centroids
+    uint my_sub  = lane / sub_dim;
+    uint my_comp = lane % sub_dim;
+
+    if (my_comp == 0 && my_sub < n_sub) {
+        float best_dist = INFINITY;
+        uint  best_c    = 0;
+        uint  x_off     = my_sub * sub_dim;
+
+        for (uint c = 0; c < n_cents; ++c) {
+            float dist    = 0.0f;
+            uint  cb_base = c * sub_dim;
+            for (uint i = 0; i < sub_dim; ++i) {
+                float d = buf_tg[x_off + i] - float(k_codebook[cb_base + i]);
+                dist += d * d;
+            }
+            if (dist < best_dist) { best_dist = dist; best_c = c; }
+        }
+        idx[my_sub] = best_c;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase D: dequantize — gather winning centroid into buf_in
+    {
+        uint c       = idx[my_sub];
+        uint cb_base = c * sub_dim;
+        buf_in[lane] = float(k_codebook[cb_base + my_comp]);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase E: inv-WHT — H_mat.T[lane, c] = H_mat[c, lane]
+    {
+        float dot = 0.0f;
+        for (uint c = 0; c < D; ++c) {
+            dot += float(H_mat[c * D + lane]) * buf_in[c];
+        }
+        buf_tg[lane] = dot;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase F: inverse smooth multiply
+    float out_val = buf_tg[lane];
+    if (has_smooth) {
+        float s = float(smooth[smooth_base + lane]);
+        out_val *= s;
+    }
+
+    // Phase G: write outputs
+    k_hat_out[key_base + lane] = half(out_val);
+
+    if (my_comp == 0 && my_sub < n_sub) {
+        uint idx_base = ((b_idx * H + h_idx) * S + s_idx) * n_sub;
+        idx_out[idx_base + my_sub] = idx[my_sub];
+    }

--- a/veloxquant_mlx/metal/src/vecinfer_encode_decode_simple.metal
+++ b/veloxquant_mlx/metal/src/vecinfer_encode_decode_simple.metal
@@ -1,0 +1,63 @@
+// vecinfer_encode_decode_simple.metal
+// Extracted from veloxquant_mlx/metal/_vecinfer.py (_ENCODE_DECODE_SIMPLE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    threadgroup float buf[MAX_D];
+    threadgroup uint  idx[MAX_N_SUB];
+
+    uint tg_idx  = threadgroup_position_in_grid.x;
+    uint lane    = thread_position_in_threadgroup.x;
+
+    uint H       = params[1];
+    uint S       = params[2];
+    uint D       = params[3];
+    uint n_sub   = params[4];
+    uint sub_dim = params[5];
+    uint n_cents = params[6];
+
+    uint s_idx = tg_idx % S;
+    uint h_idx = (tg_idx / S) % H;
+    uint b_idx = tg_idx / (S * H);
+
+    uint val_base = ((b_idx * H + h_idx) * S + s_idx) * D;
+
+    buf[lane] = float(values[val_base + lane]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    uint my_sub  = lane / sub_dim;
+    uint my_comp = lane % sub_dim;
+
+    if (my_comp == 0 && my_sub < n_sub) {
+        float best_dist = INFINITY;
+        uint  best_c    = 0;
+        uint  x_off     = my_sub * sub_dim;
+
+        for (uint c = 0; c < n_cents; ++c) {
+            float dist    = 0.0f;
+            uint  cb_base = c * sub_dim;
+            for (uint i = 0; i < sub_dim; ++i) {
+                float d = buf[x_off + i] - float(v_codebook[cb_base + i]);
+                dist += d * d;
+            }
+            if (dist < best_dist) { best_dist = dist; best_c = c; }
+        }
+        idx[my_sub] = best_c;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (my_sub < n_sub) {
+        uint c       = idx[my_sub];
+        uint cb_base = c * sub_dim;
+        buf[lane] = float(v_codebook[cb_base + my_comp]);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    v_hat_out[val_base + lane] = half(buf[lane]);
+
+    if (my_comp == 0 && my_sub < n_sub) {
+        uint idx_base = ((b_idx * H + h_idx) * S + s_idx) * n_sub;
+        idx_out[idx_base + my_sub] = idx[my_sub];
+    }

--- a/veloxquant_mlx/metal/src/vecinfer_quantize.metal
+++ b/veloxquant_mlx/metal/src/vecinfer_quantize.metal
@@ -1,0 +1,28 @@
+// vecinfer_quantize.metal
+// Extracted from veloxquant_mlx/metal/_vecinfer.py (_QUANTIZE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+
+    uint vec_idx = thread_position_in_grid.x;
+    uint N_total = x_shape[0];
+    if (vec_idx >= N_total) return;
+
+    uint n_centroids = codebook_shape[0];
+    uint sub_dim     = codebook_shape[1];
+    uint x_base      = vec_idx * sub_dim;
+
+    float best_dist = INFINITY;
+    uint  best_idx  = 0;
+
+    for (uint c = 0; c < n_centroids; ++c) {
+        uint  cb_base = c * sub_dim;
+        float dist    = 0.0f;
+        for (uint i = 0; i < sub_dim; ++i) {
+            float d = float(x[x_base + i]) - float(codebook[cb_base + i]);
+            dist += d * d;
+        }
+        if (dist < best_dist) { best_dist = dist; best_idx = c; }
+    }
+    out[vec_idx] = best_idx;


### PR DESCRIPTION
## Summary

Closes #64. Per the [spike posted on the issue](https://github.com/rajveer43/VeloxQuant-MLX/issues/64#issuecomment-5227105639): `mx.fast.metal_kernel` (mlx==0.32.0, the pinned version) only accepts an inline `source: str` — there's no file-path or `.metallib` loading API on the Metal side (`mx.metal` has no kernel-loading functions; `mx.fast.precompiled_cuda_kernel` is CUDA-only and experimental, with no Metal counterpart). So this migration is a text-asset read at import time, **not** a build-step change — MLX still JIT-compiles the same source string at call time exactly as before.

- Extracted all 19 `_..._SRC = r"""..."""` MSL blocks (13 files) into standalone `.metal` files under `veloxquant_mlx/metal/src/`.
- Each Python wrapper now does `_SRC = _read_kernel_source("<name>.metal")`, a small helper that does `(Path(__file__).parent / "src" / filename).read_text()`.
- Algorithm/memory-layout/threadgroup-strategy documentation stays in the Python docstrings and inline comments right next to each `_read_kernel_source()` call — only the raw MSL body moved, so the docs stay co-located with the dispatch/binding logic that references them.
- Added `[tool.setuptools.package-data]` to `pyproject.toml` so the `.metal` files ship inside the wheel (there was no `MANIFEST.in`/package-data config before, so without this the files would silently be missing from `pip install`).

## Verification

- Every one of the 20 extracted `.metal` files is byte-identical to its original inline string (scripted comparison against `master`).
- Built the wheel locally (`python -m build --wheel`) and confirmed all 20 `.metal` files are present under `veloxquant_mlx/metal/src/` inside it.
- `uvx ruff check` / `--format --check`: only pre-existing findings remain (verified against `master`) — `_comm_vq.py`'s unused `TG`, and `Optional` → `X | None` in `_vecinfer.py`/`fused_sdpa.py`. No new findings.
- Full test suite: 1751 passed, 1 skipped, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method`, missing `import pytest`, present on `master` too). Every kernel JIT-compiles and runs correctly from its new file-backed source — this exercises the actual GPU dispatch path for all 19 kernels, not just an import check.

## Test plan

- [x] `pytest veloxquant_mlx/tests` — 1751 passed / 1 skipped / 1 pre-existing failure
- [x] `python -m build --wheel` + unzip check — all `.metal` files present in the wheel
- [x] `ruff check` / `ruff format --check` — no new findings vs. master