### PR TITLE
fix(ci): release-notes extraction didn't match semantic-release's real heading format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,10 +124,14 @@ jobs:
           # extracting this version's section from CHANGELOG.md for the
           # release notes (the same content `semantic-release version` just
           # prepended there).
+          # semantic-release's auto-generated heading is "## v<version> (<date>)"
+          # (no brackets) -- distinct from this file's older hand-written
+          # "## [<version>] — <date>" entries. Match either so a future
+          # switch back to hand-editing doesn't silently break this again.
           VERSION="${{ steps.version.outputs.next_version }}"
-          awk -v ver="## [${VERSION}]" '
-            index($0, ver) == 1 { found=1; print; next }
-            found && index($0, "## [") == 1 { exit }
+          awk -v v1="## v${VERSION} " -v v2="## [${VERSION}]" '
+            (index($0, v1) == 1 || index($0, v2) == 1) { found=1; print; next }
+            found && index($0, "## ") == 1 { exit }
             found { print }
           ' CHANGELOG.md > release_notes.md
 


### PR DESCRIPTION
## Summary

v0.43.5's GitHub Release went out with an empty body — confirmed live (`gh release view v0.43.5 --json body` returns empty). The `awk` extraction added in #118 matched `## [<version>]` (this repo's old hand-written `CHANGELOG.md` heading style), but `semantic-release`'s real auto-generated heading — now working correctly after #119's `mode = "update"` fix — is `## v<version> (<date>)`, no brackets. Neither pattern I'd guessed matched the real entry, so `release_notes.md` came out empty and the release shipped without notes despite `CHANGELOG.md` having the right content one heading format away.

## Fix

Match both heading styles in the `awk` extraction — the real auto-generated `## v<version> ` and the legacy hand-written `## [<version>]` — so a future switch back to manual changelog editing doesn't silently regress this again.

## Test plan

- [x] Ran the exact `awk` snippet locally against the real current `CHANGELOG.md` for both `0.43.5` (auto-generated style) and `0.43.4` (hand-written bracket style) — both extract correctly now.
- [ ] Will confirm on the next real release run, and will backfill the empty/wrong release notes for v0.43.3–v0.43.5 by hand via `gh release edit` regardless (those were cut before this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)