### PR TITLE
docs(readme): replace static status claims with live CI/PyPI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@
 
 <p>
   <a href="https://pypi.org/project/VeloxQuant-MLX/"><img src="https://img.shields.io/pypi/v/VeloxQuant-MLX?style=flat-square&logo=pypi&logoColor=white&color=0078d4" alt="PyPI"/></a>
+  <a href="https://pypi.org/project/VeloxQuant-MLX/"><img src="https://img.shields.io/pypi/dm/VeloxQuant-MLX?style=flat-square&logo=pypi&logoColor=white&color=0078d4" alt="PyPI downloads"/></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.11+-0078d4?style=flat-square&logo=python&logoColor=white" alt="Python"/></a>
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon%20M1+-black?style=flat-square&logo=apple&logoColor=white" alt="Platform"/>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" alt="License"/></a>
-  <img src="https://img.shields.io/badge/tests-1759%20passing-22c55e?style=flat-square" alt="Tests"/>
   <a href="https://doi.org/10.5281/zenodo.20647294"><img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20647294-1f6feb?style=flat-square" alt="DOI"/></a>
+</p>
+
+<p>
+  <a href="https://github.com/rajveer43/VeloxQuant-MLX/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/rajveer43/VeloxQuant-MLX/release.yml?branch=master&style=flat-square&label=release%20%2B%20full%20test%20suite&logo=github" alt="Release build status"/></a>
+  <a href="https://github.com/rajveer43/VeloxQuant-MLX/actions/workflows/non-metal-unit.yml"><img src="https://img.shields.io/github/actions/workflow/status/rajveer43/VeloxQuant-MLX/non-metal-unit.yml?branch=master&style=flat-square&label=non-metal%20unit&logo=github" alt="Non-Metal unit tests"/></a>
+  <a href="https://github.com/rajveer43/VeloxQuant-MLX/actions/workflows/lint.yml"><img src="https://img.shields.io/github/actions/workflow/status/rajveer43/VeloxQuant-MLX/lint.yml?branch=master&style=flat-square&label=lint&logo=github" alt="Lint status"/></a>
+  <img src="https://img.shields.io/badge/tests-1759%20passing-22c55e?style=flat-square" alt="Tests"/>
 </p>
 
 <p>


### PR DESCRIPTION
## Summary

The badge row had a hand-set "1759 passing" text badge (kept accurate only by `scripts/sync_release_badges.py` rewriting it on each release) but no live CI status — a visitor had no way to tell if the current build is actually green without clicking through to Actions.

## Change

Added a new badge row (between the identity row and the existing trust/links row):
- **release + full test suite** — live status of `release.yml` (the macOS job that runs the full 1759-test suite)
- **non-metal unit** — live status of `non-metal-unit.yml` (runs on every PR + push to master)
- **lint** — live status of `lint.yml` (runs on every PR + push to master)
- **PyPI downloads** — live install-count badge, next to the existing PyPI version badge

Kept the existing static test-count badge alongside them — still useful as an exact number, and confirmed `scripts/sync_release_badges.py`'s regex (`badge/tests-\d+%20passing-`) still matches it unchanged.

## Test plan

- [x] Verified `sync_release_badges.py`'s two regex patterns (`tests-\d+%20passing`, `changelog-[\d.]+`) still match post-edit.
- [x] Visual check of the rendered badge grouping (identity → live CI/PyPI status → trust/legal → links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)