### PR TITLE
fix(landing): align section order and cross-links with persona paths

### DIFF
--- a/landing/assets/main.js
+++ b/landing/assets/main.js
@@ -44,29 +44,46 @@ function initCopyButtons() {
 }
 
 // ── QUICKSTART CODE TABS ──
-function initCodeTabs() {
+function activateTab(tab, { scrollIntoView = true } = {}) {
   const tabBtns = document.querySelectorAll('.tab-btn');
   const tabPanels = document.querySelectorAll('.code-panel');
+  const btn = document.querySelector(`.tab-btn[data-tab="${tab}"]`);
+  if (!btn) return;
 
-  tabBtns.forEach(btn => {
-    btn.addEventListener('click', () => {
-      const tab = btn.dataset.tab;
-      tabBtns.forEach(b => {
-        b.classList.remove('active', 'active-purple', 'active-green', 'active-teal');
-        b.setAttribute('aria-selected', 'false');
-      });
-      tabPanels.forEach(p => p.classList.remove('active'));
-      btn.setAttribute('aria-selected', 'true');
-      btn.classList.add(
-        tab === 'vecinfer' ? 'active-purple' :
-        (tab === 'spectral' || tab === 'chunkkv') ? 'active-green' :
-        tab === 'squeeze' ? 'active-teal' : 'active'
-      );
-      const panel = document.getElementById('tab-' + tab);
-      if (panel) panel.classList.add('active');
-      // Keep the active tab button in view on the horizontally-scrolling
-      // mobile tab strip.
-      btn.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+  tabBtns.forEach(b => {
+    b.classList.remove('active', 'active-purple', 'active-green', 'active-teal');
+    b.setAttribute('aria-selected', 'false');
+  });
+  tabPanels.forEach(p => p.classList.remove('active'));
+  btn.setAttribute('aria-selected', 'true');
+  btn.classList.add(
+    tab === 'vecinfer' ? 'active-purple' :
+    (tab === 'spectral' || tab === 'chunkkv') ? 'active-green' :
+    tab === 'squeeze' ? 'active-teal' : 'active'
+  );
+  const panel = document.getElementById('tab-' + tab);
+  if (panel) panel.classList.add('active');
+  // Keep the active tab button in view on the horizontally-scrolling
+  // mobile tab strip.
+  if (scrollIntoView) btn.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+}
+
+function initCodeTabs() {
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => activateTab(btn.dataset.tab));
+  });
+}
+
+// ── METHOD PICKER → QUICKSTART TAB HANDOFF ──
+// Clicking a method name in #methods jumps to #quickstart with the matching
+// code tab already selected, instead of leaving the visitor to find and
+// click the right tab themselves.
+function initPickerTabLinks() {
+  document.querySelectorAll('.picker-tab-link[data-tab]').forEach(link => {
+    link.addEventListener('click', () => {
+      // Let the anchor navigation happen; just pre-select the tab so it's
+      // showing once the browser scrolls #quickstart into view.
+      activateTab(link.dataset.tab, { scrollIntoView: false });
     });
   });
 }
@@ -310,10 +327,12 @@ function initCalculator() {
       `<p class="calc-note">Estimated from your model's real shape ` +
       `(${preset.n_layers} layers · ${preset.n_kv_heads} KV heads · head_dim ${preset.head_dim}), ` +
       `assuming 4-bit weights (~${res.weightGb} GB) and a 4 GB OS reserve. ` +
-      `${residentNote}</p>` +
+      `${residentNote} Compression has a quality cost too — see ` +
+      `<a href="#quality" class="t-accent">what it costs you →</a>.</p>` +
       `<div class="calc-cta">` +
         `<a class="btn btn-filled" href="#quickstart">Use <code class="inline plain">${rec.id}</code> →</a>` +
         `<a class="btn btn-outline" href="playground.html">Full playground →</a>` +
+        `<a class="btn btn-outline" href="#install">Install →</a>` +
       `</div>`;
 
     writeState(seqLen);
@@ -507,6 +526,7 @@ function initThemeToggle() {
 document.addEventListener('DOMContentLoaded', () => {
   initCopyButtons();
   initCodeTabs();
+  initPickerTabLinks();
   initBadgeTyping();
   initMatrixRain();
   initScrollParallax();

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -2923,6 +2923,9 @@ code.inline.max { color: var(--max); }
 }
 .picker-row.is-max .picker-pick { color: var(--max); }
 .picker-pick small { display: block; color: var(--muted); font-size: 0.74rem; margin-top: 0.2rem; }
+.picker-tab-link { text-decoration: none; }
+.picker-tab-link:hover code.inline,
+.picker-tab-link:focus-visible code.inline { text-decoration: underline; }
 
 /* ── Quality cost ── */
 .cost-pending {

--- a/landing/index.html
+++ b/landing/index.html
@@ -67,12 +67,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li><a href="#scenarios">Start here</a></li>
       <li><a href="#calculator">Calculator</a></li>
+      <li><a href="#methods">Methods</a></li>
       <li><a href="#quickstart">Quickstart</a></li>
       <li><a href="#compare">Compare</a></li>
       <li><a href="#benchmarks">Benchmarks</a></li>
       <li><a href="#quality">Quality cost</a></li>
-      <li><a href="#methods">Methods</a></li>
       <li><a href="playground.html">Playground</a></li>
       <li><a href="#install">Install</a></li>
       <li><a href="/docs/" rel="noopener">Docs</a></li>
@@ -269,7 +270,59 @@
 
   <div class="divider"></div>
 
-  <!-- ── §5 THE 3-LINE DIFF ── -->
+  <!-- ── §5 METHOD PICKER ── -->
+  <section id="methods">
+    <div class="section-head-center">
+      <p class="section-label">Which method</p>
+      <h2 class="section-title">41 methods, one decision</h2>
+      <p class="section-desc">
+        Most people need one of six. Pick by what you're optimising for —
+        the full catalogue lives in the docs.
+      </p>
+    </div>
+
+    <div class="picker-list fade-in">
+      <div class="picker-row is-default">
+        <p class="picker-goal">Balanced, nothing to calibrate
+          <small>The default. Works on any model, no setup pass.</small></p>
+        <p class="picker-pick"><a href="#quickstart" class="picker-tab-link" data-tab="rvq"><code class="inline plain">turboquant_rvq</code></a><small>7.5× keys</small></p>
+      </div>
+      <div class="picker-row is-max">
+        <p class="picker-goal">Maximum compression, quality secondary
+          <small>Needs a one-time codebook calibration.</small></p>
+        <p class="picker-pick"><a href="#quickstart" class="picker-tab-link" data-tab="vecinfer"><code class="inline plain">vecinfer</code></a><small>16× keys</small></p>
+      </div>
+      <div class="picker-row">
+        <p class="picker-goal">Longest context in fixed RAM
+          <small>Compresses keys <em>and</em> values — real resident savings.</small></p>
+        <p class="picker-pick"><code class="inline plain">rabitq</code><small>6× full KV</small></p>
+      </div>
+      <div class="picker-row">
+        <p class="picker-goal">Quality-critical work
+          <small>Per-channel keys, per-token values, fp16 residual window.</small></p>
+        <p class="picker-pick"><code class="inline plain">kivi</code><small>~4× full KV</small></p>
+      </div>
+      <div class="picker-row">
+        <p class="picker-goal">Bounded memory regardless of length
+          <small>Drops stale tokens. Quality depends on the task.</small></p>
+        <p class="picker-pick"><code class="inline plain">streaming_llm</code> / <code class="inline plain">h2o</code><small>eviction</small></p>
+      </div>
+      <div class="picker-row">
+        <p class="picker-goal">Everything else
+          <small>35 more, including cross-layer merging and spectral rotation.</small></p>
+        <p class="picker-pick"><a href="/docs/algorithms/overview" class="t-accent">algorithm reference →</a></p>
+      </div>
+    </div>
+
+    <p class="section-desc" style="margin-top:1.5rem;font-size:0.82rem;opacity:0.7">
+      Picked one? <a href="#quickstart" class="t-accent">Jump to the code →</a> ·
+      <a href="#install" class="t-accent">or install and go →</a>
+    </p>
+  </section>
+
+  <div class="divider"></div>
+
+  <!-- ── §6 THE 3-LINE DIFF ── -->
   <section id="quickstart" class="code-section">
     <p class="section-label">Quickstart</p>
     <h2 class="section-title">Three lines on top of <code class="inline max">mlx_lm</code></h2>
@@ -380,53 +433,6 @@
       Vision-language support covers single-prompt generation —
       <a href="/docs/guides/mlx-lm-integration" class="t-accent">integration guide →</a>
     </p>
-  </section>
-
-  <div class="divider"></div>
-
-  <!-- ── §6 METHOD PICKER ── -->
-  <section id="methods">
-    <div class="section-head-center">
-      <p class="section-label">Which method</p>
-      <h2 class="section-title">41 methods, one decision</h2>
-      <p class="section-desc">
-        Most people need one of six. Pick by what you're optimising for —
-        the full catalogue lives in the docs.
-      </p>
-    </div>
-
-    <div class="picker-list fade-in">
-      <div class="picker-row is-default">
-        <p class="picker-goal">Balanced, nothing to calibrate
-          <small>The default. Works on any model, no setup pass.</small></p>
-        <p class="picker-pick"><code class="inline plain">turboquant_rvq</code><small>7.5× keys</small></p>
-      </div>
-      <div class="picker-row is-max">
-        <p class="picker-goal">Maximum compression, quality secondary
-          <small>Needs a one-time codebook calibration.</small></p>
-        <p class="picker-pick"><code class="inline plain">vecinfer</code><small>16× keys</small></p>
-      </div>
-      <div class="picker-row">
-        <p class="picker-goal">Longest context in fixed RAM
-          <small>Compresses keys <em>and</em> values — real resident savings.</small></p>
-        <p class="picker-pick"><code class="inline plain">rabitq</code><small>6× full KV</small></p>
-      </div>
-      <div class="picker-row">
-        <p class="picker-goal">Quality-critical work
-          <small>Per-channel keys, per-token values, fp16 residual window.</small></p>
-        <p class="picker-pick"><code class="inline plain">kivi</code><small>~4× full KV</small></p>
-      </div>
-      <div class="picker-row">
-        <p class="picker-goal">Bounded memory regardless of length
-          <small>Drops stale tokens. Quality depends on the task.</small></p>
-        <p class="picker-pick"><code class="inline plain">streaming_llm</code> / <code class="inline plain">h2o</code><small>eviction</small></p>
-      </div>
-      <div class="picker-row">
-        <p class="picker-goal">Everything else
-          <small>35 more, including cross-layer merging and spectral rotation.</small></p>
-        <p class="picker-pick"><a href="/docs/algorithms/overview" class="t-accent">algorithm reference →</a></p>
-      </div>
-    </div>
   </section>
 
   <div class="divider"></div>
@@ -659,7 +665,9 @@
 
     <p class="section-desc" style="margin-top:1.5rem;font-size:0.82rem;opacity:0.65">
       No head-to-head throughput numbers against llama.cpp's cache are published here — different runtime,
-      different hardware paths. The honest comparison today is architectural, not a benchmark race.
+      different hardware paths. The honest comparison today is architectural, not a benchmark race. For this
+      library's own tok/s and compression numbers across 12 models, see
+      <a href="#benchmarks" class="t-accent">benchmarks →</a>.
       <a href="/docs/getting-started/comparison" class="t-accent">Full write-up →</a>
       <br /><br />
       A note on oMLX + "TurboQuant": some articles describe oMLX as shipping TurboQuant KV cache support.
@@ -816,6 +824,10 @@
       <a href="https://github.com/rajveer43/VeloxQuant-MLX/tree/master/figures" target="_blank" rel="noopener" class="t-accent">figures/</a>.
       Metal kernel benchmarks and memory measurements live in the
       <a href="playground.html" class="t-accent">playground →</a>
+    </p>
+
+    <p class="section-desc" style="margin-top:1rem;font-size:0.82rem;opacity:0.7">
+      Picked a method from the numbers above? <a href="#install" class="t-accent">Install and go →</a>
     </p>
   </section>
 

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -33,15 +33,17 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
-      <li><a href="index.html#compare">Why This?</a></li>
-      <li><a href="index.html#algorithms">Algorithms</a></li>
-      <li><a href="index.html#metal">Metal Kernels</a></li>
-      <li><a href="playground.html" aria-current="page">Playground</a></li>
+      <li><a href="index.html#scenarios">Start here</a></li>
+      <li><a href="index.html#calculator">Calculator</a></li>
+      <li><a href="index.html#methods">Methods</a></li>
+      <li><a href="index.html#quickstart">Quickstart</a></li>
+      <li><a href="index.html#compare">Compare</a></li>
       <li><a href="index.html#benchmarks">Benchmarks</a></li>
+      <li><a href="index.html#quality">Quality cost</a></li>
+      <li><a href="playground.html" aria-current="page">Playground</a></li>
       <li><a href="index.html#install">Install</a></li>
       <li><a href="/docs/" rel="noopener">Docs</a></li>
       <li><a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener">GitHub</a></li>
-      <li><a href="https://pypi.org/project/VeloxQuant-MLX/" target="_blank" rel="noopener">PyPI</a></li>
       <li>
         <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light theme" title="Toggle light / dark theme">
           <span class="theme-icon theme-icon-sun" aria-hidden="true">☀</span>


### PR DESCRIPTION
## Summary

Fixes #104 — implements all six proposed fixes to close the gap between the landing page's three self-selected personas (`#scenarios`) and the actual section order/CTAs a visitor encounters. No new sections or visual redesign, per the issue's explicit scope.

1. **Nav bar**: added `#scenarios` as the first link ("Start here") so the persona entry point is reachable from anywhere on the page, not just a fresh top-of-page load. Reordered Methods before Quickstart in the nav to match the new section order.
2. **Reordered §5/§6**: methods (picker) now comes before quickstart, so persona 3's ("I want 1-bit from the papers") scroll path matches their click path — previously quickstart's tab bar asked visitors to choose a code sample before the method picker had introduced the methods at all.
3. **Method picker → quickstart tab handoff**: the `turboquant_rvq` and `vecinfer` picker rows now link to `#quickstart` and pre-select the matching code tab, via a new `activateTab()` helper refactored out of the existing tab-click handler in `main.js` (the other three picker rows have no matching quickstart tab, so they stay plain text rather than link to a tab that doesn't exist).
4. **Compare → benchmarks cross-link**: added a line in `#compare` pointing to `#benchmarks`, since persona 2's scenario card promises benchmarks but the scroll path passes through compare first with no mention that benchmarks exists.
5. **Quality-cost mention in the calculator**: the calculator's output now links to `#quality` ("what it costs you"), since no persona path previously routed through the quality-cost table at all.
6. **Install micro-CTAs**: added a "→ Install" step at the end of `#calculator` (JS-rendered), `#methods`, and `#benchmarks` — the three persona endpoints — mirroring the existing pattern in `#explainer`, so each path has an explicit last step instead of relying on 5+ more sections of scrolling.
7. **`playground.html` nav sync** (found in review, same root cause as the issue): `playground.html` has its own separately-maintained nav bar that had drifted from `index.html`'s — two dead anchors (`index.html#algorithms`, `index.html#metal`, neither section exists), a "Why This?" label pointing at `#compare`, no `#scenarios`/`#quality` links, and a standalone PyPI link `index.html` doesn't have. Replaced it with the same link set, order, and labels as `index.html`'s nav so both pages present one consistent navigation.

## Notes

- Section-order comments (`§5`–`§11`) renumbered to stay accurate; `#install`/`§11` is unaffected since only `§5`/`§6` swapped.
- `initActiveNav()` in `main.js` needed no changes — it derives the nav-highlight list dynamically from `section[id]` rather than a hardcoded order, so it picked up the new `#scenarios` link and reordered sections automatically.
- `.picker-tab-link` gets minimal CSS (remove default underline, add one back on hover/focus) — `code.inline`'s own `color` still wins over any anchor default since it's set directly on the element.

## Test plan

- `node --check landing/assets/main.js` — syntax OK.
- Verified via script: all `<section>`/`</div>` tags balanced, every `href="#..."` anchor resolves to an existing `id` in the document (no dangling links).
- Served `landing/` locally and confirmed the HTML loads (200) and section IDs/order match intent; no headless browser available in this environment to click through the JS interactions, so the tab-handoff and calculator-CTA logic were verified by careful reading of `main.js` rather than an automated UI test — flagging this so a manual click-through is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
