### PR TITLE
fix: SortedChannelIndex.top_k() returns duplicate channels on equal-value re-insert

### DIFF
--- a/veloxquant_mlx/dsa/heap.py
+++ b/veloxquant_mlx/dsa/heap.py
@@ -123,25 +123,36 @@ class SortedChannelIndex:
     """
 
     def __init__(self) -> None:
+        # Heap entries are (magnitude, (channel_idx, version)) so that
+        # re-insertions with an unchanged magnitude can still be told apart
+        # from the live entry by version rather than by value equality.
         self._heap: MaxHeap = MaxHeap()
-        # channel_idx -> current magnitude (for dedup / update)
-        self._magnitudes: dict[int, float] = {}
-        # channel_idx -> list of heap positions (lazy deletion)
-        # We use a "lazy" deletion strategy: outdated entries are ignored on pop.
-        self._valid: dict[int, float] = {}  # channel_idx -> latest magnitude
+        # channel_idx -> (latest magnitude, latest version) — used to
+        # recognize which heap entry for a channel is still live (lazy
+        # deletion) and to skip redundant re-inserts of unchanged values.
+        self._valid: dict[int, tuple[float, int]] = {}
+        self._next_version: int = 0
 
     def insert(self, channel_idx: int, magnitude: float) -> None:
         """Insert or update a channel's magnitude.
 
         If the channel already exists, the magnitude is updated (old entry
-        is lazily invalidated).
+        is lazily invalidated). Re-inserting the same magnitude for a
+        channel that already holds it is a no-op — this keeps the heap
+        bounded at O(number of distinct channels observed) instead of
+        growing by one entry per call.
 
         Args:
             channel_idx: Index of the channel (0-indexed).
             magnitude: Non-negative magnitude value.
         """
-        self._valid[channel_idx] = magnitude
-        self._heap.push(magnitude, channel_idx)
+        current = self._valid.get(channel_idx)
+        if current is not None and current[0] == magnitude:
+            return
+        version = self._next_version
+        self._next_version += 1
+        self._valid[channel_idx] = (magnitude, version)
+        self._heap.push(magnitude, (channel_idx, version))
 
     def update(self, channel_idx: int, new_magnitude: float) -> None:
         """Update the magnitude of an existing channel.
@@ -169,19 +180,23 @@ class SortedChannelIndex:
         """
         if k <= 0:
             return []
-        # Collect valid top-k by draining lazily and re-inserting
-        collected: List[Tuple[float, int]] = []
         result: List[int] = []
-        temp_heap = MaxHeap()
+        seen: set[int] = set()
 
         # Copy the heap data to a temporary structure to avoid mutation
         heap_copy = MaxHeap()
         heap_copy._data = list(self._heap._data)
 
         while len(heap_copy) > 0 and len(result) < k:
-            mag, ch = heap_copy.pop()
-            # Lazy deletion: skip if magnitude no longer current
-            if self._valid.get(ch) == mag:
+            mag, (ch, version) = heap_copy.pop()
+            # Lazy deletion: skip if this exact (magnitude, version) is no
+            # longer the live entry for the channel. Comparing by version
+            # (not just magnitude) means a re-insert with an unchanged
+            # value can never masquerade as a second, distinct live entry.
+            if ch in seen:
+                continue
+            if self._valid.get(ch) == (mag, version):
+                seen.add(ch)
                 result.append(ch)
 
         return result

--- a/veloxquant_mlx/tests/dsa/test_heap.py
+++ b/veloxquant_mlx/tests/dsa/test_heap.py
@@ -89,3 +89,40 @@ class TestSortedChannelIndex:
             idx.insert(ch, float(ch))
         top4 = idx.top_k(4)
         assert set(top4) == {124, 125, 126, 127}
+
+    def test_top_k_no_duplicates_on_reinsert_same_magnitude(self) -> None:
+        """Regression test for #66: re-inserting a channel with a magnitude
+        equal to its current live value must not produce a duplicate in
+        top_k, and must not displace a genuinely-distinct channel."""
+        idx = SortedChannelIndex()
+        magnitudes = [1.0, 5.0, 5.0, 2.0, 0.5]
+        for _ in range(3):
+            for ch, mag in enumerate(magnitudes):
+                idx.insert(ch, mag)
+        top3 = idx.top_k(3)
+        assert len(top3) == len(set(top3)) == 3
+        assert set(top3) == {1, 2, 3}  # magnitudes 5.0, 5.0, 2.0
+
+    def test_repeated_identical_inserts_do_not_grow_heap(self) -> None:
+        """Regression test for #66: re-inserting unchanged magnitudes must
+        not grow the heap unboundedly."""
+        idx = SortedChannelIndex()
+        n_channels = 16
+        for _ in range(10):
+            for ch in range(n_channels):
+                idx.insert(ch, float(ch))
+        assert len(idx._heap) == n_channels
+        assert len(idx) == n_channels
+
+    def test_changing_magnitudes_still_dedup_top_k(self) -> None:
+        """Updates with genuinely new magnitudes must still be reflected
+        correctly in top_k, with no duplicate channels, even though the
+        heap retains stale entries via lazy deletion."""
+        idx = SortedChannelIndex()
+        idx.insert(0, 1.0)
+        idx.insert(1, 2.0)
+        idx.insert(0, 3.0)  # channel 0 updated to a new, higher magnitude
+        idx.insert(0, 3.0)  # redundant re-insert, should be a no-op
+        top2 = idx.top_k(2)
+        assert len(top2) == len(set(top2)) == 2
+        assert top2[0] == 0  # channel 0 now highest at 3.0

--- a/veloxquant_mlx/tests/outlier/__init__.py
+++ b/veloxquant_mlx/tests/outlier/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/veloxquant_mlx/tests/outlier/test_detector.py
+++ b/veloxquant_mlx/tests/outlier/test_detector.py
@@ -1,0 +1,53 @@
+"""Tests for OutlierDetector."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from veloxquant_mlx.outlier.detector import OutlierDetector
+
+
+class TestOutlierDetector:
+    def test_get_outlier_channels_are_distinct(self) -> None:
+        """Regression test for #66: repeated identical observations must not
+        cause SortedChannelIndex to return duplicate channel indices, which
+        would silently drop a genuine outlier channel from the selection."""
+        det = OutlierDetector(n_outliers=3, n_calib=1)
+        k = np.array([1.0, 5.0, 5.0, 2.0, 0.5], dtype=np.float32)
+        det.observe(k)
+        det.observe(k)
+        det.observe(k)
+
+        channels = det.get_outlier_channels()
+        assert len(channels) == len(set(channels.tolist())) == 3
+        # Magnitudes are [1.0, 5.0, 5.0, 2.0, 0.5] -> top 3 are channels 1, 2, 3.
+        assert set(channels.tolist()) == {1, 2, 3}
+
+    def test_calibration_and_reset(self) -> None:
+        det = OutlierDetector(n_outliers=2, n_calib=3)
+        k = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+        assert not det.is_calibrated
+        det.observe(k)
+        det.observe(k)
+        assert not det.is_calibrated
+        det.observe(k)
+        assert det.is_calibrated
+        assert det.n_observed == 3
+
+        det.reset()
+        assert not det.is_calibrated
+        assert det.n_observed == 0
+
+    def test_repeated_observations_bound_heap_growth(self) -> None:
+        """Regression test for #66: the underlying heap must not grow
+        unboundedly when the same (or unchanged-mean) vectors are observed
+        repeatedly."""
+        det = OutlierDetector(n_outliers=4, n_calib=1)
+        d = 16
+        k = np.arange(d, dtype=np.float32)
+        for _ in range(20):
+            det.observe(k)
+        # Running mean of an identical vector is constant after the first
+        # observation, so re-inserts should be no-ops and the heap should
+        # stay at d entries, not grow to 20 * d.
+        assert len(det._index._heap) == d


### PR DESCRIPTION
## Summary

Fixes #66 — two bugs in `SortedChannelIndex` (`veloxquant_mlx/dsa/heap.py`), both rooted in lazy-deletion staleness being detected by **magnitude equality alone**:

1. **Duplicate channels in `top_k()`** — `OutlierDetector.observe()` re-inserts every channel's running-mean magnitude on every observed token (detector.py:51-52). If a re-insert happens to match the channel's current live magnitude (trivially likely with repeated/padding tokens or ties), the heap ends up with multiple entries that all satisfy `_valid.get(ch) == mag`, so `top_k()` appends the same channel more than once — silently displacing a genuinely distinct, lower-ranked channel from the outlier selection.
2. **Unbounded heap growth** — every `insert()` pushed a new entry regardless of whether the value actually changed, so the heap grew by `d` entries per observation indefinitely (confirmed: 10 rounds × 16 channels → 160 heap entries instead of 16).

## Fix

- Tag each heap entry with a monotonically increasing `version` and store `(magnitude, version)` in `_valid`. `top_k()` now only accepts an entry whose `(magnitude, version)` exactly matches the live value for that channel — equal-value re-inserts can no longer be mistaken for a second live entry.
- Skip the `push` entirely when `insert()` is called with a magnitude unchanged from the channel's current value, keeping the heap bounded at O(distinct channels observed) for the common case (repeated/converged values) instead of growing per-call regardless of whether anything changed.

Both changes are internal to `SortedChannelIndex` — `insert`/`update`/`top_k`/`len` signatures are unchanged, and it's only consumed via that public API elsewhere in the codebase, so no other call sites needed changes.

## Test plan

- Added regression tests to `veloxquant_mlx/tests/dsa/test_heap.py`:
  - `test_top_k_no_duplicates_on_reinsert_same_magnitude` — reproduces the issue's exact repro shape at the heap level.
  - `test_repeated_identical_inserts_do_not_grow_heap` — confirms heap size stays bounded across repeated identical inserts.
  - `test_changing_magnitudes_still_dedup_top_k` — confirms genuinely-changing values still update correctly and top_k stays duplicate-free.
- Added `veloxquant_mlx/tests/outlier/test_detector.py` (new dir, no prior tests existed for `OutlierDetector`):
  - `test_get_outlier_channels_are_distinct` — the issue's repro run through the real `OutlierDetector` caller, confirms `[1 2 3]` (previously `[1 2 2]`).
  - `test_repeated_observations_bound_heap_growth` — confirms the heap stays bounded through the detector's real calling pattern.
  - `test_calibration_and_reset` — basic coverage for `is_calibrated`/`reset`, previously untested.
- Full suite: 1758 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py`, missing `import pytest`, unrelated to this change).
- `ruff check`/`ruff format` clean on all changed/new files; pre-existing lint findings in `heap.py` (deprecated `typing.List`/`Tuple` usage, `E741` ambiguous `l`) predate this change and were left untouched — two pre-existing `F841` unused-variable findings were incidentally removed as dead code during the `top_k()` rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)