### PR TITLE
fix(ci): release.yml never created a GitHub Release; token missing on bump step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Determine next version (dry run)
         id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Do NOT discard stderr or swallow the exit code here. PSR exits 2
           # with "no release will be made" when there is genuinely nothing to
@@ -80,6 +82,8 @@ jobs:
 
       - name: Bump pyproject.toml/__init__.py and prepend CHANGELOG entry (no commit yet)
         if: steps.version.outputs.next_version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release version --no-commit --no-tag --no-push --no-vcs-release
 
       - name: Sync README badges + landing page (version + live test count)
@@ -109,6 +113,30 @@ jobs:
 
       - name: Publish GitHub Release
         if: steps.version.outputs.next_version != ''
-        run: semantic-release publish
+        run: |
+          # `semantic-release publish` does NOT create a GitHub Release --
+          # it only uploads build artifacts to one that already exists. With
+          # --no-vcs-release on the bump step (deliberate: this workflow tags
+          # and pushes manually, see the step above), nothing ever created
+          # the release itself, so `publish` logged "No release corresponds
+          # to tag ..., can't upload dists" and exited 0 -- a silent no-op
+          # that looked like success. Create the release directly instead,
+          # extracting this version's section from CHANGELOG.md for the
+          # release notes (the same content `semantic-release version` just
+          # prepended there).
+          VERSION="${{ steps.version.outputs.next_version }}"
+          awk -v ver="## [${VERSION}]" '
+            index($0, ver) == 1 { found=1; print; next }
+            found && index($0, "## [") == 1 { exit }
+            found { print }
+          ' CHANGELOG.md > release_notes.md
+
+          if [ ! -s release_notes.md ]; then
+            echo "::warning::No CHANGELOG.md section found for v${VERSION}; publishing release with an empty body."
+          fi
+
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file release_notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Live-observed on the v0.43.3 run (triggered when PR #117 merged, the first release run to pass the test gate since PR #109): `pyproject.toml`/`__init__.py`/git tags all advanced correctly to v0.43.3, but **no GitHub Release was created and `CHANGELOG.md` was never touched.**

## Root causes

1. **`semantic-release publish` does not create a GitHub Release from scratch** — it only uploads build artifacts to a release that already exists. This workflow deliberately passes `--no-vcs-release` to the bump step (correct — the workflow tags/pushes manually a few steps later, per the existing comments about annotated tags and `--follow-tags`). But nothing else in the workflow ever created the release object, so `publish` logged `No release corresponds to tag v0.43.3, can't upload dists` and exited 0 — a silent no-op that read as success in the Actions UI.

   Fixed by replacing the `semantic-release publish` step with `gh release create`, using the section of `CHANGELOG.md` this version's bump step just prepended as the release-notes body.

2. **`semantic-release version` had no `GH_TOKEN`/`GITHUB_TOKEN` in its env** on either the dry-run (`--print`) or real bump step — only the final publish step had it. The bump step logged `WARNING Token value is missing!` and produced **no `CHANGELOG.md` diff at all** in the v0.43.3 run, despite the step's own name ("...and prepend CHANGELOG entry"). Added the token to both steps.

## Not fixed here

There is no PyPI publish step anywhere in this workflow — PyPI has likely never been wired to CI (confirmed separately: PyPI's latest published version is still 0.42.0). That's a bigger, separately-scoped change since it needs a `PYPI_API_TOKEN` secret decision. Flagging, not fixing, in this PR.

## Test plan

- [x] Verified the `awk` release-notes extraction locally against the real `CHANGELOG.md` — correctly isolates one version's section and stops at the next `## [` heading.
- [ ] Real verification happens on the next merge to `master` that triggers a release (can't dry-run `gh release create`/the full workflow without actually running it) — I'll watch that run and confirm a real GitHub Release + changelog entry land for whatever version comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)