### PR TITLE
docs: document the veloxquant_mlx/tests vs tests/non_metal split

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,13 @@ against the pure-MLX path). Seed all randomness: determinism is treated as a
 correctness requirement.
 
 End-to-end `mlx_lm` generation benches require Apple Silicon and are run
-locally. CI may run unit tests that do not need Metal; see
-`docs/CI_AND_TESTING.md` once present.
+locally.
+
+The repo has two, deliberately separate test directories —
+`veloxquant_mlx/tests/` (MLX-dependent, requires Apple Silicon) and
+`tests/non_metal/` (pure Python, MLX-free, runs on plain Linux CI). See
+[`docs/CI_AND_TESTING.md`](docs/CI_AND_TESTING.md#two-test-directories-and-why)
+for why the split exists and which one a new test belongs in.
 
 ## Submitting changes
 

--- a/docs/CI_AND_TESTING.md
+++ b/docs/CI_AND_TESTING.md
@@ -3,11 +3,56 @@
 VeloxQuant-MLX targets **Apple Silicon** (M1+). End-to-end `mlx_lm`
 generation and Metal kernel parity tests need a real Mac GPU.
 
+## Two test directories, and why
+
+The repo has two, separately-run test trees:
+
+| Directory | Suite | Runner | Run via |
+| --- | --- | --- | --- |
+| `veloxquant_mlx/tests/` | Main suite (MLX-dependent) | `macos-14` (Apple Silicon) | `pytest` (`testpaths` in `pyproject.toml`) |
+| `tests/non_metal/` | Pure-Python, MLX-free tests | `ubuntu-latest` | `.github/workflows/non-metal-unit.yml` |
+
+This split is **intentional, not a stray duplicate** — do not merge the two
+directories or delete `tests/non_metal/` as "cleanup."
+
+**Why `tests/non_metal/` has to live outside `veloxquant_mlx/`:** collecting
+any module under `veloxquant_mlx/` triggers `veloxquant_mlx/__init__.py`,
+which imports `mlx`. `mlx` only installs/runs on Apple Silicon, so any test
+file under `veloxquant_mlx/tests/` requires the expensive `macos-14` runner
+just to be *collected*, even if the test itself never touches MLX. Modules
+that are genuinely pure Python (e.g. `veloxquant_mlx/tools/mac_recommender.py`,
+a RAM/method recommender with no MLX dependency) can still get fast, cheap
+CI coverage by keeping their tests in `tests/non_metal/` instead, loaded via
+`importlib.util.spec_from_file_location` (not a normal import) specifically
+to avoid pulling in `veloxquant_mlx/__init__.py`'s import chain. This keeps
+`non-metal-unit.yml` running on a plain `ubuntu-latest` runner with no `mlx`
+install at all.
+
+`pyproject.toml`'s `testpaths = ["veloxquant_mlx/tests"]` means a plain
+`pytest` invocation at the repo root never picks up `tests/non_metal/` — only
+the dedicated `non-metal-unit` workflow does, with explicit isolation flags
+(`--noconftest --import-mode=importlib -c /dev/null -o addopts=`) so it
+doesn't pick up the project's own pytest config.
+
+**When adding a new test, choose based on the module under test, not the
+test's own content:**
+
+- If the module you're testing imports `mlx` (directly or transitively,
+  including anything under `veloxquant_mlx/` that isn't leaf-level pure
+  Python) → `veloxquant_mlx/tests/`.
+- If the module is genuinely pure Python with **no** MLX dependency (a CLI
+  tool, config parser, recommender, etc.) → consider adding it to
+  `tests/non_metal/` as well (or instead, if it has no MLX-dependent
+  behavior to test) so it gets cheap, fast Linux coverage. Follow the
+  `importlib.util.spec_from_file_location` loading pattern in
+  `tests/non_metal/test_mac_recommender.py` to avoid importing
+  `veloxquant_mlx/__init__.py`.
+
 ## What should run where
 
 | Suite | Where | Notes |
 | --- | --- | --- |
-| Pure Python unit tests (no Metal) | Linux CI or macOS CI | Examples: `tests/non_metal/test_mac_recommender.py`, many quantizer math tests |
+| Pure Python unit tests (no Metal) | Linux CI (`non-metal-unit.yml`) or macOS CI | Examples: `tests/non_metal/test_mac_recommender.py`, many quantizer math tests under `veloxquant_mlx/tests/` |
 | Metal parity / kernel tests | Apple Silicon only | Skip or mark `metal` on headless/Linux runners |
 | End-to-end generation benches | Local macOS | Scripts under `benchmark_scripts/` and `scripts/validate_kv_memory.py` |
 
@@ -21,7 +66,5 @@ generation and Metal kernel parity tests need a real Mac GPU.
 
 ## Suggested follow-up CI (not required for Phase 1)
 
-- A workflow that runs a **non-Metal** pytest selection on Linux (lint + pure
-  Python modules).
 - Document `pytest -m "not metal"` once Metal tests are consistently marked.
 - Keep release publishing (PyPI) separate from e2e benches.

--- a/tests/non_metal/test_mac_recommender.py
+++ b/tests/non_metal/test_mac_recommender.py
@@ -1,4 +1,8 @@
-"""Unit tests for the Mac / RAM method recommender (no MLX required)."""
+"""Unit tests for the Mac / RAM method recommender (no MLX required).
+
+Lives outside veloxquant_mlx/tests/ on purpose — see
+docs/CI_AND_TESTING.md#two-test-directories-and-why.
+"""
 
 from __future__ import annotations
 

--- a/veloxquant_mlx/tests/__init__.py
+++ b/veloxquant_mlx/tests/__init__.py
@@ -1,1 +1,5 @@
+# MLX-dependent test suite (requires Apple Silicon). For pure-Python,
+# MLX-free tests that must run on plain Linux CI, see tests/non_metal/ at
+# the repo root instead — see docs/CI_AND_TESTING.md for why the split
+# exists and which directory a new test belongs in.
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Fixes #63 — the two test directories (`veloxquant_mlx/tests/` and `tests/non_metal/`) are an intentional split, not a stray duplicate, but that reasoning wasn't documented anywhere a contributor would look first. This is a docs-only change per the issue's own recommendation; no code or CI behavior changes.

- **`docs/CI_AND_TESTING.md`**: adds a "Two test directories, and why" section explaining the `veloxquant_mlx/__init__.py` → `mlx` import-chain constraint that forces `tests/non_metal/` to live outside the package (so `non-metal-unit.yml` can run on plain `ubuntu-latest` without installing `mlx`), plus guidance on which directory a new test belongs in. Also removes the now-stale "suggested follow-up: non-Metal Linux CI" bullet, since `non-metal-unit.yml` already exists (added in `ba09551`, after this doc was originally written — confirmed via `git log`).
- **`CONTRIBUTING.md`**: replaces the broken "see `docs/CI_AND_TESTING.md` once present" placeholder (that file already exists) with a direct link to the new section.
- **`veloxquant_mlx/tests/__init__.py`** and **`tests/non_metal/test_mac_recommender.py`**: short cross-reference comments at the two places a contributor adding a test would actually look first, per the issue's second recommendation.

## Test plan

- `ruff check` / `ruff format --check` clean on both touched Python files.
- `tests/non_metal/test_mac_recommender.py` run exactly as `non-metal-unit.yml` invokes it: 8 passed.
- Full suite (`python -m pytest veloxquant_mlx/tests -q`): 1758 passed, 1 pre-existing unrelated failure (`test_mlx_lm_patch.py`, missing `import pytest`) — unaffected by this change.
- Verified the `CONTRIBUTING.md` anchor link matches GitHub's heading slug for "Two test directories, and why" → `#two-test-directories-and-why`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)