### PR TITLE
fix(integration): restore release gate, fix make_cache patch-before-validate order

### DIFF
--- a/veloxquant_mlx/integration/mlx_lm_patch.py
+++ b/veloxquant_mlx/integration/mlx_lm_patch.py
@@ -71,8 +71,8 @@ def patch_model_kv_cache(model: Any, config: KVCacheConfig) -> list[Any]:
     def _make_cache(*_args: Any, **_kwargs: Any) -> list[Any]:
         return KVCacheBuilder.for_model(model, config)
 
-    model.make_cache = _make_cache
     caches = _make_cache()
+    model.make_cache = _make_cache
     print(
         f"[veloxquant_mlx] Wired {len(caches)} layer cache(s) with "
         f"{config.method!r} (fresh per call)."

--- a/veloxquant_mlx/tests/integration/test_mlx_lm_patch.py
+++ b/veloxquant_mlx/tests/integration/test_mlx_lm_patch.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import mlx.core as mx
+import pytest
 
 from veloxquant_mlx.cache.base import KVCacheConfig
 from veloxquant_mlx.core.exceptions import QuantizerConfigError


### PR DESCRIPTION
## Summary

- `test_mlx_lm_patch.py::test_patch_model_kv_cache_refuses_standalone_method` called `pytest.raises(...)` with no `import pytest` in the file — a bare `NameError`, not a real assertion failure. This test runs as part of `release.yml`'s test-suite gate (`python -m pytest veloxquant_mlx/tests -q`), which blocks the entire bump/tag/publish pipeline on any failure.
- **Every release workflow run since PR #109 (2026-08-08 14:19 UTC) has failed at this step** — 8+ consecutive failures. `pyproject.toml`/`__init__.py`/git tags reached `v0.43.2` from an earlier successful run, but `CHANGELOG.md`, GitHub Releases, and PyPI have all been stuck at `v0.42.0` since — meaning none of PRs #88–#116 have actually shipped anywhere a user consumes the package.
- Every one of those 24 PRs' test-plan sections dismissed this exact failure as "pre-existing, unrelated, out of scope" and moved on without fixing it.

## Real bug found underneath

Adding the missing import let the test actually run — and it failed for real. `patch_model_kv_cache()` (`veloxquant_mlx/integration/mlx_lm_patch.py`) set `model.make_cache = _make_cache` **before** calling `_make_cache()` to validate the config. `KVCacheBuilder.for_model()` raises `QuantizerConfigError` for standalone methods (e.g. `"spectral"`) inside that call — by the time it raises, `model.make_cache` was already permanently pointed at a closure that will always fail. This contradicts the function's own docstring: *"Raised immediately by the underlying `KVCacheBuilder.for_model()` call, before `model.make_cache` is touched."*

Same bug class as PR #105's `calibrate_layer_sensitivities` fix (mutate-before-validate leaving the model corrupted after an exception).

## Fix

- Added `import pytest` to `test_mlx_lm_patch.py`.
- Swapped the two lines in `patch_model_kv_cache()`: build/validate the cache first, assign `model.make_cache` only after it succeeds.

## Test plan

- [x] `pytest veloxquant_mlx/tests/integration/test_mlx_lm_patch.py -v` — 5/5 passed (was 4 passed, 1 `NameError`)
- [x] `pytest veloxquant_mlx/tests -q` — **1759 passed** (was 1758 passed, 1 failed)

## Why this matters right now

This is a release-blocker: merging it is what lets `release.yml` actually run to completion on the next push to `master` and publish everything that's been queued up since v0.42.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)