### PR TITLE
feat(release): publish to TestPyPI then PyPI via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,3 +144,79 @@ jobs:
             --notes-file release_notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build sdist + wheel
+        if: steps.version.outputs.next_version != ''
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+          ls -la dist/
+
+      - name: Upload dist/ for the publish jobs
+        if: steps.version.outputs.next_version != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: dist/
+          retention-days: 7
+
+    outputs:
+      # Empty when the "release" job's own `if:` skips it entirely (a
+      # [skip ci] push) or when it ran but found no releasable commits --
+      # either way, both publish jobs below no-op via their own `if:`.
+      next_version: ${{ steps.version.outputs.next_version }}
+
+  # Trusted Publishing (OIDC): no PyPI/TestPyPI API token is stored anywhere
+  # in this repo. Each job below authenticates via a short-lived OIDC token
+  # GitHub mints for the run, which PyPI/TestPyPI trust because this
+  # repo+workflow+environment combination was registered as a trusted
+  # publisher on each index ahead of time (pypi.org / test.pypi.org ->
+  # project -> Publishing -> Add a new publisher). The `environment:` name
+  # here must exactly match what was registered there.
+  publish-testpypi:
+    needs: release
+    if: needs.release.outputs.next_version != ''
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/VeloxQuant-MLX
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # TestPyPI is a shared, non-authoritative sandbox that does not
+          # get wiped per-release -- a version collision there (e.g. a
+          # manual test upload of the same version) should not block the
+          # real PyPI publish below.
+          skip-existing: true
+
+  # Real PyPI. Gated on TestPyPI succeeding first (needs: includes
+  # publish-testpypi) -- this is the "test run before the real release"
+  # requested. No skip-existing here: a collision on real PyPI means
+  # something is wrong (e.g. this version was already published by a
+  # different run) and should fail loudly, not silently no-op.
+  publish-pypi:
+    needs: [release, publish-testpypi]
+    if: needs.release.outputs.next_version != ''
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/VeloxQuant-MLX
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Wires PyPI publishing into `release.yml`, which had no PyPI step at all before this — confirmed separately that PyPI has been stuck at v0.42.0 while GitHub Releases/tags advanced past it, because nothing was ever built to reach it.

Every release run now: bumps version → tags → GitHub Release (existing behavior, unchanged) → **builds sdist+wheel → publishes to TestPyPI → publishes to real PyPI**, automatically, gated so PyPI only gets touched after TestPyPI succeeds first.

## Auth: Trusted Publishing (OIDC), no stored secrets

Uses `pypa/gh-action-pypi-publish` with `id-token: write` — GitHub mints a short-lived OIDC token per run, which PyPI/TestPyPI trust because this repo+workflow+environment combination is registered as a trusted publisher on each index. **No `PYPI_API_TOKEN`/`TEST_PYPI_API_TOKEN` is stored anywhere in this repo.**

## ⚠️ Manual setup required before this works

This is a one-time step only the account owner can do (needs PyPI/TestPyPI login), and I can't do it from here:

1. Go to **https://pypi.org** → your `VeloxQuant-MLX` project → **Publishing** → **Add a new publisher**
   - Owner: `rajveer43`
   - Repository: `VeloxQuant-MLX`
   - Workflow: `release.yml`
   - Environment: `pypi`
2. Same on **https://test.pypi.org** for the project, with Environment: `testpypi`

Until both are registered, `publish-testpypi`/`publish-pypi` will fail with an OIDC/auth error — the existing GitHub-Release-only behavior (everything before this PR) is completely unaffected either way, so this is safe to merge before that setup is done; the new jobs just won't succeed yet.

## Structure

- `release` job: additionally builds `dist/`, uploads it as a workflow artifact, and exposes `next_version` as a job output (empty when no release was cut, correctly short-circuiting both jobs below).
- `publish-testpypi` (needs `release`): publishes first, `skip-existing: true` — TestPyPI is a shared sandbox that isn't wiped per-release, so a collision there shouldn't block the real release.
- `publish-pypi` (needs `[release, publish-testpypi]`): only runs after TestPyPI succeeds — this is the "test run before real release" being asked for. No `skip-existing` — a collision on real PyPI means something is genuinely wrong and should fail loudly.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid YAML, 3 jobs.
- [x] Full test suite unaffected: 1759/1759 passing.
- [ ] Real verification requires the trusted-publisher setup above, then watching the next release run actually reach TestPyPI/PyPI — I'll watch that once it's set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)