### PR TITLE
fix(cache): default KVCacheConfig method to turboquant_rvq, not turboquant_prod

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -95,7 +95,7 @@ class KVCacheConfig:
         "nestedkv",
         "amc",
         "a2ats",
-    ] = "turboquant_prod"
+    ] = "turboquant_rvq"
     head_dim: int = 128
     bit_width_inlier: Union[int, list] = 2
     bit_width_outlier: Optional[int] = None

--- a/veloxquant_mlx/tests/cache/test_base_for_model.py
+++ b/veloxquant_mlx/tests/cache/test_base_for_model.py
@@ -105,6 +105,23 @@ def test_for_model_accepts_serving_compatible_method() -> None:
     assert len(caches) == 2
 
 
+def test_default_method_is_serving_compatible() -> None:
+    """Regression test for issue #130: KVCacheConfig()'s default method used
+    to be "turboquant_prod", a STANDALONE_METHODS entry -- so a user who
+    built a config with no explicit `method=` and then called
+    patch_model_kv_cache()/for_model() on a live model got refused
+    immediately, even though nothing about their code named a standalone
+    method. The out-of-the-box default must always be one for_model()
+    actually accepts.
+    """
+    default_method = KVCacheConfig().method
+    assert default_method not in STANDALONE_METHODS
+
+    model = _make_fake_model()
+    caches = KVCacheBuilder.for_model(model, KVCacheConfig())
+    assert len(caches) == 2
+
+
 def test_for_model_accepts_all_non_standalone_methods() -> None:
     """Every method NOT in STANDALONE_METHODS must still be accepted by the
     refusal check itself (build may still fail later for unrelated


### PR DESCRIPTION
## Summary

- `KVCacheConfig()`'s default `method` was `turboquant_prod`, one of the 5 `STANDALONE_METHODS` (#27, #56) that `for_model()`/`patch_model_kv_cache()` refuse outright with a `QuantizerConfigError` — so a user who built a config with no explicit `method=` and then patched a live model got refused immediately, despite never naming a standalone method.
- The README already documents `turboquant_rvq` as **"the default"** (`README.md:185`) and every quickstart example in it already uses `method="turboquant_rvq"` — the `KVCacheConfig` dataclass default had drifted out of sync with the docs. This aligns the two.
- `turboquant_prod` remains fully supported for standalone/research use via `KVCacheFactory.create()` / `KVCacheBuilder.build()` — only the zero-config default changes.

Closes #130 (chose option 2 from that issue's discussion — cheapest, zero-risk fix for the "default breaks under server" surprise, independent of the larger question of whether the 5 standalone methods ever get real serving adapters).

## Test plan

- [x] Added `test_default_method_is_serving_compatible` in `test_base_for_model.py`, asserting `KVCacheConfig().method not in STANDALONE_METHODS` and that `for_model()` accepts the zero-config default without raising.
- [x] Confirmed no existing test pinned the old default value before changing it (`grep` across `veloxquant_mlx/tests/`).
- [x] Full suite: `1760 passed` (was 1759 before the new test; zero regressions).

## References

- #130 (this PR's source issue)
- #27, #56 (original standalone-method serving-contract investigation)