### PR TITLE
fix(ci): release.yml re-ran full release steps when nothing actually changed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,18 @@ jobs:
             exit 1
           fi
 
+          # "No release will be made" still prints the *current* (unchanged)
+          # version to stdout, not an empty string -- e.g. "0.43.6" when
+          # 0.43.6 was already released and nothing since qualifies (a
+          # docs-only merge landing right after a real release). Treating
+          # that as next_version made every downstream step run again for
+          # a version that was never actually bumped: "Commit, tag, and
+          # push" found nothing staged (README/CHANGELOG/pyproject.toml
+          # were already at that version) and failed on an empty commit.
+          if grep -qi "no release will be made" version_err.txt; then
+            NEXT_VERSION=""
+          fi
+
           echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: No release needed


### PR DESCRIPTION
## Summary

Live-observed failure right after #122 (a docs-only merge) landed: the release run failed at "Commit, tag, and push the release" with `nothing added to commit but untracked files present`.

## Root cause

`semantic-release version --print` prints the **current** version to stdout even when nothing qualifies for a release — it only signals "no release" via stderr (`No release will be made, 0.43.6 has already been released!`) and exit code 2. The workflow's own existing comment already explains why that "no release" signal has to come from stderr/exit-code rather than trusting stdout/exit-code alone — but the `next_version` GitHub Actions output was still being set from `NEXT_VERSION` (i.e. stdout) unconditionally, even inside the branch that correctly detected "no release will be made."

So every step gated on `next_version != ''` ran again for a version that was never actually bumped: the "Bump" step found nothing to change (README/CHANGELOG.md/pyproject.toml were already correct from the prior real release), so `git add` staged nothing, and the commit step failed on an empty index.

## Fix

Explicitly clear `NEXT_VERSION` to empty whenever the "no release will be made" stderr message matched, regardless of what stdout printed — matching what the surrounding comments already describe as the intended behavior.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid YAML.
- [ ] Real verification: the next push to `master` that has no releasable commits (e.g. this PR's own merge, if `ci`/`fix` isn't in `patch_tags` — it is, so this itself may trigger a real 0.43.7 release; either way I'll watch it) should hit "No release needed" cleanly with no downstream failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)