### PR TITLE
fix(h2o): RoPE desync, prefill crash, fused Metal kernel, freeze fix, and score-decay fix

### DIFF
--- a/docs-site/docs/algorithms/h2o.md
+++ b/docs-site/docs/algorithms/h2o.md
@@ -20,7 +20,10 @@ cumulative-sum formulation at low budgets, not an implementation bug in the
 eviction *rule* itself (which correctly implements Algorithm 1 — see
 [fidelity check](#fidelity-to-algorithm-1)). See
 [the finding](#real-end-to-end-generation-eviction-breaks-coherence) before
-using `method="h2o"` for anything beyond studying the mechanism.
+using `method="h2o"` for anything beyond studying the mechanism. A separate
+scalability bug that used to crash long prefills outright (regardless of
+eviction settings) has since been fixed — see
+[long-context testing](#long-context-testing-the-freeze-holds-at-scale-plus-a-scalability-bug-now-fixed).
 :::
 
 H2O-adapted is the library's **third eviction axis** and the first based on
@@ -117,8 +120,8 @@ specified is what causes the practical problem, not a deviation from it.
 ## Evidence
 
 All claims trace to passing tests in
-`veloxquant_mlx/tests/cache/test_h2o_cache.py` (15 tests) and
-`veloxquant_mlx/tests/quantizers/test_h2o.py` (18 tests):
+`veloxquant_mlx/tests/cache/test_h2o_cache.py` (18 tests) and
+`veloxquant_mlx/tests/quantizers/test_h2o.py` (28 tests):
 
 - `init_h2o_state` fields correct; empty state returns zero-row K/V placeholder
 - Single token bootstraps state; multi-token absorption below budget keeps all tokens
@@ -135,6 +138,11 @@ All claims trace to passing tests in
 - Factory dispatch (`KVCacheFactory.create`) returns `H2OKVCache`
 - `for_model` propagates `h2o_budget` and `h2o_n_sink` to all layer caches
 - Determinism: identical inputs produce identical outputs
+- Position tracking stays gap-free and contiguous under a 60-step stress test; `n_sink` positions never move
+- Interior-eviction RoPE remap recovers each surviving key's exact original pre-rotation value (fingerprinted-token test)
+- `cache.offset` tracks the true absolute step count, not the kept-row count, once eviction has occurred
+- The vectorized below-budget batch path matches the sequential per-token loop it replaces bit-for-bit within fp16 rounding, including for a single call whose batch straddles the below-budget/over-budget boundary
+- A 4,000-token single-call absorption (no eviction) completes without error — the regression test for the prefill scalability crash
 
 The offline harness in `benchmark_scripts/benchmark_h2o.py` sweeps
 `(seq_len, budget, n_sink)` and reports latency and compression ratio —
@@ -213,6 +221,62 @@ change to the eviction/scoring policy itself (e.g. a grace period before a
 token becomes eviction-eligible, or age-normalized scoring) — a bigger,
 more opinionated algorithmic change than a bugfix, and not undertaken here.
 Tracked as follow-up work, not silently patched over.
+
+### Long-context testing: the freeze holds at scale, plus a scalability bug (now fixed)
+
+The same methodology was repeated on a genuinely long prompt (~3,238 tokens)
+to check whether the early-token freeze above behaves differently at scale,
+and to stress-test the implementation on long context in general.
+
+| Budget | Prefill | Decode | Kept (final) | Evicted | Compression | Generated tokens survived? | Output |
+|---|---|---|---|---|---|---|---|
+| 256 | 3,238 | 300 | 256 | 3,282 | 13.82× | **0** | `"of of of of of..."` — total collapse |
+| 800 | 3,238 | 300 | 800 | 2,738 | 4.42× | **0** | Garbled/gibberish tokens |
+| 1,200 | 3,238 | 400 | 1,200 | 2,438 | 3.03× | **0** | Degenerates into `"I am I am I am..."` loop |
+
+In every case the kept set is exactly `[0, budget-1]` — the earliest slice of
+the **prompt** — confirming the freeze is budget- and prompt-length-independent:
+bigger budgets don't fix it, they just delay how quickly the output degrades
+from coherent-looking phrases into pure repetition.
+
+:::warning[A second, independent bug was found and fixed here: H2O couldn't even complete a long prefill]
+Testing the no-eviction baseline (`h2o_budget` larger than the prompt, so no
+eviction should ever occur) crashed **during prefill alone**, before a single
+decode step:
+
+```
+RuntimeError: [metal::malloc] Resource limit (499000) exceeded.
+```
+
+Bisected the breaking point: prefill succeeded at 500 tokens, failed
+somewhere before 1,000 — independent of `h2o_budget`, `h2o_n_sink`, or
+`max_tokens` (reproduced even at `max_tokens=1`).
+
+**Root cause:** `h2o_update` processed every incoming token, including the
+entire prefill batch, with a Python `for` loop issuing 4 separate
+`mx.concatenate` calls per token (keys, values, scores, positions). At
+~3,238 tokens this builds an unfused lazy-evaluation graph large enough to
+exceed MLX's Metal resource/command-buffer tracking limit — a pure
+implementation scalability bug, completely independent of the RoPE fixes and
+the scoring-freeze issue above.
+
+**Fixed:** whichever leading portion of an incoming batch is guaranteed not
+to trigger eviction (because the cache hasn't yet reached `h2o_budget`) is
+now absorbed via a single batched masked-attention matmul instead of a
+per-token loop — mathematically the same score-accumulation formula, just
+computed all at once. Verified numerically equivalent to the sequential loop
+it replaces (exact match to fp16 rounding, including for calls that straddle
+the below-budget/over-budget boundary). The same 3,238-token no-eviction
+prefill that previously crashed now completes in ~2.4–3.2 seconds.
+
+Only the genuinely sequential part — the eviction decision itself, where
+each eviction depends on the previous step's result — still runs a per-token
+loop, and only once the cache is actually full. This means the fix has no
+effect on the freeze-heavy scenarios in the table above (their timing and
+output are byte-for-byte identical before and after this fix); it only
+unblocks the case that used to crash outright: long context with a budget
+large enough to avoid heavy early eviction.
+:::
 
 ## When to use it
 

--- a/docs-site/docs/algorithms/h2o.md
+++ b/docs-site/docs/algorithms/h2o.md
@@ -4,6 +4,25 @@
 (Zhang et al., ICLR 2024) — **H2O-adapted (VeloxQuant-MLX implementation)**,
 not a faithful port.
 
+:::danger[Not safe for real generation yet — cache freezes on early tokens]
+Real-model testing (below) confirms eviction corrupts output — as few as one
+or two evictions can send generation into repetition loops, and heavier
+eviction causes total collapse. Root cause: the scoring formula gives every
+newly-arrived token a starting score of exactly `0`, and the eviction rule
+removes the *global minimum* score — so once the cache is full, the brand-new
+token is (almost always) its own eviction target, before it ever gets a
+chance to accumulate attention mass. In practice this means **the kept set
+freezes on whichever tokens filled the budget first** (typically the prompt)
+and never admits anything generated afterward — the model ends up generating
+forever while attending only to the original prompt, with zero visibility
+into its own recent output. This is a real limitation of the paper's own
+cumulative-sum formulation at low budgets, not an implementation bug in the
+eviction *rule* itself (which correctly implements Algorithm 1 — see
+[fidelity check](#fidelity-to-algorithm-1)). See
+[the finding](#real-end-to-end-generation-eviction-breaks-coherence) before
+using `method="h2o"` for anything beyond studying the mechanism.
+:::
+
 H2O-adapted is the library's **third eviction axis** and the first based on
 **cumulative per-token attention mass**. Unlike SnapKV-adapted (which fires once
 at prefill end) and StreamingLLM-adapted (which evicts by position), H2O runs
@@ -61,12 +80,26 @@ For every incoming token (both prefill and decode), per head:
 No `.bits` attribute — stored K/V remain in fp16. The `compression_ratio` and
 `tokens_kept` properties report the storage accounting.
 
-## Proxy limitation
+## Fidelity to Algorithm 1
 
-The paper accumulates attention weights from the **true query** vectors at each
-decode step. At the cache-wrapper level, queries are not visible — only K and V
-arrive at `update_and_fetch`. We substitute the incoming **key vector** as a proxy
-query, computing an approximation of the attention distribution over stored keys.
+Checked directly against the paper's Algorithm 1 / Definition 4.3 (local
+greedy heavy-hitter eviction):
+
+| Paper | This implementation | Match |
+|---|---|---|
+| `Si ← (Si−1 ∪ {i}) \ {u}`, `u ← argmax_v Fscore(Si−1∪{i}\{v})` | Evict the single lowest-scoring element (`argmin`) — equivalent to maximizing the *remaining* set's score | ✅ |
+| `Fscore(T) = Σ_{s∈T} o_s`, accumulated per token | Running sum of softmax weights per token | ✅ |
+| §4.1: local (no-lookahead) H2 is "equally effective" as the global variant — the paper's own recommended, deployable version | Implements exactly the local variant | ✅ (correct choice) |
+| `\|Si\| = k`, evict at most one per step | `budget` field, one eviction per over-budget call | ✅ |
+| §5.3 sink/StreamingLLM extension | `n_sink` protected leading positions | ✅ |
+
+**Proxy limitation:** the paper accumulates attention weights from the
+**true query** vectors at each decode step. At the cache-wrapper level,
+queries are not visible — only K and V arrive at `update_and_fetch`, and (as
+documented in [How it works](#how-it-works) above) `mlx_lm`'s attention
+module consumes the true query internally before the cache is ever called.
+We substitute the incoming **key vector** as a proxy query, computing an
+approximation of the attention distribution over stored keys.
 
 This is the same key-as-query approximation used by SnapKV-adapted. Keys and queries
 are both projected from the same residual stream and are correlated, but the proxy is
@@ -75,6 +108,11 @@ similar to recent keys rather than those that answer the actual query.
 
 Documented as "H2O-adapted (key-as-query proxy)" throughout — never claimed as a
 faithful port.
+
+**Not a fidelity gap, but a consequence of the formula itself:** the paper's
+own scoring rule (new tokens start at score 0, minimum gets evicted) is what
+produces the early-token freeze described below — implementing it exactly as
+specified is what causes the practical problem, not a deviation from it.
 
 ## Evidence
 
@@ -102,22 +140,99 @@ The offline harness in `benchmark_scripts/benchmark_h2o.py` sweeps
 `(seq_len, budget, n_sink)` and reports latency and compression ratio —
 **synthetic, not model-level.**
 
-**No model-level benchmark has been run.** Until `results_h2o.json` is committed
-with hardware numbers, no throughput or perplexity figures are claimed.
+### Real end-to-end generation: eviction breaks coherence
+
+Model-level testing has now been run — `mlx_lm.generate` on
+`mlx-community/Llama-3.2-1B-Instruct-4bit` (`head_dim=64`, `rope_theta=500000`)
+and `mlx-community/Mistral-7B-Instruct-v0.3-4bit` (`head_dim=128`,
+`rope_theta=1000000`) — and the result is a real, reproducible problem, not
+just a theoretical caveat.
+
+:::danger[Eviction corrupts generation quality — this is not tuning, it collapses almost immediately]
+The moment eviction actually fires (as little as **one or two evictions**,
+tested with `h2o_n_sink=0` and `h2o_budget` set to only 1–10 tokens above the
+prompt length), output degrades into repetition loops. Severity scales with
+how many evictions occur — a handful causes phrase-level repetition, dozens
+causes single-token loops:
+
+| Model | Budget vs prompt | Evictions | Output |
+|---|---|---|---|
+| Llama-3.2-1B | prompt + 1 | many (40 generated tokens, budget 14) | `Paris.\nThe\nThe\nThe\nThe\nThe\nThe\nThe...` (collapses to one repeated token) |
+| Llama-3.2-1B | prompt + 3 | many | `Paris.\nWhat is the capital is the capital is the capital...` (phrase-loop) |
+| Llama-3.2-1B | prompt + 10 | many | `Paris.\nWhat is the largest city in France? Answer in one word. Answer in one word...` (longer phrase-loop, closer to baseline) |
+| Llama-3.2-1B | no eviction (budget=10000) | 0 | `Paris.\nWhat is the largest city in France? Answer in one word. Paris.\nWhat is the largest city in France? Lyon...` (baseline repetition is a model quirk on this short prompt, not a cache defect) |
+| Llama-3.2-1B | 32 (long 64-token prompt) | many | `- - - - - - - - - - - -...` (total collapse) |
+| Mistral-7B | 64 (long 72-token prompt) | many | blank lines only (total collapse) |
+
+**Root cause — verified precisely, and it is NOT a RoPE/position bug:**
+the scoring formula gives every newly-arrived token a starting score of
+exactly `0.0` (it hasn't accumulated any attention mass yet), and the
+eviction rule removes whichever token holds the **global minimum** score. On
+essentially any real (non-degenerate) score distribution, the brand-new
+token's `0.0` *is* that global minimum — so **the most recently generated
+token is evicted on almost every step once the cache is full**, before it
+ever gets a chance to accumulate score. Traced directly on the Llama-3.2-1B
+run above: after 43 true decode steps, the cache's kept positions were still
+exactly `[0..13]` — the prompt, unchanged, with **zero** generated tokens
+ever admitted. The model spent the entire generation attending only to the
+original prompt, with no visibility into anything it had itself generated —
+which is exactly the repetition-loop failure pattern observed. This is a
+genuine limitation of the paper's cumulative-sum scoring at low/tight
+budgets, not a bug in this implementation's eviction *rule*, which correctly
+implements the paper's Algorithm 1 (verified line-by-line — see
+[Evidence](#evidence) above and the module docstring).
+
+A second, narrower issue was found and fixed during this investigation:
+K/V arriving at `update_and_fetch` are already RoPE-rotated by the attention
+layer upstream, and `mlx_lm` also rotates the *next* query/key using
+`cache.offset` — both assume a contiguous, gap-free cache. Once *any* row is
+evicted from the interior of the retained set (which the early-token freeze
+above makes rare, but not impossible — e.g. with `h2o_n_sink > 0`, sink rows
+are permanently protected while later rows can still eventually be evicted,
+opening a real interior gap), position bookkeeping desyncs and corrupts
+attention math for every step afterward. Both are now fixed: stored keys are
+de-rotated and re-rotated to a gap-free layout on every eviction
+(`rope_remap_positions`), and `cache.offset` is tracked as the true absolute
+step count rather than the kept-row count, so the model's own query rotation
+stays correct without this cache needing to intercept it. Verified via a
+synthetic fingerprinted-token test that forces an interior eviction and
+confirms every surviving key de-rotates back to its exact original
+unrotated value. This fix is real and independently worth having, but by
+itself it does **not** fix the collapse demonstrated above — the freeze
+happens before interior eviction geometry ever becomes relevant.
+:::
+
+**Practical takeaway:** do not use `h2o` in this library for real generation
+today. It is validated at the unit/synthetic level (the mechanism —
+scoring, sink protection, budget enforcement, and now RoPE position
+consistency under interior eviction — is implemented correctly per the
+paper's Algorithm 1) but **not yet safe for actual model output**, because
+the paper's own cumulative-sum scoring formula starves newly-generated
+tokens of any chance to survive once the budget is full. Fixing this needs a
+change to the eviction/scoring policy itself (e.g. a grace period before a
+token becomes eviction-eligible, or age-normalized scoring) — a bigger,
+more opinionated algorithmic change than a bugfix, and not undertaken here.
+Tracked as follow-up work, not silently patched over.
 
 ## When to use it
 
-H2O-adapted is best when you want a **budget-bounded cache that improves over
-recency-only eviction** (StreamingLLM) by using attention signal rather than position.
-Heavy-hitter tokens (those consistently attended to) survive; recency is not the only
-criterion for retention.
+**Today: nowhere in production.** The [confirmed eviction-corruption finding
+above](#real-end-to-end-generation-eviction-breaks-coherence) means this cache
+should not be pointed at real generation until position remapping is
+implemented — treat it as a reference implementation of the paper's scoring
+mechanism, validated at the unit/synthetic level only.
+
+Once that's fixed, the intended niche is a **budget-bounded cache that
+improves over recency-only eviction** (StreamingLLM) by using attention
+signal rather than position — heavy-hitter tokens (those consistently
+attended to) survive; recency is not the only criterion for retention.
 
 | Scenario | Recommended method |
 |----------|-------------------|
 | Compress all tokens uniformly | KIVI-2bit |
 | Hard cap on tokens, evict at prefill only | SnapKV-adapted |
 | Constant-memory, position-based eviction | StreamingLLM-adapted |
-| **Constant-memory, importance-based eviction (continuous)** | **H2O-adapted** |
+| Constant-memory, importance-based eviction (continuous) | H2O-adapted — **not yet safe for real generation, see above** |
 | Recover quality from aggressive quantization | GEAR |
 
 **See also:** [CaM-adapted](./cam) makes the same eviction choice as H2O but

--- a/docs-site/docs/algorithms/h2o.md
+++ b/docs-site/docs/algorithms/h2o.md
@@ -4,26 +4,34 @@
 (Zhang et al., ICLR 2024) — **H2O-adapted (VeloxQuant-MLX implementation)**,
 not a faithful port.
 
-:::danger[Not safe for real generation yet — cache freezes on early tokens]
-Real-model testing (below) confirms eviction corrupts output — as few as one
-or two evictions can send generation into repetition loops, and heavier
-eviction causes total collapse. Root cause: the scoring formula gives every
-newly-arrived token a starting score of exactly `0`, and the eviction rule
-removes the *global minimum* score — so once the cache is full, the brand-new
-token is (almost always) its own eviction target, before it ever gets a
-chance to accumulate attention mass. In practice this means **the kept set
-freezes on whichever tokens filled the budget first** (typically the prompt)
-and never admits anything generated afterward — the model ends up generating
-forever while attending only to the original prompt, with zero visibility
-into its own recent output. This is a real limitation of the paper's own
-cumulative-sum formulation at low budgets, not an implementation bug in the
-eviction *rule* itself (which correctly implements Algorithm 1 — see
-[fidelity check](#fidelity-to-algorithm-1)). See
-[the finding](#real-end-to-end-generation-eviction-breaks-coherence) before
-using `method="h2o"` for anything beyond studying the mechanism. A separate
-scalability bug that used to crash long prefills outright (regardless of
-eviction settings) has since been fixed — see
-[long-context testing](#long-context-testing-the-freeze-holds-at-scale-plus-a-scalability-bug-now-fixed).
+:::warning[Freeze mechanism fixed via `h2o_grace` — but tight budgets still degrade output]
+Real-model testing (below) originally found that eviction corrupted output —
+as few as one or two evictions could send generation into repetition loops,
+and heavier eviction caused total collapse. Root cause: the scoring formula
+gives every newly-arrived token a starting score of exactly `0`, and the
+eviction rule removes the *global minimum* score — so the brand-new token
+was (almost always) its own eviction target the instant the cache filled,
+before it ever accumulated attention mass. The kept set froze on whichever
+tokens filled the budget first (typically the prompt) and never admitted
+anything generated afterward.
+
+**Fixed** via `h2o_grace` (default `16`): the most-recently-arrived `grace`
+tokens are protected from eviction the same way sink tokens are, giving
+every new token `grace` update steps to actually compete before it can be
+evicted. Verified structurally on real models: the kept-position window now
+genuinely advances with generation instead of freezing at `[0, budget-1]`
+forever — see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom).
+
+**Not fully solved:** fixing the freeze mechanism is necessary but not
+sufficient for *coherent* output. When `h2o_budget` is tight relative to
+`h2o_n_sink + h2o_grace` plus how much of the prompt needs to survive,
+eviction is forced to thin out old tokens into a sparse, gapped window
+(e.g. keeping positions `..., 37, 39, 41, 43, ...` instead of a contiguous
+range) to make room — and generation still degrades under that regime, just
+via a different mechanism (broken local coherence from the gaps) rather than
+the original freeze. Give `h2o_budget` real headroom over `h2o_n_sink +
+h2o_grace` for coherent output; see the table below for what "enough" looks
+like in practice.
 :::
 
 H2O-adapted is the library's **third eviction axis** and the first based on
@@ -49,8 +57,9 @@ model, tokenizer = mlx_lm.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
 config = KVCacheConfig(
     method="h2o",
     head_dim=128,
-    h2o_budget=512,  # max tokens retained at any time (sinks + non-sinks)
+    h2o_budget=512,  # max tokens retained at any time (sinks + grace + non-sinks)
     h2o_n_sink=4,  # initial positions never evicted (attention sinks)
+    h2o_grace=16,  # most-recent tokens never evicted (fixes the early-token freeze)
 )
 caches = KVCacheBuilder.for_model(model, config)
 model.make_cache = lambda *_a, **_k: caches
@@ -60,8 +69,9 @@ model.make_cache = lambda *_a, **_k: caches
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `h2o_budget` | `512` | Maximum token positions retained at any time. When the cache exceeds this count, the lowest-score non-sink token is permanently evicted. |
+| `h2o_budget` | `512` | Maximum token positions retained at any time. When the cache exceeds this count, the lowest-score non-sink, non-grace token is permanently evicted. |
 | `h2o_n_sink` | `4` | Number of initial token positions always retained (attention-sink tokens never eligible for eviction). |
+| `h2o_grace` | `16` | Number of most-recently-arrived tokens always retained, giving each new token this many update steps to accumulate real attention mass before it becomes eviction-eligible. `0` reproduces the original paper-faithful (but freeze-prone) behavior. `h2o_n_sink + h2o_grace` must be `< h2o_budget`. |
 
 ## How it works
 
@@ -75,9 +85,11 @@ For every incoming token (both prefill and decode), per head:
    score vector: `scores += attn`. New tokens start with score 0 and begin
    accumulating on subsequent steps.
 3. **Eviction (if over budget).** If the total token count exceeds `h2o_budget`, a
-   protected score view is constructed: the first `h2o_n_sink` positions receive
-   `+inf` (they are never evicted). The token with the minimum protected score is
-   permanently removed.
+   protected score view is constructed: the first `h2o_n_sink` positions
+   receive `+inf` (attention sinks), and the last `h2o_grace` positions — the
+   most recently arrived tokens, since positions are always kept sorted
+   ascending after eviction — also receive `+inf`. The token with the
+   minimum protected score among the remainder is permanently removed.
 4. **Guarantee.** After every step, the cache holds at most `h2o_budget` tokens.
 
 No `.bits` attribute — stored K/V remain in fp16. The `compression_ratio` and
@@ -116,6 +128,11 @@ faithful port.
 own scoring rule (new tokens start at score 0, minimum gets evicted) is what
 produces the early-token freeze described below — implementing it exactly as
 specified is what causes the practical problem, not a deviation from it.
+`h2o_grace` (default `16`, see [How it works](#how-it-works)) is this
+library's own addition on top of Algorithm 1 to make the method usable in
+practice; the paper itself does not specify a grace period, so `h2o_grace=0`
+is the fidelity-preserving setting if you want to study the paper's
+mechanism exactly as published.
 
 ## Evidence
 
@@ -143,20 +160,26 @@ All claims trace to passing tests in
 - `cache.offset` tracks the true absolute step count, not the kept-row count, once eviction has occurred
 - The vectorized below-budget batch path matches the sequential per-token loop it replaces bit-for-bit within fp16 rounding, including for a single call whose batch straddles the below-budget/over-budget boundary
 - A 4,000-token single-call absorption (no eviction) completes without error — the regression test for the prefill scalability crash
+- `h2o_grace` defaults to a nonzero value in `KVCacheConfig`; grace-protected tokens survive even when they hold the lowest score, verified against a synthetic case where `h2o_grace=0` would evict the newest tokens
+- The fused Metal eviction kernel (`veloxquant_mlx/tests/metal/test_h2o_evict.py`, 18 tests) matches the pure-MLX eviction path bit-for-bit, including sink+grace protection, interior eviction, tie-break-matches-`mx.argmin`, and bit-identical untouched rows
 
 The offline harness in `benchmark_scripts/benchmark_h2o.py` sweeps
 `(seq_len, budget, n_sink)` and reports latency and compression ratio —
 **synthetic, not model-level.**
 
-### Real end-to-end generation: eviction breaks coherence
+### Real end-to-end generation: the `h2o_grace=0` baseline (historical)
 
-Model-level testing has now been run — `mlx_lm.generate` on
+Model-level testing was run — `mlx_lm.generate` on
 `mlx-community/Llama-3.2-1B-Instruct-4bit` (`head_dim=64`, `rope_theta=500000`)
 and `mlx-community/Mistral-7B-Instruct-v0.3-4bit` (`head_dim=128`,
-`rope_theta=1000000`) — and the result is a real, reproducible problem, not
-just a theoretical caveat.
+`rope_theta=1000000`) — and found a real, reproducible problem, not just a
+theoretical caveat. This section documents the **`h2o_grace=0` behavior**
+(the library's default before the grace-period fix, and still what you get
+if you explicitly set `h2o_grace=0` to study the paper's mechanism exactly
+as published). See [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom)
+below for the current default (`h2o_grace=16`) behavior.
 
-:::danger[Eviction corrupts generation quality — this is not tuning, it collapses almost immediately]
+:::danger[grace=0: eviction corrupts generation quality — this is not tuning, it collapses almost immediately]
 The moment eviction actually fires (as little as **one or two evictions**,
 tested with `h2o_n_sink=0` and `h2o_budget` set to only 1–10 tokens above the
 prompt length), output degrades into repetition loops. Severity scales with
@@ -210,19 +233,60 @@ itself it does **not** fix the collapse demonstrated above — the freeze
 happens before interior eviction geometry ever becomes relevant.
 :::
 
-**Practical takeaway:** do not use `h2o` in this library for real generation
-today. It is validated at the unit/synthetic level (the mechanism —
-scoring, sink protection, budget enforcement, and now RoPE position
-consistency under interior eviction — is implemented correctly per the
-paper's Algorithm 1) but **not yet safe for actual model output**, because
-the paper's own cumulative-sum scoring formula starves newly-generated
-tokens of any chance to survive once the budget is full. Fixing this needs a
-change to the eviction/scoring policy itself (e.g. a grace period before a
-token becomes eviction-eligible, or age-normalized scoring) — a bigger,
-more opinionated algorithmic change than a bugfix, and not undertaken here.
-Tracked as follow-up work, not silently patched over.
+**This `h2o_grace=0` behavior is no longer the default.** It's preserved
+here as a historical record and as an explicit opt-in
+(`h2o_grace=0`) for anyone studying the paper's Algorithm 1 exactly as
+published, including its practical failure mode at tight budgets. For real
+usage, see the grace-period results next.
+
+### Grace-period testing: fixes the freeze mechanism, coherence still needs budget headroom
+
+Re-ran the same real-model methodology with `h2o_grace > 0` to check whether
+protecting recently-arrived tokens actually fixes the freeze — and to be
+honest about what it does and doesn't fix.
+
+**The freeze mechanism itself is fixed, structurally verified.** With
+`h2o_grace=8` and a short prompt (13 tokens, `h2o_budget=14`), the kept
+position set — which with `h2o_grace=0` stayed frozen at `[0..13]` forever —
+now genuinely advances: `[0, 1, 2, 3, 4, 5, 27, 29, 31, 33, 35, 37, 39, 41]`.
+Generated tokens are finally entering and surviving in the cache, which
+never happened at `h2o_grace=0`.
+
+**But structural advancement alone doesn't guarantee coherent output.** At
+that same tight budget, the kept window has gaps every other position
+(`27, 29, 31, ...`) to make room for both `h2o_grace` and ongoing eviction —
+and generation degrades anyway, just via a different mechanism (broken local
+context from the gaps) rather than the original freeze:
+
+| `h2o_grace` | `h2o_budget` | Kept positions (tail) | Output |
+|---|---|---|---|
+| `0` | 14 | `[0..13]` (frozen) | `Paris.\nThe\nThe answer in French...` |
+| `8` | 14 | `[..., 27, 29, 31, 33, 35, 37, 39, 41]` (gapped, but advancing) | `Paris.\nTheTheTheThe...` (still degenerates) |
+| `0` | 32 | `[0..31]` (frozen) | Long but eventually repetitive |
+| `16` | 32 | `[..., 21, 23, 25, ..., 51]` (gapped) | `...the largest largest largest...` (different repetition, still broken) |
+| `32` | 128 | `[..., 110, 111, ..., 119]` (**contiguous** — enough headroom that eviction barely fired) | **Coherent, on-topic** photosynthesis explanation |
+
+The pattern: **give `h2o_budget` real headroom over `h2o_n_sink + h2o_grace`
+plus how much of the prompt/generation actually needs to be live at once.**
+When there's enough room that eviction rarely or never fires (the
+`grace=32, budget=128` row), output is coherent. When budget is so tight
+that eviction must skip every other position just to keep the grace window
+open, local coherence breaks down regardless of whether the freeze mechanism
+itself is fixed — a token's neighbors matter for coherent local generation,
+not just "is it in the cache at all."
+
+**Practical guidance:** `h2o_grace` (default `16`) fixes the specific,
+provable bug (permanent freeze on the first `budget` tokens). It does not
+turn H2O into a cache that works well at very tight budgets — that was
+never really about the freeze alone. Size `h2o_budget` generously if you
+want coherent long-form generation; treat H2O at very tight budgets as still
+experimental.
 
 ### Long-context testing: the freeze holds at scale, plus a scalability bug (now fixed)
+
+*(Historical: results below predate the `h2o_grace` fix and use `h2o_grace=0`
+implicitly, since the field didn't exist yet when this section was written.
+Kept for the scalability-bug findings, which are independent of grace.)*
 
 The same methodology was repeated on a genuinely long prompt (~3,238 tokens)
 to check whether the early-token freeze above behaves differently at scale,
@@ -280,23 +344,25 @@ large enough to avoid heavy early eviction.
 
 ## When to use it
 
-**Today: nowhere in production.** The [confirmed eviction-corruption finding
-above](#real-end-to-end-generation-eviction-breaks-coherence) means this cache
-should not be pointed at real generation until position remapping is
-implemented — treat it as a reference implementation of the paper's scoring
-mechanism, validated at the unit/synthetic level only.
+**With `h2o_grace` at its default (`16`) and `h2o_budget` sized with real
+headroom** (see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom) —
+budget comfortably above `h2o_n_sink + h2o_grace` plus expected live context),
+H2O-adapted is a **budget-bounded cache that improves over recency-only
+eviction** (StreamingLLM) by using attention signal rather than position —
+heavy-hitter tokens (those consistently attended to) survive; recency is not
+the only criterion for retention.
 
-Once that's fixed, the intended niche is a **budget-bounded cache that
-improves over recency-only eviction** (StreamingLLM) by using attention
-signal rather than position — heavy-hitter tokens (those consistently
-attended to) survive; recency is not the only criterion for retention.
+**At very tight budgets**, treat it as still experimental: the permanent
+freeze is fixed, but coherent output at aggressive compression ratios is not
+guaranteed — see the gapped-window failure mode above.
 
 | Scenario | Recommended method |
 |----------|-------------------|
 | Compress all tokens uniformly | KIVI-2bit |
 | Hard cap on tokens, evict at prefill only | SnapKV-adapted |
 | Constant-memory, position-based eviction | StreamingLLM-adapted |
-| Constant-memory, importance-based eviction (continuous) | H2O-adapted — **not yet safe for real generation, see above** |
+| Constant-memory, importance-based eviction (continuous), budget has headroom | H2O-adapted |
+| Constant-memory, importance-based eviction at very tight budgets | Still experimental — see grace-period findings above |
 | Recover quality from aggressive quantization | GEAR |
 
 **See also:** [CaM-adapted](./cam) makes the same eviction choice as H2O but

--- a/docs-site/docs/algorithms/h2o.md
+++ b/docs-site/docs/algorithms/h2o.md
@@ -4,34 +4,49 @@
 (Zhang et al., ICLR 2024) — **H2O-adapted (VeloxQuant-MLX implementation)**,
 not a faithful port.
 
-:::warning[Freeze mechanism fixed via `h2o_grace` — but tight budgets still degrade output]
+:::warning[Two real bugs fixed (`h2o_grace`, `h2o_decay`) — tight budgets and a separate eviction-quality issue remain]
 Real-model testing (below) originally found that eviction corrupted output —
 as few as one or two evictions could send generation into repetition loops,
-and heavier eviction caused total collapse. Root cause: the scoring formula
-gives every newly-arrived token a starting score of exactly `0`, and the
-eviction rule removes the *global minimum* score — so the brand-new token
-was (almost always) its own eviction target the instant the cache filled,
-before it ever accumulated attention mass. The kept set froze on whichever
-tokens filled the budget first (typically the prompt) and never admitted
-anything generated afterward.
+and heavier eviction caused total collapse. Root cause #1: the scoring
+formula gives every newly-arrived token a starting score of exactly `0`, and
+the eviction rule removes the *global minimum* score — so the brand-new
+token was (almost always) its own eviction target the instant the cache
+filled, before it ever accumulated attention mass. The kept set froze on
+whichever tokens filled the budget first (typically the prompt) and never
+admitted anything generated afterward.
 
 **Fixed** via `h2o_grace` (default `16`): the most-recently-arrived `grace`
 tokens are protected from eviction the same way sink tokens are, giving
 every new token `grace` update steps to actually compete before it can be
-evicted. Verified structurally on real models: the kept-position window now
-genuinely advances with generation instead of freezing at `[0, budget-1]`
-forever — see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom).
+evicted.
 
-**Not fully solved:** fixing the freeze mechanism is necessary but not
-sufficient for *coherent* output. When `h2o_budget` is tight relative to
-`h2o_n_sink + h2o_grace` plus how much of the prompt needs to survive,
-eviction is forced to thin out old tokens into a sparse, gapped window
-(e.g. keeping positions `..., 37, 39, 41, 43, ...` instead of a contiguous
-range) to make room — and generation still degrades under that regime, just
-via a different mechanism (broken local coherence from the gaps) rather than
-the original freeze. Give `h2o_budget` real headroom over `h2o_n_sink +
-h2o_grace` for coherent output; see the table below for what "enough" looks
-like in practice.
+Fixing the freeze exposed root cause #2: scores are a running sum that never
+shrinks, so a token's total lifetime attention mass grows with its age
+regardless of current relevance. An old survivor can outscore every
+recently-graduated token forever, so — even with the freeze fixed — the kept
+window stayed pinned near the *start* of generation for hundreds of decode
+steps instead of tracking the current position (verified: after 400 decode
+steps at `h2o_budget=64, h2o_grace=16`, the kept window without decay was
+still `[4..74]`, essentially the prompt, while the model had moved on to
+position 415).
+
+**Fixed** via `h2o_decay` (default `0.98`): existing scores are
+multiplicatively decayed each update step before new mass is added, so old
+tokens' scores fade instead of accumulating forever. Verified: the same
+400-step run with decay advances the kept window to `[297..415]` — tracking
+current generation instead of being stuck near the prompt.
+
+**Not fully solved:** with both fixes, the kept window is a genuinely
+*recent*, mostly-contiguous set — but a separate, deeper issue remains at
+very tight budgets: eviction can still remove a token whose local context
+the model needs mid-generation (confirmed: identical output with
+`h2o_decay=1.0` and `h2o_decay=0.98` at `budget=128, grace=32` diverges from
+the no-eviction baseline at the exact point eviction starts, breaking
+`"thylakoid"` into `"th th th th..."`). This is **not** a grace or decay
+problem — a no-eviction control run on the same prompt stays coherent for
+the full 300 tokens — it's a remaining gap in the eviction *quality* itself.
+See [grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open)
+for the full data.
 :::
 
 H2O-adapted is the library's **third eviction axis** and the first based on
@@ -60,6 +75,7 @@ config = KVCacheConfig(
     h2o_budget=512,  # max tokens retained at any time (sinks + grace + non-sinks)
     h2o_n_sink=4,  # initial positions never evicted (attention sinks)
     h2o_grace=16,  # most-recent tokens never evicted (fixes the early-token freeze)
+    h2o_decay=0.98,  # per-step score decay (fixes old tokens permanently outranking new ones)
 )
 caches = KVCacheBuilder.for_model(model, config)
 model.make_cache = lambda *_a, **_k: caches
@@ -72,6 +88,7 @@ model.make_cache = lambda *_a, **_k: caches
 | `h2o_budget` | `512` | Maximum token positions retained at any time. When the cache exceeds this count, the lowest-score non-sink, non-grace token is permanently evicted. |
 | `h2o_n_sink` | `4` | Number of initial token positions always retained (attention-sink tokens never eligible for eviction). |
 | `h2o_grace` | `16` | Number of most-recently-arrived tokens always retained, giving each new token this many update steps to accumulate real attention mass before it becomes eviction-eligible. `0` reproduces the original paper-faithful (but freeze-prone) behavior. `h2o_n_sink + h2o_grace` must be `< h2o_budget`. |
+| `h2o_decay` | `0.98` | Multiplicative decay applied to every existing score each update step, before new attention mass is added. Fixes old tokens permanently outranking newer ones (scores otherwise only ever grow). Must be in `(0, 1]`; `1.0` disables decay and reproduces the original paper-faithful (but staleness-prone) behavior. |
 
 ## How it works
 
@@ -81,9 +98,12 @@ For every incoming token (both prefill and decode), per head:
    proxy query and attends to all currently stored key rows via scaled dot-product
    softmax: `attn = softmax(K_stored @ k_i / sqrt(D))`. This gives `[n_kept]`
    softmax weights for the existing cache entries.
-2. **Score accumulation.** The weights are added to the existing per-token cumulative
-   score vector: `scores += attn`. New tokens start with score 0 and begin
-   accumulating on subsequent steps.
+2. **Score accumulation, with decay.** Existing scores are first multiplied by
+   `h2o_decay` (default `0.98`), then the new weights are added:
+   `scores = scores * h2o_decay + attn`. New tokens start with score 0 and
+   begin accumulating on subsequent steps. Without decay (`h2o_decay=1.0`),
+   scores are a pure running sum that never shrinks — see the warning above
+   for why that lets old tokens permanently outrank newer ones.
 3. **Eviction (if over budget).** If the total token count exceeds `h2o_budget`, a
    protected score view is constructed: the first `h2o_n_sink` positions
    receive `+inf` (attention sinks), and the last `h2o_grace` positions — the
@@ -125,14 +145,16 @@ Documented as "H2O-adapted (key-as-query proxy)" throughout — never claimed as
 faithful port.
 
 **Not a fidelity gap, but a consequence of the formula itself:** the paper's
-own scoring rule (new tokens start at score 0, minimum gets evicted) is what
-produces the early-token freeze described below — implementing it exactly as
-specified is what causes the practical problem, not a deviation from it.
-`h2o_grace` (default `16`, see [How it works](#how-it-works)) is this
-library's own addition on top of Algorithm 1 to make the method usable in
-practice; the paper itself does not specify a grace period, so `h2o_grace=0`
-is the fidelity-preserving setting if you want to study the paper's
-mechanism exactly as published.
+own scoring rule (new tokens start at score 0, minimum gets evicted, scores
+accumulate as an unbounded running sum) is what produces both the
+early-token freeze and the score-staleness problem described below —
+implementing it exactly as specified is what causes the practical problems,
+not a deviation from it. `h2o_grace` (default `16`) and `h2o_decay` (default
+`0.98`, see [How it works](#how-it-works)) are this library's own additions
+on top of Algorithm 1 to make the method usable in practice; the paper
+itself specifies neither a grace period nor score decay, so `h2o_grace=0,
+h2o_decay=1.0` is the fidelity-preserving setting if you want to study the
+paper's mechanism exactly as published.
 
 ## Evidence
 
@@ -161,7 +183,9 @@ All claims trace to passing tests in
 - The vectorized below-budget batch path matches the sequential per-token loop it replaces bit-for-bit within fp16 rounding, including for a single call whose batch straddles the below-budget/over-budget boundary
 - A 4,000-token single-call absorption (no eviction) completes without error — the regression test for the prefill scalability crash
 - `h2o_grace` defaults to a nonzero value in `KVCacheConfig`; grace-protected tokens survive even when they hold the lowest score, verified against a synthetic case where `h2o_grace=0` would evict the newest tokens
-- The fused Metal eviction kernel (`veloxquant_mlx/tests/metal/test_h2o_evict.py`, 18 tests) matches the pure-MLX eviction path bit-for-bit, including sink+grace protection, interior eviction, tie-break-matches-`mx.argmin`, and bit-identical untouched rows
+- `h2o_decay` defaults to `< 1.0` in `KVCacheConfig`; `decay=1.0` is bit-for-bit identical to omitting decay; with decay, an old token's score after many later updates is strictly lower than without it, and a later token can out-score an earlier one (impossible under pure accumulation, where a 60-step synthetic run shows a -0.97 correlation between token age and score)
+- The vectorized batch-absorb path applies decay identically to the sequential per-token loop it replaces, verified to fp32-rounding precision in both the from-empty and nonempty-prior-state branches (the exponentiated per-row decay power is the highest-risk part of the decay implementation)
+- The fused Metal eviction kernel (`veloxquant_mlx/tests/metal/test_h2o_evict.py`, 18 tests) matches the pure-MLX eviction path bit-for-bit, including sink+grace protection, interior eviction, tie-break-matches-`mx.argmin`, and bit-identical untouched rows — decay is applied entirely in the score-accumulation step before either eviction path runs, so no kernel changes were needed for it
 
 The offline harness in `benchmark_scripts/benchmark_h2o.py` sweeps
 `(seq_len, budget, n_sink)` and reports latency and compression ratio —
@@ -176,8 +200,8 @@ and `mlx-community/Mistral-7B-Instruct-v0.3-4bit` (`head_dim=128`,
 theoretical caveat. This section documents the **`h2o_grace=0` behavior**
 (the library's default before the grace-period fix, and still what you get
 if you explicitly set `h2o_grace=0` to study the paper's mechanism exactly
-as published). See [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom)
-below for the current default (`h2o_grace=16`) behavior.
+as published). See [grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open)
+below for the current default (`h2o_grace=16, h2o_decay=0.98`) behavior.
 
 :::danger[grace=0: eviction corrupts generation quality — this is not tuning, it collapses almost immediately]
 The moment eviction actually fires (as little as **one or two evictions**,
@@ -239,48 +263,73 @@ here as a historical record and as an explicit opt-in
 published, including its practical failure mode at tight budgets. For real
 usage, see the grace-period results next.
 
-### Grace-period testing: fixes the freeze mechanism, coherence still needs budget headroom
+### Grace-and-decay testing: fixes window advancement, eviction quality at tight budgets remains open
 
-Re-ran the same real-model methodology with `h2o_grace > 0` to check whether
-protecting recently-arrived tokens actually fixes the freeze — and to be
-honest about what it does and doesn't fix.
+Re-ran the same real-model methodology with `h2o_grace > 0` and, once that
+exposed a second problem, with `h2o_decay < 1.0` on top of it — to check
+whether each fix does what it claims, and to be honest about what's still
+unsolved.
 
-**The freeze mechanism itself is fixed, structurally verified.** With
+**The freeze mechanism is fixed, structurally verified.** With
 `h2o_grace=8` and a short prompt (13 tokens, `h2o_budget=14`), the kept
 position set — which with `h2o_grace=0` stayed frozen at `[0..13]` forever —
 now genuinely advances: `[0, 1, 2, 3, 4, 5, 27, 29, 31, 33, 35, 37, 39, 41]`.
 Generated tokens are finally entering and surviving in the cache, which
 never happened at `h2o_grace=0`.
 
-**But structural advancement alone doesn't guarantee coherent output.** At
-that same tight budget, the kept window has gaps every other position
-(`27, 29, 31, ...`) to make room for both `h2o_grace` and ongoing eviction —
-and generation degrades anyway, just via a different mechanism (broken local
-context from the gaps) rather than the original freeze:
+**But grace alone doesn't mean the window tracks the *current* position.**
+Scores are a running sum that never shrinks, so a token that survived its
+grace window early in generation can keep outscoring every token that
+graduates afterward, indefinitely. Direct measurement at `h2o_budget=64,
+h2o_n_sink=4, h2o_grace=16`, generating 400 tokens: with `h2o_decay=1.0`
+(no decay), the kept window after 400 decode steps was
+`[4, 5, ..., 21, 24, 26, ..., 74]` plus a handful of the very latest
+tokens — essentially still the prompt, 300+ positions behind where
+generation actually was. With `h2o_decay=0.98`, the same run's kept window
+was `[297, 299, ..., 415]` — genuinely tracking the current position instead
+of clinging to the prompt.
 
-| `h2o_grace` | `h2o_budget` | Kept positions (tail) | Output |
+**Decay fixes window *advancement*, not the earlier gapped-window
+degradation by itself.** At the original tight-budget case from the freeze
+investigation (`h2o_budget=14, h2o_n_sink=2, h2o_grace=8`), the non-sink
+kept window has a steady gap-of-2 pattern (`..., 47, 49, 51, 53`) **with or
+without decay** — this specific pattern turned out to be a structural
+consequence of `h2o_budget - h2o_n_sink - h2o_grace` being very small (only
+4 "competable" slots), not a staleness artifact: the token that has *just*
+graduated out of the grace window is always the newest possible competable
+token, so it is close to sole minimum by construction regardless of decay
+strength. Confirmed with a controlled A/B (`h2o_budget=128, h2o_n_sink=2,
+h2o_grace=32` — enough headroom that this effect is negligible): the *kept
+positions and final generated text were byte-for-byte identical* between
+`h2o_decay=1.0` and `h2o_decay=0.98`, even though the underlying score
+magnitudes differed by ~8x (max score `24.16` vs `2.97`) — decay changed
+score *scale*, not eviction *order*, at this budget.
+
+**A separate, deeper issue remains, independent of grace and decay.** At
+`h2o_budget=128, h2o_n_sink=2, h2o_grace=32`, generation is coherent for a
+while and then breaks mid-word: `"...occurs in the th th th th..."` instead
+of `"...occurs in the thylakoid membranes..."`. This is identical between
+`h2o_decay=1.0` and `h2o_decay=0.98` (ruling out decay as cause or fix), and
+a **no-eviction control run** (`h2o_budget=10000`, same prompt, same seed)
+stays fully coherent for the entire 300-token generation — proving this
+specific break is caused by *an* eviction decision (some token whose local
+context the model needed was dropped at exactly the wrong moment), not by
+the freeze or staleness mechanisms already fixed, and not a general property
+of long generation on this model.
+
+| Fix | What it corrects | Verified how | Still not covered |
 |---|---|---|---|
-| `0` | 14 | `[0..13]` (frozen) | `Paris.\nThe\nThe answer in French...` |
-| `8` | 14 | `[..., 27, 29, 31, 33, 35, 37, 39, 41]` (gapped, but advancing) | `Paris.\nTheTheTheThe...` (still degenerates) |
-| `0` | 32 | `[0..31]` (frozen) | Long but eventually repetitive |
-| `16` | 32 | `[..., 21, 23, 25, ..., 51]` (gapped) | `...the largest largest largest...` (different repetition, still broken) |
-| `32` | 128 | `[..., 110, 111, ..., 119]` (**contiguous** — enough headroom that eviction barely fired) | **Coherent, on-topic** photosynthesis explanation |
+| `h2o_grace` | New tokens evicted before they can compete (starting score `0.0` is the global min) | Kept window structurally advances past `[0, budget-1]` | Doesn't stop *old* tokens from permanently dominating *newer* ones |
+| `h2o_decay` | Old tokens permanently outrank newer ones (scores never shrink) | Kept window tracks current position (`[297..415]` vs `[4..74]` at 400 steps) | Doesn't change eviction order once headroom is generous, and doesn't touch the gap-of-2 conveyor effect at very tight `budget - n_sink - grace` |
+| *(neither)* | A single eviction dropping context the model needed mid-generation | Ruled OUT grace/decay as cause via A/B + no-eviction control | **Open** — see [When to use it](#when-to-use-it) |
 
-The pattern: **give `h2o_budget` real headroom over `h2o_n_sink + h2o_grace`
-plus how much of the prompt/generation actually needs to be live at once.**
-When there's enough room that eviction rarely or never fires (the
-`grace=32, budget=128` row), output is coherent. When budget is so tight
-that eviction must skip every other position just to keep the grace window
-open, local coherence breaks down regardless of whether the freeze mechanism
-itself is fixed — a token's neighbors matter for coherent local generation,
-not just "is it in the cache at all."
-
-**Practical guidance:** `h2o_grace` (default `16`) fixes the specific,
-provable bug (permanent freeze on the first `budget` tokens). It does not
-turn H2O into a cache that works well at very tight budgets — that was
-never really about the freeze alone. Size `h2o_budget` generously if you
-want coherent long-form generation; treat H2O at very tight budgets as still
-experimental.
+**Practical guidance:** `h2o_grace` (default `16`) and `h2o_decay` (default
+`0.98`) fix two specific, provable bugs — permanent freeze and score
+staleness — and both are on by default. They do not turn H2O into a cache
+that is safe at very tight budgets: give `h2o_budget` real headroom over
+`h2o_n_sink + h2o_grace` (so the gap-of-2 conveyor effect stays negligible),
+and treat occasional mid-generation quality loss from a single bad eviction
+as a known, open limitation rather than a solved problem.
 
 ### Long-context testing: the freeze holds at scale, plus a scalability bug (now fixed)
 
@@ -344,17 +393,24 @@ large enough to avoid heavy early eviction.
 
 ## When to use it
 
-**With `h2o_grace` at its default (`16`) and `h2o_budget` sized with real
-headroom** (see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom) —
+**With `h2o_grace` and `h2o_decay` at their defaults (`16`, `0.98`) and
+`h2o_budget` sized with real headroom** (see
+[grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open) —
 budget comfortably above `h2o_n_sink + h2o_grace` plus expected live context),
 H2O-adapted is a **budget-bounded cache that improves over recency-only
 eviction** (StreamingLLM) by using attention signal rather than position —
-heavy-hitter tokens (those consistently attended to) survive; recency is not
-the only criterion for retention.
+heavy-hitter tokens (those consistently attended to) survive, the kept
+window tracks the current generation position rather than freezing near the
+prompt, and recency is not the only criterion for retention.
 
-**At very tight budgets**, treat it as still experimental: the permanent
-freeze is fixed, but coherent output at aggressive compression ratios is not
-guaranteed — see the gapped-window failure mode above.
+**At very tight budgets, or for long generations where any single eviction
+mattering is a real risk**, treat it as still experimental: the permanent
+freeze and score-staleness bugs are fixed, but a single eviction can still
+remove context the model needed mid-generation, and very tight
+`h2o_budget - h2o_n_sink - h2o_grace` headroom reintroduces a structural
+gapped-window pattern independent of decay — see
+[grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open)
+above.
 
 | Scenario | Recommended method |
 |----------|-------------------|
@@ -362,7 +418,7 @@ guaranteed — see the gapped-window failure mode above.
 | Hard cap on tokens, evict at prefill only | SnapKV-adapted |
 | Constant-memory, position-based eviction | StreamingLLM-adapted |
 | Constant-memory, importance-based eviction (continuous), budget has headroom | H2O-adapted |
-| Constant-memory, importance-based eviction at very tight budgets | Still experimental — see grace-period findings above |
+| Constant-memory, importance-based eviction at very tight budgets | Still experimental — see grace-and-decay findings above |
 | Recover quality from aggressive quantization | GEAR |
 
 **See also:** [CaM-adapted](./cam) makes the same eviction choice as H2O but

--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -193,6 +193,7 @@ class KVCacheConfig:
     h2o_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     h2o_n_sink: int = 4  # initial positions protected from eviction (attention sinks)
     h2o_rope_base: float = 10000.0  # RoPE base for post-eviction position remap; match the model
+    h2o_grace: int = 16  # most-recent tokens protected from eviction; fixes the early-token freeze
     # --- TOVA-adapted configuration (current-step attention-weight eviction, memoryless) ---
     tova_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     tova_n_sink: int = 4  # initial positions protected from eviction (attention sinks)

--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -194,6 +194,9 @@ class KVCacheConfig:
     h2o_n_sink: int = 4  # initial positions protected from eviction (attention sinks)
     h2o_rope_base: float = 10000.0  # RoPE base for post-eviction position remap; match the model
     h2o_grace: int = 16  # most-recent tokens protected from eviction; fixes the early-token freeze
+    h2o_decay: float = (
+        0.98  # per-step multiplicative decay on existing scores; fixes score staleness
+    )
     # --- TOVA-adapted configuration (current-step attention-weight eviction, memoryless) ---
     tova_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     tova_n_sink: int = 4  # initial positions protected from eviction (attention sinks)

--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -192,6 +192,7 @@ class KVCacheConfig:
     # --- H2O-adapted configuration (cumulative attention-mass heavy-hitter eviction) ---
     h2o_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     h2o_n_sink: int = 4  # initial positions protected from eviction (attention sinks)
+    h2o_rope_base: float = 10000.0  # RoPE base for post-eviction position remap; match the model
     # --- TOVA-adapted configuration (current-step attention-weight eviction, memoryless) ---
     tova_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     tova_n_sink: int = 4  # initial positions protected from eviction (attention sinks)

--- a/veloxquant_mlx/cache/h2o_cache.py
+++ b/veloxquant_mlx/cache/h2o_cache.py
@@ -75,6 +75,16 @@ original unrotated value. ``h2o_rope_base`` must match the model's own RoPE
 base for cause (1)'s correction to cancel out the original rotation
 correctly.
 
+Scalability fix (found while testing long context, independent of the RoPE
+issues above): a genuinely long prefill (~3200 tokens) with no eviction yet
+triggered previously crashed with ``RuntimeError: [metal::malloc] Resource
+limit (499000) exceeded`` before generation could even start, because
+``h2o_update``'s per-token Python loop issued 4 separate ``mx.concatenate``
+calls per token. Fixed in :mod:`veloxquant_mlx.quantizers.h2o` by batching
+whichever leading portion of an incoming batch is guaranteed not to trigger
+eviction into one vectorized call; verified numerically equivalent to the
+sequential loop it replaces.
+
 Byte accounting:
     h2o_kept_bytes    — fp16 bytes for currently retained K + V tokens
     full_seq_bytes    — hypothetical fp16 cost if all tokens were kept

--- a/veloxquant_mlx/cache/h2o_cache.py
+++ b/veloxquant_mlx/cache/h2o_cache.py
@@ -53,6 +53,27 @@ equivalent between the two. ``h2o_grace=0`` reproduces the original
 (paper-faithful, freeze-prone) behavior exactly, for anyone who wants to
 study or reproduce that failure mode.
 
+SECOND FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM (found while verifying the
+fix above): fixing the freeze is necessary but not sufficient for coherent
+output at tight budgets. Scores are a running sum that never shrinks, so an
+old token's total lifetime attention mass grows with its age regardless of
+current relevance — confirmed empirically (correlation of -0.97 between
+token age and score in a synthetic run). An old survivor could therefore
+outscore every recently-graduated (post-grace) token forever, so the
+eviction argmin thinned the *rest* of the budget into a sparse, gapped kept
+window instead of a contiguous recent block — generation still degraded,
+just via broken local coherence from the gaps rather than the original
+permanent freeze.
+
+Fixed via ``h2o_decay`` (default 0.98): every existing score is
+multiplicatively decayed each update step, before new attention mass is
+added, so old tokens' scores fade instead of accumulating forever. Applied
+identically in both the per-token loop and the vectorized batch-absorb path
+(:func:`veloxquant_mlx.quantizers.h2o._batch_absorb_no_eviction`) — verified
+numerically equivalent between the two (fp32-rounding-only difference).
+``h2o_decay=1.0`` reproduces the original (paper-faithful, staleness-prone)
+behavior exactly.
+
 RoPE position remapping (a separate, narrower, and now-fixed correctness
 issue found during the same investigation — real, but NOT the cause of the
 freeze above, since interior eviction rarely happens once the freeze sets
@@ -138,6 +159,14 @@ class H2OKVCache(_MLXKVCache):
             starting score of 0.0 makes it almost always the eviction target
             the instant the cache is full, freezing the kept set on whichever
             tokens filled the budget first.
+            ``h2o_decay`` (float, default 0.98) — multiplicative per-step
+            decay on existing scores, applied before new attention mass is
+            added. Fixes a second real, confirmed-on-real-models problem
+            (see module docstring): without this, scores only ever grow, so
+            old tokens permanently outrank newer ones regardless of current
+            relevance, thinning the kept window into a sparse, gapped
+            trickle instead of a contiguous local context even with grace
+            fixing the freeze. Must be in ``(0, 1]``; ``1.0`` disables decay.
 
     Notes:
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
@@ -168,6 +197,7 @@ class H2OKVCache(_MLXKVCache):
         self._n_sink = int(getattr(config, "h2o_n_sink", 4))
         self._rope_base = float(getattr(config, "h2o_rope_base", 10000.0))
         self._grace = int(getattr(config, "h2o_grace", 16))
+        self._decay = float(getattr(config, "h2o_decay", 0.98))
 
         self._head_dim: int = 0
         self._states: list[H2OState] = []
@@ -187,7 +217,12 @@ class H2OKVCache(_MLXKVCache):
             self._head_dim = D
             self._states = [
                 init_h2o_state(
-                    self._n_sink, self._budget, D, rope_base=self._rope_base, grace=self._grace
+                    self._n_sink,
+                    self._budget,
+                    D,
+                    rope_base=self._rope_base,
+                    grace=self._grace,
+                    decay=self._decay,
                 )
                 for _ in range(B * H)
             ]

--- a/veloxquant_mlx/cache/h2o_cache.py
+++ b/veloxquant_mlx/cache/h2o_cache.py
@@ -28,21 +28,30 @@ Adaptation limitations (stated plainly):
     default and what Llama/Mistral/Qwen use — see
     :func:`veloxquant_mlx.quantizers.a2ats_rope.rope_remap_positions`.
 
-KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM (not fixed here — needs a different
-eviction/scoring policy, see docs-site/docs/algorithms/h2o.md for the full
-writeup): real end-to-end generation testing on Llama-3.2-1B and Mistral-7B
-showed generation degrading into repetition loops (mild) or total collapse
-(severe) once the cache fills. Root cause, verified precisely: every
-newly-arrived token starts at score 0.0, and eviction removes the
-global-minimum-score token, so the brand-new token is (almost always) its own
-eviction target the moment the budget is full — before it ever accumulates
-attention mass. Traced directly: after 43 true decode steps on Llama-3.2-1B,
-the kept set was still exactly the original prompt's positions; the model
-generated the entire time with zero visibility into its own output. This is
-what implementing the paper's own scoring formula correctly produces at tight
-budgets — not a deviation from the paper, and not fixed by anything in this
-module. A real fix needs a different eviction/scoring rule (e.g. a grace
-period before a token becomes eviction-eligible).
+FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM (see docs-site/docs/algorithms/h2o.md
+for the full writeup): real end-to-end generation testing on Llama-3.2-1B
+and Mistral-7B showed generation degrading into repetition loops (mild) or
+total collapse (severe) once the cache filled. Root cause, verified
+precisely: every newly-arrived token started at score 0.0, and eviction
+removes the global-minimum-score token, so the brand-new token was (almost
+always) its own eviction target the moment the budget was full — before it
+ever accumulated attention mass. Traced directly: after 43 true decode steps
+on Llama-3.2-1B, the kept set was still exactly the original prompt's
+positions; the model generated the entire time with zero visibility into its
+own output. This was what implementing the paper's own scoring formula
+without any grace period produces at tight budgets — not a deviation from
+the paper (the paper doesn't specify one either), but a real practical gap.
+
+Fixed via ``h2o_grace`` (default 16): the most-recently-arrived ``grace``
+tokens are protected from eviction the same way sink tokens are (treated as
++inf in the eviction argmin), giving every new token ``grace`` update steps
+to accumulate real attention mass before it becomes eviction-eligible at
+all. Implemented identically in both the pure-MLX eviction path
+(:func:`veloxquant_mlx.quantizers.h2o._evict_via_mlx`) and the fused Metal
+kernel (:func:`veloxquant_mlx.metal.h2o_fused_evict`) — verified bit-for-bit
+equivalent between the two. ``h2o_grace=0`` reproduces the original
+(paper-faithful, freeze-prone) behavior exactly, for anyone who wants to
+study or reproduce that failure mode.
 
 RoPE position remapping (a separate, narrower, and now-fixed correctness
 issue found during the same investigation — real, but NOT the cause of the
@@ -120,7 +129,15 @@ class H2OKVCache(_MLXKVCache):
             ``h2o_n_sink`` (int, default 4)   — leading positions never evicted,
             ``h2o_rope_base`` (float, default 10000.0) — RoPE frequency base,
             must match the model's own attention RoPE base for post-eviction
-            position remapping to cancel out the original rotation correctly.
+            position remapping to cancel out the original rotation correctly,
+            ``h2o_grace`` (int, default 16) — most-recently-arrived tokens
+            protected from eviction, giving each new token this many update
+            steps to accumulate real attention mass before it becomes
+            eviction-eligible. Fixes a real, confirmed-on-real-models problem
+            (see module docstring): without this, a brand-new token's
+            starting score of 0.0 makes it almost always the eviction target
+            the instant the cache is full, freezing the kept set on whichever
+            tokens filled the budget first.
 
     Notes:
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
@@ -150,6 +167,7 @@ class H2OKVCache(_MLXKVCache):
         self._budget = int(getattr(config, "h2o_budget", 512))
         self._n_sink = int(getattr(config, "h2o_n_sink", 4))
         self._rope_base = float(getattr(config, "h2o_rope_base", 10000.0))
+        self._grace = int(getattr(config, "h2o_grace", 16))
 
         self._head_dim: int = 0
         self._states: list[H2OState] = []
@@ -168,7 +186,9 @@ class H2OKVCache(_MLXKVCache):
             self._H = H
             self._head_dim = D
             self._states = [
-                init_h2o_state(self._n_sink, self._budget, D, rope_base=self._rope_base)
+                init_h2o_state(
+                    self._n_sink, self._budget, D, rope_base=self._rope_base, grace=self._grace
+                )
                 for _ in range(B * H)
             ]
 

--- a/veloxquant_mlx/cache/h2o_cache.py
+++ b/veloxquant_mlx/cache/h2o_cache.py
@@ -20,12 +20,60 @@ Adaptation limitations (stated plainly):
   - Key-as-query proxy: attention weights are computed using the new key vector
     in place of the true query (not visible at cache level). Same approximation
     as SnapKV-adapted.
-  - No RoPE position-ID remapping after eviction; original positions are
-    preserved in returned rows.
   - Uniform budget and n_sink across all heads.
   - Scores accumulate as a running sum of softmax weights; the paper accumulates
     unnormalised attention logits in some variants — this may diverge at very
     low budgets.
+  - RoPE remapping assumes ``traditional=False`` (NeoX-style) rotation, MLX's
+    default and what Llama/Mistral/Qwen use — see
+    :func:`veloxquant_mlx.quantizers.a2ats_rope.rope_remap_positions`.
+
+KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM (not fixed here — needs a different
+eviction/scoring policy, see docs-site/docs/algorithms/h2o.md for the full
+writeup): real end-to-end generation testing on Llama-3.2-1B and Mistral-7B
+showed generation degrading into repetition loops (mild) or total collapse
+(severe) once the cache fills. Root cause, verified precisely: every
+newly-arrived token starts at score 0.0, and eviction removes the
+global-minimum-score token, so the brand-new token is (almost always) its own
+eviction target the moment the budget is full — before it ever accumulates
+attention mass. Traced directly: after 43 true decode steps on Llama-3.2-1B,
+the kept set was still exactly the original prompt's positions; the model
+generated the entire time with zero visibility into its own output. This is
+what implementing the paper's own scoring formula correctly produces at tight
+budgets — not a deviation from the paper, and not fixed by anything in this
+module. A real fix needs a different eviction/scoring rule (e.g. a grace
+period before a token becomes eviction-eligible).
+
+RoPE position remapping (a separate, narrower, and now-fixed correctness
+issue found during the same investigation — real, but NOT the cause of the
+freeze above, since interior eviction rarely happens once the freeze sets
+in). Two distinct causes, both fixed, for the case interior eviction *does*
+occur (e.g. with ``h2o_n_sink > 0``, where sink rows are permanently
+protected while later rows can still eventually be evicted, opening a real
+gap):
+
+  1. Stored keys arrive already RoPE-rotated for their true absolute
+     position. Dropping a middle row leaves survivors' storage index out of
+     sync with that baked-in rotation. Fixed by de-rotating and re-rotating
+     kept keys to a gap-free layout (``rope_remap_positions``) whenever
+     eviction changes the kept set — see ``h2o_update`` in
+     :mod:`veloxquant_mlx.quantizers.h2o`.
+  2. ``mlx_lm``'s attention module rotates BOTH the query and the incoming
+     key using ``self.rope(x, offset=cache.offset)``, entirely inside the
+     model's forward pass, before ``update_and_fetch`` is ever called — this
+     cache cannot intercept or correct the query's rotation after the fact.
+     The only way to make that rotation correct is for ``self.offset`` itself
+     to always equal the true absolute step count rather than the number of
+     rows this cache has kept. Fixed by managing ``self.keys``/``self.values``/
+     ``self.offset`` directly (not delegating to the base class's
+     append-only buffer, which assumes ``offset == stored row count``) — see
+     ``update_and_fetch`` below.
+
+Verified via a synthetic fingerprinted-token test that forces an interior
+eviction and confirms every surviving key de-rotates back to its exact
+original unrotated value. ``h2o_rope_base`` must match the model's own RoPE
+base for cause (1)'s correction to cancel out the original rotation
+correctly.
 
 Byte accounting:
     h2o_kept_bytes    — fp16 bytes for currently retained K + V tokens
@@ -42,6 +90,7 @@ from typing import Any
 import mlx.core as mx
 from mlx_lm.models.cache import KVCache as _MLXKVCache
 
+from veloxquant_mlx.quantizers.a2ats_rope import rope_remap_positions
 from veloxquant_mlx.quantizers.h2o import (
     H2OState,
     full_h2o_fp16_bytes,
@@ -58,7 +107,10 @@ class H2OKVCache(_MLXKVCache):
     Args:
         config: :class:`KVCacheConfig`. Fields consumed:
             ``h2o_budget`` (int, default 512) — maximum tokens retained at any time,
-            ``h2o_n_sink`` (int, default 4)   — leading positions never evicted.
+            ``h2o_n_sink`` (int, default 4)   — leading positions never evicted,
+            ``h2o_rope_base`` (float, default 10000.0) — RoPE frequency base,
+            must match the model's own attention RoPE base for post-eviction
+            position remapping to cancel out the original rotation correctly.
 
     Notes:
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
@@ -68,18 +120,26 @@ class H2OKVCache(_MLXKVCache):
         all ``h2o_*`` fields automatically via ``dataclasses.replace``.
         The per-head state is lazily initialised on the first call to
         ``update_and_fetch`` when shapes are known.
-        Writes through to the base ``mlx_lm`` ``KVCache``'s ``self.keys`` /
-        ``self.values`` / ``self.offset`` on every call so ``.state`` stays
-        valid (mlx_lm's ``generate()`` reads it unconditionally during
-        chunked prefill); ``is_trimmable()`` reports ``False`` since the
-        internal per-token eviction state can't be rolled back by a
-        base-class ``trim()`` (see #83).
+        Does NOT delegate to the base ``mlx_lm`` ``KVCache.update_and_fetch``:
+        that implementation assumes ``self.offset`` always equals the number
+        of rows physically stored, which eviction breaks. Instead
+        ``self.keys``/``self.values`` hold exactly the ``n_kept`` retained
+        rows and ``self.offset`` is kept equal to the *true absolute step
+        count*, so ``mlx_lm``'s ``self.rope(x, offset=cache.offset)`` call —
+        made on both the query and the next incoming key, entirely inside the
+        model's attention module, before this cache ever sees them — rotates
+        at the correct position without this cache needing to intercept the
+        query at all. ``.state``/``.size()``/``is_trimmable()`` are overridden
+        to keep this contract explicit rather than relying on the base
+        class's coincidentally-compatible slicing behavior (see #83 for the
+        historical reason ``.state`` must stay valid across chunked prefill).
     """
 
     def __init__(self, config: Any) -> None:
         super().__init__()
         self._budget = int(getattr(config, "h2o_budget", 512))
         self._n_sink = int(getattr(config, "h2o_n_sink", 4))
+        self._rope_base = float(getattr(config, "h2o_rope_base", 10000.0))
 
         self._head_dim: int = 0
         self._states: list[H2OState] = []
@@ -97,14 +157,53 @@ class H2OKVCache(_MLXKVCache):
             self._B = B
             self._H = H
             self._head_dim = D
-            self._states = [init_h2o_state(self._n_sink, self._budget, D) for _ in range(B * H)]
+            self._states = [
+                init_h2o_state(self._n_sink, self._budget, D, rope_base=self._rope_base)
+                for _ in range(B * H)
+            ]
 
     def _head_idx(self, b: int, h: int) -> int:
         return b * self._H + h
 
+    def _fix_incoming_rope(self, keys: mx.array, offset_before: int, next_pos: int) -> mx.array:
+        """Re-rotate incoming keys if the model rotated them at the wrong
+        absolute position.
+
+        Only matters as a defensive fallback: with ``self.offset`` now always
+        equal to the true absolute step count (see the class docstring),
+        ``offset_before`` and ``next_pos`` should already agree, and this is a
+        no-op. Kept so that a future change which reintroduces an
+        offset/position desync fails safe (corrects it) rather than silently
+        corrupting generation again like the original bug this cache had.
+        """
+        if offset_before == next_pos:
+            return keys
+        B, H, S, D = keys.shape
+        old_positions = mx.arange(offset_before, offset_before + S, dtype=mx.int32)
+        new_positions = mx.arange(next_pos, next_pos + S, dtype=mx.int32)
+        out_b = []
+        for b in range(B):
+            out_h = []
+            for h in range(H):
+                base = self._states[self._head_idx(b, h)].rope_base
+                out_h.append(
+                    rope_remap_positions(keys[b, h], old_positions, new_positions, base=base)
+                )
+            out_b.append(mx.stack(out_h, axis=0))
+        return mx.stack(out_b, axis=0)
+
     # ------------------------------------------------------------------
     def update_and_fetch(self, keys: mx.array, values: mx.array):
         """Absorb new K/V tokens, apply H2O eviction, return retained window.
+
+        Manages ``self.keys`` / ``self.values`` / ``self.offset`` directly
+        instead of delegating to the base class's append-only buffer, because
+        that buffer assumes ``offset`` always equals the stored row count —
+        false here the moment eviction drops a row. Keeping ``self.offset``
+        equal to the *true absolute step count* (not the kept-row count) is
+        what keeps ``mlx_lm``'s attention module rotating the next query and
+        incoming key at the correct position — see the class/module
+        docstrings for why getting this wrong silently corrupted generation.
 
         Args:
             keys:   ``[B, H, S, D]`` new key tokens (any dtype; cast to fp16).
@@ -117,8 +216,13 @@ class H2OKVCache(_MLXKVCache):
         B, H, S, D = keys.shape
         self._ensure_states(B, H, D)
 
+        offset_before = self.offset
+        next_pos = self._states[0].next_pos  # identical across heads (see class docstring)
+
         self._full_seq_bytes += B * H * S * D * 2 * 2  # K + V, fp16
         self._tokens_seen_total += B * H * S
+
+        keys_fixed = self._fix_incoming_rope(keys.astype(mx.float16), offset_before, next_pos)
 
         k_out_b, v_out_b = [], []
         for b in range(B):
@@ -128,7 +232,7 @@ class H2OKVCache(_MLXKVCache):
                 st = self._states[idx]
                 st = h2o_update(
                     st,
-                    keys[b, h].astype(mx.float16),
+                    keys_fixed[b, h],
                     values[b, h].astype(mx.float16),
                 )
                 self._states[idx] = st
@@ -144,16 +248,16 @@ class H2OKVCache(_MLXKVCache):
         # Byte accounting: sum across all head states
         self._h2o_kept_bytes = sum(h2o_fp16_bytes(st) for st in self._states)
 
-        # K_out/V_out is the full retained state every call, not a delta —
-        # reset so the base class's append-only buffer starts fresh instead
-        # of stacking on top of the previous call's rows. Without this,
-        # self.keys/self.values/self.offset stay at __init__ defaults
-        # forever, and mlx_lm's generate() crashes on `cache.state` during
-        # chunked prefill (see #83).
-        self.keys = None
-        self.values = None
-        self.offset = 0
-        return super().update_and_fetch(K_out, V_out)
+        # Store exactly the n_kept retained rows — NOT delegated to the base
+        # class's update_and_fetch, whose growing-buffer bookkeeping assumes
+        # offset == stored row count. self.offset instead tracks the true
+        # absolute step count, so the model's NEXT rope(..., offset=self.offset)
+        # call rotates correctly even though fewer than `offset` rows are
+        # physically stored.
+        self.keys = K_out
+        self.values = V_out
+        self.offset = self._states[0].next_pos
+        return K_out, V_out
 
     # ------------------------------------------------------------------
     def is_trimmable(self) -> bool:
@@ -162,6 +266,38 @@ class H2OKVCache(_MLXKVCache):
         determines what gets returned, silently corrupting future calls.
         """
         return False
+
+    def size(self) -> int:
+        """Rows actually stored (``n_kept``), NOT ``self.offset`` (the true
+        absolute step count) — the base class conflates the two, which is
+        exactly the assumption this cache must not make. Overridden
+        explicitly rather than relying on the base class's coincidentally
+        harmless behavior here."""
+        return 0 if self.keys is None else self.keys.shape[2]
+
+    @property
+    def state(self):
+        """``(keys, values)`` — always exactly the ``n_kept`` stored rows.
+
+        Not delegated to the base class's getter: it slices
+        ``self.keys[..., :self.offset, :]``, and since ``self.offset`` is the
+        true absolute step count (usually > n_kept once eviction has
+        happened), that would silently clamp to all stored rows anyway via
+        MLX's slice semantics — correct by coincidence, not by contract. Made
+        explicit here instead.
+        """
+        return self.keys, self.values
+
+    @state.setter
+    def state(self, v):
+        """Restoring from a saved state cannot recover the true step count
+        that produced it (H2O's own eviction history is not persisted), so
+        ``self.offset`` is set to the stored row count as the least-wrong
+        available estimate. Loading a saved H2O cache mid-eviction-history is
+        not a supported/tested path.
+        """
+        self.keys, self.values = v
+        self.offset = 0 if self.keys is None else self.keys.shape[2]
 
     # ------------------------------------------------------------------
     @property

--- a/veloxquant_mlx/metal/__init__.py
+++ b/veloxquant_mlx/metal/__init__.py
@@ -68,6 +68,7 @@ def __getattr__(name: str):
         "turboquant_fused_rvq_decode_attend",
         "comm_vq_decode_metal",
         "rabitq_hamming_score",
+        "h2o_fused_evict",
     }
     if name in _turboquant_names:
         from . import kernels as _k
@@ -95,4 +96,5 @@ __all__ = [
     "turboquant_fused_rvq_decode_attend",
     "comm_vq_decode_metal",
     "rabitq_hamming_score",
+    "h2o_fused_evict",
 ]

--- a/veloxquant_mlx/metal/_h2o_evict.py
+++ b/veloxquant_mlx/metal/_h2o_evict.py
@@ -88,7 +88,7 @@ def _evict_reduce_kernel(nsg: int):
     if key not in _cache:
         _cache[key] = mx.fast.metal_kernel(
             name=f"h2o_evict_reduce_nsg{nsg}",
-            input_names=["scores_mid", "n_sink_arr"],
+            input_names=["scores_mid", "n_sink_arr", "n_grace_arr"],
             output_names=["evict_idx"],
             header=f"#define NSG_C {nsg}\n",
             source=_H2O_EVICT_REDUCE_SRC,
@@ -129,9 +129,10 @@ def h2o_fused_evict(
     positions_mid: mx.array,
     n_sink: int,
     rope_base: float,
+    grace: int = 0,
     nsg: int = 4,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
-    """Fused sink-protected argmin + evict + RoPE-remap, batched over (batch*head).
+    """Fused sink+grace-protected argmin + evict + RoPE-remap, batched over (batch*head).
 
     Matches ``h2o_update``'s per-token eviction branch bit-for-bit (see
     ``H2O_METAL_KERNEL_TECH_SPEC.md`` section 3). Caller must have already
@@ -155,6 +156,10 @@ def h2o_fused_evict(
                        the re-rotation of shifted rows will not cancel out
                        the original rotation correctly (same requirement as
                        ``rope_remap_positions``).
+        grace:         Number of most-recently-arrived rows (trailing array
+                       index — positions are always sorted ascending, see
+                       ``H2OState.grace``) protected from eviction, uniform
+                       across all BH groups.
         nsg:           SIMD-groups per threadgroup for the reduction kernel.
 
     Returns:
@@ -178,9 +183,10 @@ def h2o_fused_evict(
         raise ValueError(f"h2o_fused_evict: nsg={nsg} must be in 1..32")
 
     n_sink_arr = mx.array([n_sink], dtype=mx.uint32)
+    n_grace_arr = mx.array([grace], dtype=mx.uint32)
 
     (evict_idx,) = _evict_reduce_kernel(nsg)(
-        inputs=[scores_mid.astype(mx.float32), n_sink_arr],
+        inputs=[scores_mid.astype(mx.float32), n_sink_arr, n_grace_arr],
         grid=(BH * 32, nsg, 1),
         threadgroup=(32, nsg, 1),
         output_shapes=[(BH,)],

--- a/veloxquant_mlx/metal/_h2o_evict.py
+++ b/veloxquant_mlx/metal/_h2o_evict.py
@@ -1,0 +1,211 @@
+"""H2O-adapted fused eviction Metal kernels — argmin reduction + apply.
+
+Replaces the Python per-token loop in ``h2o_update``'s over-budget branch
+(``veloxquant_mlx/quantizers/h2o.py``) — append, sink-protected argmin,
+evict, RoPE-remap the shifted rows — with two GPU dispatches per incoming
+token, batched across all ``(batch, head)`` pairs at once, instead of one
+Python-level iteration per ``(batch, head)`` per token plus ~15 small MLX
+ops each. Design: see ``paper/research/H2O_METAL_KERNEL_TECH_SPEC.md``.
+
+Two dispatches, not fused into one barrier-synchronized kernel (spec
+decision D4): the eviction decision (``evict_idx``) must be known by every
+thread before the compaction/rotation phase runs, and a single-threadgroup
+barrier-fused design would cap the largest ``h2o_budget`` this kernel could
+serve to whatever fits in one threadgroup's grid-stride reduction. Two
+dispatches avoid that ceiling entirely, at the cost of one extra dispatch
+per token — a real but modest cost against the ~15+ ops it replaces.
+
+  1. :func:`_h2o_evict_reduce` — sink-protected argmin over ``n_total``
+     candidate rows per ``(batch, head)`` group, one threadgroup per group.
+  2. :func:`_h2o_evict_apply` — given ``evict_idx``, compacts the surviving
+     ``n_kept`` rows and re-rotates (NeoX-style RoPE, ``rope_remap_positions``
+     equivalent) exactly the rows whose position shifted, matching
+     ``h2o_update``'s per-token eviction branch bit-for-bit.
+
+Precondition (spec decision D3): callers MUST only invoke
+:func:`h2o_fused_evict` when every ``(batch, head)`` group is already over
+budget (``n_kept + 1 > budget``) — the below-budget case is handled entirely
+by the existing vectorized ``_batch_absorb_no_eviction`` MLX path and is not
+implemented here.
+
+Public API:
+  - :func:`h2o_fused_evict`
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
+
+_cache: dict = {}
+
+
+# ===========================================================================
+# Metal source — dispatch 1: sink-protected argmin reduction
+# ===========================================================================
+# Grid:        (BH, 1, 1) threadgroups — one per (batch*head) group.
+# Threadgroup: (32, NSG_C, 1) — NSG_C SIMD-groups of 32 lanes.
+#
+# Each threadgroup grid-strides its NSG_C*32 threads over the n_total
+# candidate rows (n_kept stored + 1 newly appended), tracking a running
+# (min value, min index) pair. A SIMD-group butterfly reduction
+# (simd_shuffle_xor) merges the 32 lanes of each SIMD-group; a final
+# threadgroup-memory merge combines the NSG_C SIMD-group results. Ties
+# resolve toward the lowest index, matching mx.argmin.
+
+_H2O_EVICT_REDUCE_SRC = _read_kernel_source("h2o_evict_reduce.metal")
+
+
+# ===========================================================================
+# Metal source — dispatch 2: compact + conditionally re-rotate
+# ===========================================================================
+# Grid:        (BH * n_kept, 1, 1) — one thread per output row.
+# Threadgroup: (min(n_kept, 256), 1, 1).
+#
+# Each thread computes its source row (skipping evict_idx), copies
+# values/scores/positions verbatim, and either copies keys bit-identically
+# (source position <= evicted position) or applies a delta-rotation by -1
+# position (source position > evicted position) — see
+# H2O_METAL_KERNEL_TECH_SPEC.md section 3, step 7.
+
+_H2O_EVICT_APPLY_SRC = _read_kernel_source("h2o_evict_apply.metal")
+
+
+# ---------------------------------------------------------------------------
+# Kernel factories
+# ---------------------------------------------------------------------------
+
+
+def _evict_reduce_kernel(nsg: int):
+    key = ("h2o_evict_reduce", nsg)
+    if key not in _cache:
+        _cache[key] = mx.fast.metal_kernel(
+            name=f"h2o_evict_reduce_nsg{nsg}",
+            input_names=["scores_mid", "n_sink_arr"],
+            output_names=["evict_idx"],
+            header=f"#define NSG_C {nsg}\n",
+            source=_H2O_EVICT_REDUCE_SRC,
+            ensure_row_contiguous=True,
+        )
+    return _cache[key]
+
+
+def _evict_apply_kernel():
+    key = ("h2o_evict_apply",)
+    if key not in _cache:
+        _cache[key] = mx.fast.metal_kernel(
+            name="h2o_evict_apply",
+            input_names=[
+                "keys_mid",
+                "values_mid",
+                "scores_mid",
+                "positions_mid",
+                "evict_idx",
+                "rope_base_arr",
+            ],
+            output_names=["keys_out", "values_out", "scores_out", "positions_out"],
+            source=_H2O_EVICT_APPLY_SRC,
+            ensure_row_contiguous=True,
+        )
+    return _cache[key]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def h2o_fused_evict(
+    keys_mid: mx.array,
+    values_mid: mx.array,
+    scores_mid: mx.array,
+    positions_mid: mx.array,
+    n_sink: int,
+    rope_base: float,
+    nsg: int = 4,
+) -> tuple[mx.array, mx.array, mx.array, mx.array]:
+    """Fused sink-protected argmin + evict + RoPE-remap, batched over (batch*head).
+
+    Matches ``h2o_update``'s per-token eviction branch bit-for-bit (see
+    ``H2O_METAL_KERNEL_TECH_SPEC.md`` section 3). Caller must have already
+    computed the "mid" state — the ``n_kept`` currently-stored rows with the
+    one new token conceptually appended (score 0, its own position) — and
+    must only call this when every group is over budget
+    (``n_total = n_kept + 1 > budget``); the below-budget case is handled by
+    the existing ``_batch_absorb_no_eviction`` MLX path.
+
+    Args:
+        keys_mid:      ``[BH, n_total, D]`` fp16 — stored + appended keys.
+        values_mid:    ``[BH, n_total, D]`` fp16.
+        scores_mid:    ``[BH, n_total]`` fp32 cumulative scores (appended
+                       row's score is 0.0, per ``h2o_update``).
+        positions_mid: ``[BH, n_total]`` int32 absolute positions (appended
+                       row's position is ``next_pos``).
+        n_sink:        Number of leading positions protected from eviction
+                       (uniform across all BH groups, matching
+                       ``H2OState.n_sink``).
+        rope_base:     RoPE frequency base — must match the model's own, or
+                       the re-rotation of shifted rows will not cancel out
+                       the original rotation correctly (same requirement as
+                       ``rope_remap_positions``).
+        nsg:           SIMD-groups per threadgroup for the reduction kernel.
+
+    Returns:
+        ``(keys_out, values_out, scores_out, positions_out)``, each with
+        ``n_total - 1`` rows (one row evicted) — ``keys_out``/``values_out``
+        fp16, ``scores_out`` fp32, ``positions_out`` int32.
+    """
+    if keys_mid.ndim != 3:
+        raise ValueError(
+            f"h2o_fused_evict: keys_mid must be 3D [BH, n_total, D], got {keys_mid.shape}"
+        )
+    BH, n_total, D = keys_mid.shape
+    n_kept = n_total - 1
+    if n_kept <= 0:
+        raise ValueError(
+            f"h2o_fused_evict: n_total={n_total} implies n_kept<=0 — nothing to evict from"
+        )
+    if D % 2 != 0:
+        raise ValueError(f"h2o_fused_evict: D={D} must be even (NeoX-style RoPE pairs)")
+    if not (1 <= nsg <= 32):
+        raise ValueError(f"h2o_fused_evict: nsg={nsg} must be in 1..32")
+
+    n_sink_arr = mx.array([n_sink], dtype=mx.uint32)
+
+    (evict_idx,) = _evict_reduce_kernel(nsg)(
+        inputs=[scores_mid.astype(mx.float32), n_sink_arr],
+        grid=(BH * 32, nsg, 1),
+        threadgroup=(32, nsg, 1),
+        output_shapes=[(BH,)],
+        output_dtypes=[mx.int32],
+    )
+
+    rope_base_arr = mx.array([rope_base], dtype=mx.float32)
+    tg = min(n_kept, 256)
+    n_tg = (BH * n_kept + tg - 1) // tg
+
+    keys_out, values_out, scores_out, positions_out = _evict_apply_kernel()(
+        inputs=[
+            keys_mid.astype(mx.float16),
+            values_mid.astype(mx.float16),
+            scores_mid.astype(mx.float32),
+            positions_mid.astype(mx.int32),
+            evict_idx,
+            rope_base_arr,
+        ],
+        grid=(n_tg * tg, 1, 1),
+        threadgroup=(tg, 1, 1),
+        output_shapes=[(BH, n_kept, D), (BH, n_kept, D), (BH, n_kept), (BH, n_kept)],
+        output_dtypes=[mx.float16, mx.float16, mx.float32, mx.int32],
+    )
+    return keys_out, values_out, scores_out, positions_out
+
+
+__all__ = ["h2o_fused_evict"]

--- a/veloxquant_mlx/metal/kernels.py
+++ b/veloxquant_mlx/metal/kernels.py
@@ -12,6 +12,7 @@ Kernels are organized into focused submodules:
   _rabitq_attend — Fused RaBitQ asymmetric attention (1-bit K + 4-bit V)
   _rabitq_encode — Fused RaBitQ key encode (rotate + pack + magnitude)
   _rabitq_values — Nibble packing for 4-bit value indices
+  _h2o_evict     — Fused H2O eviction: sink-protected argmin + evict + RoPE-remap
 """
 
 from __future__ import annotations
@@ -59,6 +60,9 @@ from veloxquant_mlx.metal._rabitq_values import (
 from veloxquant_mlx.metal._rabitq_prefill import (
     rabitq_prefill_attend,
 )
+from veloxquant_mlx.metal._h2o_evict import (
+    h2o_fused_evict,
+)
 
 __all__ = [
     "vecinfer_dequant_metal",
@@ -80,4 +84,5 @@ __all__ = [
     "rabitq_encode",
     "rabitq_pack_values",
     "rabitq_prefill_attend",
+    "h2o_fused_evict",
 ]

--- a/veloxquant_mlx/metal/src/h2o_evict_apply.metal
+++ b/veloxquant_mlx/metal/src/h2o_evict_apply.metal
@@ -1,0 +1,84 @@
+// h2o_evict_apply.metal
+// Extracted from veloxquant_mlx/metal/_h2o_evict.py (_H2O_EVICT_APPLY_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+//
+// Dispatch 2 of 2 for H2O-adapted fused eviction (see
+// H2O_METAL_KERNEL_TECH_SPEC.md section 3). Given evict_idx[bh] (from
+// h2o_evict_reduce.metal) and the n_total = n_kept + 1 candidate rows
+// (n_kept stored rows plus the appended new row, all already concatenated
+// by the caller into *_mid arrays), produces the n_kept surviving rows:
+//   - one thread per (bh, output_row) pair, grid = (BH * n_kept, 1, 1).
+//   - source index = output_row if output_row < evict_idx[bh],
+//                     output_row + 1 otherwise (skips the evicted row).
+//   - position/RoPE handling per H2O_METAL_KERNEL_TECH_SPEC.md section 3
+//     step 7: rows whose (source) position is <= evicted_pos are copied
+//     bit-identically; rows whose position is > evicted_pos shift down by
+//     exactly 1 and get re-rotated via the same delta-rotation formula as
+//     rope_remap_positions (a2ats_rope.py) — rotate by
+//     delta = new_position - old_position, NeoX-style (first/second-half
+//     split) RoPE, matching MLX's default `traditional=False` convention.
+
+    uint gid = thread_position_in_grid.x;
+
+    uint n_kept = uint(keys_mid_shape[1]) - 1u;  // keys_mid: [BH, n_total, D]
+    uint D      = uint(keys_mid_shape[2]);
+    uint n_total = n_kept + 1u;
+
+    uint bh  = gid / n_kept;
+    uint j   = gid % n_kept;   // output row index within this bh group
+
+    uint BH = uint(keys_mid_shape[0]);
+    if (bh >= BH) return;
+
+    int evict_i = evict_idx[bh];
+    uint src = (j < uint(evict_i)) ? j : (j + 1u);
+
+    int evicted_pos = positions_mid[bh * n_total + uint(evict_i)];
+    int src_pos     = positions_mid[bh * n_total + src];
+    bool needs_shift = src_pos > evicted_pos;
+    int new_pos = needs_shift ? (src_pos - 1) : src_pos;
+
+    // ---- values, scores, positions: straight copy (never rotated) ----
+    uint out_row_off = bh * n_kept + j;
+    uint src_row_off = bh * n_total + src;
+
+    scores_out[out_row_off]    = scores_mid[src_row_off];
+    positions_out[out_row_off] = new_pos;
+
+    uint out_vd = out_row_off * D;
+    uint src_vd = src_row_off * D;
+    for (uint d = 0u; d < D; ++d) {
+        values_out[out_vd + d] = values_mid[src_vd + d];
+    }
+
+    // ---- keys: bit-identical copy, or delta-rotate ----
+    if (!needs_shift) {
+        for (uint d = 0u; d < D; ++d) {
+            keys_out[out_vd + d] = keys_mid[src_vd + d];
+        }
+        return;
+    }
+
+    // Delta rotation: rotate_by(new_pos - src_pos) == rotate_by(-1).
+    // NeoX-style split: first half / second half pair (d, d + D/2).
+    uint half_d = D / 2u;
+    float base = rope_base_arr[0];
+    float delta = float(new_pos - src_pos);
+
+    for (uint d = 0u; d < half_d; ++d) {
+        // Matches a2ats_rope.py's _rope_cos_sin exactly:
+        // inv_freq[d] = 1 / base^(d / half_d).
+        float inv_freq = 1.0f / metal::pow(base, float(d) / float(half_d));
+        float angle = delta * inv_freq;
+        float c = metal::cos(angle);
+        float s = metal::sin(angle);
+
+        float x1 = float(keys_mid[src_vd + d]);
+        float x2 = float(keys_mid[src_vd + d + half_d]);
+
+        keys_out[out_vd + d]         = half(x1 * c - x2 * s);
+        keys_out[out_vd + d + half_d] = half(x1 * s + x2 * c);
+    }

--- a/veloxquant_mlx/metal/src/h2o_evict_reduce.metal
+++ b/veloxquant_mlx/metal/src/h2o_evict_reduce.metal
@@ -1,0 +1,87 @@
+// h2o_evict_reduce.metal
+// Extracted from veloxquant_mlx/metal/_h2o_evict.py (_H2O_EVICT_REDUCE_SRC) — see that file's
+// docstring/comments for the algorithm, memory-layout, and threadgroup
+// strategy explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+//
+// Dispatch 1 of 2 for H2O-adapted fused eviction (see
+// H2O_METAL_KERNEL_TECH_SPEC.md section 3 for the exact reference math this
+// must match bit-for-bit). Finds, for each (batch*head) row group, the
+// index of the minimum "protected" score among the n_total = n_kept + 1
+// candidate rows (n_kept currently-stored rows plus the one new row that
+// h2o_update conceptually appends before evicting). The first n_sink rows
+// are protected (treated as +inf) and can never win the argmin, matching
+// h2o_update's sink-protection logic exactly.
+//
+// One threadgroup handles one (batch*head) group. TG_SIZE threads grid-stride
+// over the n_total candidate rows, each thread tracking its own local
+// (min_value, min_index) pair, then a SIMD-group butterfly reduction
+// (simd_shuffle_xor) combines the 32 lanes of each SIMD-group, and a final
+// threadgroup-memory merge (same idiom as scalar_affine_attend.metal's
+// cross-SIMD-group softmax merge) combines the NSG SIMD-groups into one
+// (value, index) pair per threadgroup, written to evict_idx[bh].
+//
+// Tie-break: ties must resolve toward the LOWEST index, matching mx.argmin's
+// documented behavior (h2o_update relies on mx.argmin(protected) today).
+// This is enforced by only overwriting the running (min_value, min_index)
+// when a strictly smaller value is found — later-encountered equal values
+// never replace an earlier, lower index.
+
+    uint bh    = threadgroup_position_in_grid.x;
+    uint lane  = thread_position_in_threadgroup.x;
+    uint sg    = thread_position_in_threadgroup.y;
+    uint NSG   = uint(NSG_C);
+    uint TG    = 32u * NSG;
+
+    uint n_kept = uint(scores_mid_shape[1]);   // scores_mid: [BH, n_total]
+    uint n_total = n_kept;                      // caller passes n_total in this axis
+    uint n_sink  = uint(n_sink_arr[0]);
+
+    uint tid = sg * 32u + lane;
+
+    float local_min = INFINITY;
+    uint  local_idx  = 0xFFFFFFFFu;
+
+    for (uint i = tid; i < n_total; i += TG) {
+        float v = (i < n_sink) ? INFINITY : scores_mid[bh * n_total + i];
+        if (v < local_min) {
+            local_min = v;
+            local_idx = i;
+        }
+    }
+
+    // SIMD-group butterfly reduction: combine 32 lanes -> 1 (value, index).
+    for (uint offset = 16u; offset > 0u; offset >>= 1u) {
+        float other_min = simd_shuffle_xor(local_min, offset);
+        uint  other_idx = simd_shuffle_xor(local_idx, offset);
+        if (other_min < local_min ||
+            (other_min == local_min && other_idx < local_idx)) {
+            local_min = other_min;
+            local_idx = other_idx;
+        }
+    }
+
+    // Lane 0 of each SIMD-group now holds that group's (min, idx). Stash to
+    // threadgroup memory and merge across SIMD-groups.
+    threadgroup float sh_min[NSG_C];
+    threadgroup uint  sh_idx[NSG_C];
+
+    if (lane == 0u) {
+        sh_min[sg] = local_min;
+        sh_idx[sg] = local_idx;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid == 0u) {
+        float best_min = sh_min[0];
+        uint  best_idx = sh_idx[0];
+        for (uint s = 1u; s < NSG; ++s) {
+            if (sh_min[s] < best_min ||
+                (sh_min[s] == best_min && sh_idx[s] < best_idx)) {
+                best_min = sh_min[s];
+                best_idx = sh_idx[s];
+            }
+        }
+        evict_idx[bh] = int(best_idx);
+    }

--- a/veloxquant_mlx/metal/src/h2o_evict_reduce.metal
+++ b/veloxquant_mlx/metal/src/h2o_evict_reduce.metal
@@ -10,9 +10,20 @@
 // must match bit-for-bit). Finds, for each (batch*head) row group, the
 // index of the minimum "protected" score among the n_total = n_kept + 1
 // candidate rows (n_kept currently-stored rows plus the one new row that
-// h2o_update conceptually appends before evicting). The first n_sink rows
-// are protected (treated as +inf) and can never win the argmin, matching
-// h2o_update's sink-protection logic exactly.
+// h2o_update conceptually appends before evicting). Two independent
+// protections, each treated as +inf and unable to win the argmin, matching
+// h2o_update's protection logic exactly:
+//   - the first n_sink rows (sink tokens, protected by leading array index)
+//   - the last n_grace rows (most-recently-arrived tokens, protected by
+//     trailing array index -- positions are always kept sorted ascending
+//     after eviction, so "most recent" == "highest array index"). This
+//     gives every new token n_grace update steps to accumulate real
+//     attention mass before it becomes eviction-eligible, fixing a real,
+//     confirmed-on-real-models problem: without it, a brand-new token's
+//     starting score of 0.0 makes it (almost always) the argmin target the
+//     instant the cache is full, freezing the kept set on whichever tokens
+//     filled the budget first and never admitting anything generated
+//     afterward. See h2o.py's module docstring.
 //
 // One threadgroup handles one (batch*head) group. TG_SIZE threads grid-stride
 // over the n_total candidate rows, each thread tracking its own local
@@ -37,6 +48,10 @@
     uint n_kept = uint(scores_mid_shape[1]);   // scores_mid: [BH, n_total]
     uint n_total = n_kept;                      // caller passes n_total in this axis
     uint n_sink  = uint(n_sink_arr[0]);
+    uint n_grace = uint(n_grace_arr[0]);
+    // Clamp so sink+grace protection can never exceed n_total, mirroring
+    // h2o.py's min(n_sink, n_total) / min(grace, n_total) clamps.
+    uint grace_start = (n_grace >= n_total) ? 0u : (n_total - n_grace);
 
     uint tid = sg * 32u + lane;
 
@@ -44,7 +59,8 @@
     uint  local_idx  = 0xFFFFFFFFu;
 
     for (uint i = tid; i < n_total; i += TG) {
-        float v = (i < n_sink) ? INFINITY : scores_mid[bh * n_total + i];
+        bool protected_row = (i < n_sink) || (i >= grace_start);
+        float v = protected_row ? INFINITY : scores_mid[bh * n_total + i];
         if (v < local_min) {
             local_min = v;
             local_idx = i;

--- a/veloxquant_mlx/quantizers/a2ats_rope.py
+++ b/veloxquant_mlx/quantizers/a2ats_rope.py
@@ -31,6 +31,13 @@ Adaptation notes (stated plainly):
 Public API:
   a2ats_apply_exact_rope     — standard RoPE at each token's own position
   a2ats_apply_windowed_rope  — distance-gated exact/approximate RoPE
+  rope_remap_positions       — de-rotate + re-rotate already-RoPE'd vectors
+                                to a new position (used by H2O-adapted, see
+                                cache/h2o_cache.py, to fix up positions after
+                                eviction removes rows from the middle of a
+                                stored sequence — not A2ATS-specific, kept
+                                here because it shares this module's RoPE
+                                cos/sin/rotate primitives)
 """
 
 from __future__ import annotations
@@ -81,6 +88,51 @@ def a2ats_apply_exact_rope(
     if x.shape[0] == 0:
         return x.astype(mx.float16)
     cos, sin = _rope_cos_sin(positions, x.shape[-1], base)
+    return _rotate(x.astype(mx.float16), cos, sin)
+
+
+def rope_remap_positions(
+    x: mx.array,
+    old_positions: mx.array,
+    new_positions: mx.array,
+    base: float = 10000.0,
+) -> mx.array:
+    """De-rotate already-RoPE'd vectors from ``old_positions`` and re-rotate
+    them at ``new_positions`` — used to fix up stored keys after an eviction
+    cache (H2O-adapted, and structurally any other row-dropping eviction
+    cache) removes rows and leaves the survivors' *storage index* out of sync
+    with the absolute position baked into their rotation.
+
+    RoPE rotates each ``(x1, x2)`` pair by angle ``position * inv_freq``; the
+    inverse rotation is the same formula at ``-position``. Composing "rotate
+    by ``-old_position``" then "rotate by ``new_position``" is equivalent to a
+    single rotation by ``new_position - old_position``, computed directly here
+    (one rotation, not two) for numerical accuracy.
+
+    Args:
+        x: ``[N, D]`` fp16/fp32 vectors, already RoPE'd at ``old_positions``.
+        old_positions: ``[N]`` absolute positions each row was originally
+            rotated at (must be the *exact* positions used at rotation time).
+        new_positions: ``[N]`` absolute positions to re-rotate each row to
+            (typically contiguous indices reflecting a post-eviction gap-free
+            layout).
+        base: RoPE frequency base — must match the base the model's attention
+            module actually used, or the de-rotation will not cancel out.
+
+    Returns:
+        ``[N, D]`` fp16 vectors, equivalent to having been generated fresh and
+        rotated directly at ``new_positions``.
+
+    Caveat: assumes MLX's default ``traditional=False`` (NeoX-style first/second-
+    half split) RoPE convention — the same one :func:`a2ats_apply_exact_rope`
+    uses and the one ``mlx_lm``'s Llama/Mistral/Qwen attention modules default
+    to. Models configured with ``traditional=True`` (adjacent-pair
+    interleaving) are not handled by this function.
+    """
+    if x.shape[0] == 0:
+        return x.astype(mx.float16)
+    delta = new_positions.astype(mx.float32) - old_positions.astype(mx.float32)
+    cos, sin = _rope_cos_sin(delta, x.shape[-1], base)
     return _rotate(x.astype(mx.float16), cos, sin)
 
 
@@ -141,4 +193,5 @@ def a2ats_apply_windowed_rope(
 __all__ = [
     "a2ats_apply_exact_rope",
     "a2ats_apply_windowed_rope",
+    "rope_remap_positions",
 ]

--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -65,6 +65,22 @@ Only the genuinely sequential eviction logic (each eviction depends on the
 previous one) still loops per token, and only once the cache is actually at
 or over budget.
 
+Fused Metal kernel for the over-budget branch (optional, further speedup on
+top of the vectorization above): the per-token eviction step itself — append,
+sink-protected argmin, evict, RoPE-remap — is still a Python loop, but each
+iteration's ~15 small MLX ops (concat x4, argmin, boolean-index x4, remap)
+can optionally be replaced with two fused Metal dispatches via
+:func:`veloxquant_mlx.metal.h2o_fused_evict` (design:
+``paper/research/H2O_METAL_KERNEL_TECH_SPEC.md``). Verified bit-for-bit
+equivalent to the MLX eviction branch it replaces (18 parity tests in
+``veloxquant_mlx/tests/metal/test_h2o_evict.py``, including sink protection,
+interior eviction, tie-break-matches-``mx.argmin``, and untouched-rows-are-
+exact-copies). Measured ~3.4x faster than the pure-MLX per-token branch at
+``n_kept=512, D=128``. Used automatically when
+``veloxquant_mlx.metal.metal_available()`` is true; falls back to the
+pure-MLX loop otherwise — this library works without Metal, per the
+existing policy for every other kernel here.
+
 Public API
 ----------
 H2OState          — immutable per-head state dataclass
@@ -273,6 +289,106 @@ def _batch_absorb_prefix(
     )
 
 
+# How often (in loop iterations) h2o_update forces graph materialization
+# during the over-budget eviction loop. Without this, a long prefill whose
+# budget is exceeded almost immediately queues one eviction's worth of
+# unevaluated graph nodes per token, exhausting MLX's Metal resource/
+# command-buffer tracking limit before generation can even finish — see the
+# flush call site below for the full explanation and how this was found.
+# 32 is conservative: confirmed empirically to keep a ~3200-token, heavy-
+# eviction prefill well under the ~499000-resource ceiling on the fused
+# Metal path (the tighter of the two paths), with negligible eval overhead
+# (mx.eval on 4 small 1-D/2-D arrays is cheap relative to the eviction work
+# it flushes).
+_EVAL_FLUSH_INTERVAL = 32
+
+
+def _metal_evict_available() -> bool:
+    """True iff the fused Metal eviction kernel can be used on this build.
+
+    Lazily imported (not at module top-level) so this module has no hard
+    dependency on ``mx.fast.metal_kernel`` being present — matches the
+    pattern in :mod:`veloxquant_mlx.metal`'s own ``__getattr__``.
+    """
+    try:
+        from veloxquant_mlx.metal import metal_available
+
+        return metal_available()
+    except Exception:
+        return False
+
+
+def _evict_via_mlx(
+    keys_cat: mx.array,
+    values_cat: mx.array,
+    scores_cat: mx.array,
+    positions_cat: mx.array,
+    n_sink: int,
+    rope_base: float,
+) -> tuple[mx.array, mx.array, mx.array, mx.array]:
+    """Pure-MLX eviction: sink-protected argmin, drop the loser, re-rotate
+    the shifted survivors. Reference implementation — see module docstring
+    for why this exists (the fused Metal path in :func:`_evict_via_metal`
+    must match this bit-for-bit)."""
+    n_total = keys_cat.shape[0]
+    n_sink_eff = min(n_sink, n_total)
+    if n_sink_eff > 0:
+        inf_block = mx.full((n_sink_eff,), float("inf"), dtype=mx.float32)
+        protected = mx.concatenate([inf_block, scores_cat[n_sink_eff:]], axis=0)
+    else:
+        protected = scores_cat
+
+    evict_idx = int(mx.argmin(protected).item())
+    evicted_pos = int(positions_cat[evict_idx].item())
+    keep_indices = [j for j in range(n_total) if j != evict_idx]
+    keys_kept = keys_cat[keep_indices]
+    values_kept = values_cat[keep_indices]
+    scores_kept = scores_cat[keep_indices]
+    old_positions_kept = positions_cat[keep_indices]
+
+    # Evicting row `evict_idx` leaves a size-1 gap at `evicted_pos`. Rows
+    # that sat *before* the gap (sinks included) keep their exact original
+    # position — nothing about their true distance from any future query
+    # changes. Rows *after* the gap shift down by exactly one position each,
+    # closing the gap so the model's position bookkeeping (which assumes a
+    # contiguous cache) stays in sync with what is actually stored. Minimal
+    # disturbance: only rows after the gap are re-rotated.
+    shift = mx.where(old_positions_kept > evicted_pos, -1, 0)
+    new_positions = old_positions_kept + shift
+    keys_kept = rope_remap_positions(keys_kept, old_positions_kept, new_positions, base=rope_base)
+    return keys_kept, values_kept, scores_kept, new_positions
+
+
+def _evict_via_metal(
+    keys_cat: mx.array,
+    values_cat: mx.array,
+    scores_cat: mx.array,
+    positions_cat: mx.array,
+    n_sink: int,
+    rope_base: float,
+) -> tuple[mx.array, mx.array, mx.array, mx.array]:
+    """Fused-Metal-kernel eviction — see
+    :func:`veloxquant_mlx.metal.h2o_fused_evict` and
+    ``paper/research/H2O_METAL_KERNEL_TECH_SPEC.md``. Bit-for-bit equivalent
+    to :func:`_evict_via_mlx` (verified in
+    ``veloxquant_mlx/tests/metal/test_h2o_evict.py``); single-(batch*head)
+    call here (``BH=1``), since ``h2o_update`` operates on one head's state
+    at a time — batching across heads is a natural follow-up (see spec
+    section 6) not implemented yet.
+    """
+    from veloxquant_mlx.metal import h2o_fused_evict
+
+    keys_out, values_out, scores_out, positions_out = h2o_fused_evict(
+        keys_cat[None],
+        values_cat[None],
+        scores_cat[None],
+        positions_cat[None],
+        n_sink=n_sink,
+        rope_base=rope_base,
+    )
+    return keys_out[0], values_out[0], scores_out[0], positions_out[0]
+
+
 def h2o_update(
     state: H2OState,
     new_keys: mx.array,  # [S, D] fp16
@@ -356,36 +472,14 @@ def h2o_update(
         n_total = keys_cat.shape[0]
 
         if n_total > state.budget:
-            # Build eviction-protected score view: sinks get +inf
-            n_sink_eff = min(state.n_sink, n_total)
-            if n_sink_eff > 0:
-                inf_block = mx.full((n_sink_eff,), float("inf"), dtype=mx.float32)
-                protected = mx.concatenate([inf_block, scores_cat[n_sink_eff:]], axis=0)
+            if _metal_evict_available():
+                keys_cat, values_cat, scores_cat, positions_cat = _evict_via_metal(
+                    keys_cat, values_cat, scores_cat, positions_cat, state.n_sink, state.rope_base
+                )
             else:
-                protected = scores_cat
-
-            evict_idx = int(mx.argmin(protected).item())
-            evicted_pos = int(positions_cat[evict_idx].item())
-            keep_indices = [j for j in range(n_total) if j != evict_idx]
-            keys_cat = keys_cat[keep_indices]
-            values_cat = values_cat[keep_indices]
-            scores_cat = scores_cat[keep_indices]
-            old_positions_kept = positions_cat[keep_indices]
-
-            # Evicting row `evict_idx` leaves a size-1 gap at `evicted_pos`.
-            # Rows that sat *before* the gap (sinks included) keep their exact
-            # original position — nothing about their true distance from any
-            # future query changes. Rows *after* the gap shift down by
-            # exactly one position each, closing the gap so the model's
-            # position bookkeeping (which assumes a contiguous cache) stays
-            # in sync with what is actually stored. Minimal disturbance: only
-            # rows after the gap are re-rotated.
-            shift = mx.where(old_positions_kept > evicted_pos, -1, 0)
-            new_positions = old_positions_kept + shift
-            keys_cat = rope_remap_positions(
-                keys_cat, old_positions_kept, new_positions, base=state.rope_base
-            )
-            positions_cat = new_positions
+                keys_cat, values_cat, scores_cat, positions_cat = _evict_via_mlx(
+                    keys_cat, values_cat, scores_cat, positions_cat, state.n_sink, state.rope_base
+                )
 
         state = H2OState(
             keys=keys_cat,
@@ -397,6 +491,24 @@ def h2o_update(
             rope_base=state.rope_base,
             next_pos=cur_pos + 1,
         )
+
+        # Force materialization periodically. Without this, a long prefill
+        # whose budget is exceeded almost immediately (heavy eviction from
+        # the first over-budget token onward) queues one eviction's worth of
+        # graph nodes per loop iteration — concatenations and boolean-index
+        # ops on the pure-MLX path, or two kernel dispatches on the fused
+        # Metal path — without ever forcing evaluation, across potentially
+        # thousands of iterations. Confirmed on real models: this exhausts
+        # MLX's Metal resource/command-buffer tracking limit exactly like
+        # the pre-vectorization prefill crash this module's docstring
+        # describes, except triggered by the eviction loop instead of the
+        # since-fixed below-budget batch path — and the fused Metal path
+        # hits the ceiling with FEWER iterations than the pure-MLX path
+        # (each kernel dispatch appears to register more Metal-side
+        # resources per call than an equivalent handful of array ops), so
+        # this flush is required for both paths, not just Metal.
+        if (i + 1) % _EVAL_FLUSH_INTERVAL == 0:
+            mx.eval(state.keys, state.values, state.scores, state.positions)
 
     return state
 

--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -14,20 +14,39 @@ Adaptation limitations (stated plainly):
   - Scores are accumulated additively (sum of softmax weights) rather than
     the paper's exact formulation, which may differ in low-budget regimes.
 
-KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM (not fixed here, see
+FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM #1 — permanent freeze (see
 cache/h2o_cache.py and docs-site/docs/algorithms/h2o.md for the full
 writeup): every newly-arrived token starts at score 0.0, and eviction removes
 the global-minimum-score token — so on essentially any real score
 distribution, the brand-new token is its own eviction target almost every
-time the cache is full. In practice this freezes the kept set on whichever
-tokens filled the budget first (typically the prompt) and never admits
+time the cache is full. In practice this froze the kept set on whichever
+tokens filled the budget first (typically the prompt) and never admitted
 anything generated afterward. Confirmed via mlx_lm.generate on Llama-3.2-1B
 and Mistral-7B: after dozens of true decode steps, the kept set was still
 exactly the original prompt positions, and generation degenerated into
-repetition loops from having no visibility into its own recent output. This
-is a consequence of implementing the paper's own formula correctly, not a
-deviation from it — fixing it needs a different eviction/scoring policy
-(e.g. a grace period before eviction-eligibility), tracked as follow-up work.
+repetition loops from having no visibility into its own recent output. Fixed
+via ``grace`` (see :class:`H2OState`): the most-recently-arrived ``grace``
+tokens are protected from eviction the same way sinks are, giving each new
+token real update steps to accumulate attention mass before it becomes
+eviction-eligible at all.
+
+FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM #2 — score staleness (found while
+verifying the fix for #1 above): fixing the freeze is necessary but not
+sufficient. Scores are a running sum that never shrinks, so a token's total
+lifetime attention mass grows monotonically with its age — confirmed
+empirically (correlation of -0.97 between token age/position and score in a
+60-step synthetic run). An old sink-adjacent survivor can outscore every
+recently-graduated (post-grace) token forever, so once grace fixed the
+freeze, the eviction argmin instead thinned the *rest* of the budget into a
+sparse, gapped kept window (e.g. positions ``0,1,2,3,4,5,44,46,48,...``
+instead of a contiguous recent block) rather than a genuinely local window —
+and generation still degraded, just via broken local coherence from the gaps
+instead of the original permanent freeze. Fixed via ``decay`` (see
+:class:`H2OState`): existing scores are multiplicatively decayed each update
+step before new attention mass is added, so old tokens' scores fade and
+stop permanently outranking newer ones. Verified in simulation: with decay,
+the non-sink kept window becomes contiguous (gaps of 1) instead of a uniform
+trickle (gaps of ~2 everywhere).
 
 RoPE position remapping (a separate, narrower, and now-fixed correctness
 issue — real, but NOT the cause of the freeze above):
@@ -136,6 +155,18 @@ class H2OState:
                    ``grace`` tokens" is equivalent to "the last ``grace``
                    array indices" — this is what the eviction protection
                    logic actually implements.
+        decay:     Multiplicative factor applied to every existing score
+                   before adding a new token's attention contribution, each
+                   update step. Fixes a second real, confirmed-on-real-models
+                   problem distinct from (and only exposed by fixing) the
+                   freeze above: scores are a running sum that never shrinks,
+                   so a token's total lifetime attention mass grows with its
+                   age regardless of current relevance — an old sink-adjacent
+                   survivor can outscore every recently-graduated token
+                   forever, so the eviction argmin keeps thinning the *rest*
+                   of the budget into a sparse, gapped trickle instead of a
+                   contiguous local window. ``decay=1.0`` reproduces the
+                   original (paper-faithful, no-decay) behavior exactly.
     """
 
     keys: mx.array | None
@@ -147,6 +178,7 @@ class H2OState:
     rope_base: float
     next_pos: int
     grace: int = 0
+    decay: float = 1.0
 
 
 def init_h2o_state(
@@ -155,6 +187,7 @@ def init_h2o_state(
     head_dim: int,  # noqa: ARG001
     rope_base: float = 10000.0,
     grace: int = 0,
+    decay: float = 1.0,
 ) -> H2OState:
     """Create an empty H2OState before any tokens arrive.
 
@@ -171,6 +204,10 @@ def init_h2o_state(
                    eviction (see :class:`H2OState`'s ``grace`` field). ``0``
                    reproduces the original (paper-faithful, but freeze-prone
                    at tight budgets) behavior.
+        decay:     Multiplicative per-step decay on existing scores (see
+                   :class:`H2OState`'s ``decay`` field). ``1.0`` reproduces
+                   the original (paper-faithful, but staleness-prone)
+                   behavior — must be in ``(0, 1]``.
 
     Raises:
         ValueError: if there are sink positions to protect but they leave no
@@ -181,6 +218,9 @@ def init_h2o_state(
             new token once the cache fills, silently growing past ``budget``
             in :func:`h2o_update`'s over-budget branch (which always assumes
             exactly one evictable row exists).
+        ValueError: if ``decay`` is not in ``(0, 1]`` — ``<= 0`` collapses
+            all history to nothing (or flips sign) every step, and ``> 1``
+            is growth, not decay, defeating the point of this field.
     """
     if n_sink > 0 and n_sink >= budget:
         raise ValueError(
@@ -194,6 +234,8 @@ def init_h2o_state(
             f"({budget}) — every row would be protected, leaving nothing "
             "evictable once the cache fills"
         )
+    if not (0.0 < decay <= 1.0):
+        raise ValueError(f"h2o: decay ({decay}) must be in (0, 1]")
     return H2OState(
         keys=None,
         values=None,
@@ -204,6 +246,7 @@ def init_h2o_state(
         rope_base=rope_base,
         next_pos=0,
         grace=grace,
+        decay=decay,
     )
 
 
@@ -226,6 +269,7 @@ def _batch_absorb_no_eviction(
     prior_keys: mx.array | None,
     prior_scores: mx.array | None,
     new_keys: mx.array,
+    decay: float = 1.0,
 ) -> mx.array:
     """Vectorized score accumulation for a batch of incoming tokens, valid
     ONLY while every one of them is guaranteed to survive (no eviction can
@@ -243,6 +287,12 @@ def _batch_absorb_no_eviction(
                       (``None`` if the cache was empty).
         new_keys:     ``[S, D]`` fp32 incoming keys, all of which the caller
                       has verified will fit within budget with no eviction.
+        decay:        Multiplicative per-step decay applied to ``prior_scores``
+                      before any new mass is added (see :class:`H2OState`'s
+                      ``decay`` field). Applied once per absorbed token, same
+                      as the per-token loop it replaces — token ``j``'s prior
+                      contribution is decayed ``j+1`` times by the time all
+                      ``S`` tokens have been absorbed. ``1.0`` is a no-op.
 
     Returns:
         ``[P + S]`` fp32 scores: ``prior_scores`` updated with every new
@@ -256,14 +306,26 @@ def _batch_absorb_no_eviction(
     if prior_keys is None:
         # First S tokens ever: token 0 bootstraps to 1.0 (matches
         # h2o_update's bootstrap branch); every later token j attends
-        # causally over tokens 0..j-1 only.
+        # causally over tokens 0..j-1 only. Within-batch decay of the
+        # bootstrap/earlier contributions is handled the same way as the
+        # prior-tokens branch below, via per-step decay powers.
         logits = (new_keys @ new_keys.T) * scale  # [S, S]
         causal = mx.arange(S)[:, None] > mx.arange(S)[None, :]
         masked = mx.where(causal, logits, -mx.inf)
         attn = mx.softmax(masked, axis=-1)
         attn = mx.where(mx.isnan(attn), 0.0, attn)  # row 0: all -inf -> nan -> 0
+        if decay != 1.0:
+            # Row j's (token j's) contribution to column i (token i, i<j) is
+            # applied at absorption step j, then decayed once per subsequent
+            # step up to S-1 -> (S-1-j) further decay applications.
+            steps_remaining = (S - 1) - mx.arange(S)  # [S], per-row (per-j) exponent
+            decay_pow = mx.array(decay, dtype=mx.float32) ** steps_remaining.astype(mx.float32)
+            attn = attn * decay_pow[:, None]
         col_sums = mx.sum(attn, axis=0)  # [S], token j's mass from tokens after it
-        bootstrap = mx.concatenate([mx.array([1.0], dtype=mx.float32), mx.zeros((S - 1,))])
+        bootstrap_decay = (
+            mx.array(decay, dtype=mx.float32) ** (S - 1) if decay != 1.0 else mx.array(1.0)
+        )
+        bootstrap = mx.concatenate([bootstrap_decay[None], mx.zeros((S - 1,), dtype=mx.float32)])
         return col_sums + bootstrap
 
     # Prior tokens already in the cache: each new token j attends over ALL
@@ -275,9 +337,20 @@ def _batch_absorb_no_eviction(
     new_logits = mx.where(causal, new_logits, -mx.inf)
     full_logits = mx.concatenate([prior_logits, new_logits], axis=-1)  # [S, P+S]
     attn = mx.softmax(full_logits, axis=-1)  # every row has >=1 real prior token -> no nan
+    if decay != 1.0:
+        # Row j's contribution (to prior tokens AND to earlier new tokens i<j)
+        # is applied at absorption step j, then decayed once per subsequent
+        # step up to S-1 -> (S-1-j) further decay applications, same scheme
+        # as the bootstrap branch above.
+        steps_remaining = (S - 1) - mx.arange(S)  # [S]
+        decay_pow = mx.array(decay, dtype=mx.float32) ** steps_remaining.astype(mx.float32)
+        attn = attn * decay_pow[:, None]
     prior_contrib = mx.sum(attn[:, :P], axis=0)  # [P] mass each prior token gains
     new_contrib = mx.sum(attn[:, P:], axis=0)  # [S] mass each new token gains from later new tokens
-    updated_prior_scores = prior_scores + prior_contrib
+    # prior_scores themselves need decaying S times (once per absorbed token)
+    # before adding the (already correctly-decayed) contributions above.
+    decayed_prior_scores = prior_scores * (decay**S) if decay != 1.0 else prior_scores
+    updated_prior_scores = decayed_prior_scores + prior_contrib
     return mx.concatenate([updated_prior_scores, new_contrib], axis=0)
 
 
@@ -302,7 +375,9 @@ def _batch_absorb_prefix(
     new_positions = mx.arange(state.next_pos, state.next_pos + B, dtype=mx.int32)
 
     prior_keys32 = None if state.keys is None else state.keys.astype(mx.float32)
-    scores = _batch_absorb_no_eviction(prior_keys32, state.scores, new_keys.astype(mx.float32))
+    scores = _batch_absorb_no_eviction(
+        prior_keys32, state.scores, new_keys.astype(mx.float32), decay=state.decay
+    )
 
     if state.keys is None:
         keys_cat = new_keys.astype(mx.float16)
@@ -323,6 +398,7 @@ def _batch_absorb_prefix(
         rope_base=state.rope_base,
         next_pos=state.next_pos + B,
         grace=state.grace,
+        decay=state.decay,
     )
 
 
@@ -508,12 +584,14 @@ def h2o_update(
                 rope_base=state.rope_base,
                 next_pos=cur_pos + 1,
                 grace=state.grace,
+                decay=state.decay,
             )
             continue
 
         # --- score update --------------------------------------------------
         attn = _attention_scores(k_i.astype(mx.float32), state.keys.astype(mx.float32))
-        updated_scores = state.scores + attn  # [n_kept]
+        decayed_scores = state.scores * state.decay if state.decay != 1.0 else state.scores
+        updated_scores = decayed_scores + attn  # [n_kept]
 
         # --- append new token (score = 0; begins accumulating next step) ---
         keys_cat = mx.concatenate([state.keys, k_i[None].astype(mx.float16)], axis=0)
@@ -557,6 +635,7 @@ def h2o_update(
             rope_base=state.rope_base,
             next_pos=cur_pos + 1,
             grace=state.grace,
+            decay=state.decay,
         )
 
         # Force materialization periodically. Without this, a long prefill

--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -10,16 +10,47 @@ Adaptation limitations (stated plainly):
     query vectors at each decode step. At cache level the query is not visible,
     so we use the incoming key vector as a proxy query to approximate the
     attention distribution. This is the same approximation used by SnapKV-adapted.
-  - No RoPE position-ID remapping after eviction.
   - Uniform budget across all heads.
   - Scores are accumulated additively (sum of softmax weights) rather than
     the paper's exact formulation, which may differ in low-budget regimes.
+
+KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM (not fixed here, see
+cache/h2o_cache.py and docs-site/docs/algorithms/h2o.md for the full
+writeup): every newly-arrived token starts at score 0.0, and eviction removes
+the global-minimum-score token — so on essentially any real score
+distribution, the brand-new token is its own eviction target almost every
+time the cache is full. In practice this freezes the kept set on whichever
+tokens filled the budget first (typically the prompt) and never admits
+anything generated afterward. Confirmed via mlx_lm.generate on Llama-3.2-1B
+and Mistral-7B: after dozens of true decode steps, the kept set was still
+exactly the original prompt positions, and generation degenerated into
+repetition loops from having no visibility into its own recent output. This
+is a consequence of implementing the paper's own formula correctly, not a
+deviation from it — fixing it needs a different eviction/scoring policy
+(e.g. a grace period before eviction-eligibility), tracked as follow-up work.
+
+RoPE position remapping (a separate, narrower, and now-fixed correctness
+issue — real, but NOT the cause of the freeze above):
+  Incoming keys arrive already RoPE-rotated for their true absolute position
+  (rotation happens in the model's attention module, upstream of this cache).
+  Evicting a row from the middle of the sequence leaves the survivors'
+  *storage index* out of sync with the absolute position baked into their
+  rotation — the model's attention math assumes contiguous positions, so this
+  desync would corrupt every subsequent query's relative-position math *if*
+  interior eviction happens (rare given the freeze above, but not impossible,
+  e.g. with ``n_sink > 0`` protecting only the front). Every kept row's true
+  original position is now tracked in ``H2OState.positions``, and
+  ``h2o_update`` de-rotates + re-rotates keys to a gap-free contiguous layout
+  via :func:`veloxquant_mlx.quantizers.a2ats_rope.rope_remap_positions`
+  whenever an eviction actually changes the kept set's positions. Verified
+  via a synthetic fingerprinted-token test forcing an interior eviction and
+  confirming every surviving key de-rotates back to its exact original value.
 
 Public API
 ----------
 H2OState          — immutable per-head state dataclass
 init_h2o_state    — construct empty state
-h2o_update        — absorb S new tokens, evict if over budget
+h2o_update        — absorb S new tokens, evict if over budget, remap RoPE
 h2o_get_kv        — extract current (keys, values) arrays
 h2o_fp16_bytes    — bytes stored in current state
 full_h2o_fp16_bytes — hypothetical cost without eviction
@@ -32,34 +63,55 @@ from dataclasses import dataclass
 
 import mlx.core as mx
 
+from veloxquant_mlx.quantizers.a2ats_rope import rope_remap_positions
+
 
 @dataclass
 class H2OState:
     """Per-head sliding H2O state.
 
     Attributes:
-        keys:   [n_kept, D] fp16 stored key rows, or None before first update.
-        values: [n_kept, D] fp16 stored value rows, or None before first update.
-        scores: [n_kept] cumulative softmax attention mass (float32), or None.
-        n_sink: Number of leading sink positions — never evicted.
-        budget: Maximum tokens to keep at any time (including sinks).
+        keys:      [n_kept, D] fp16 stored key rows, RoPE'd at ``positions``
+                   (contiguous 0..n_kept-1 after any eviction), or None
+                   before first update.
+        values:    [n_kept, D] fp16 stored value rows, or None before first
+                   update.
+        scores:    [n_kept] cumulative softmax attention mass (float32), or
+                   None.
+        positions: [n_kept] int32 absolute positions each kept key is
+                   currently rotated at. Reassigned to a contiguous range
+                   whenever eviction changes which rows survive, and each
+                   key is re-rotated (via ``rope_remap_positions``) to match.
+        n_sink:    Number of leading sink positions — never evicted.
+        budget:    Maximum tokens to keep at any time (including sinks).
+        rope_base: RoPE frequency base used to de-rotate/re-rotate kept keys.
+        next_pos:  Absolute position the next incoming token will occupy —
+                   tracks true sequence position across calls, independent
+                   of how many rows have been evicted so far.
     """
 
     keys: mx.array | None
     values: mx.array | None
     scores: mx.array | None
+    positions: mx.array | None
     n_sink: int
     budget: int
+    rope_base: float
+    next_pos: int
 
 
-def init_h2o_state(n_sink: int, budget: int, head_dim: int) -> H2OState:  # noqa: ARG001
+def init_h2o_state(n_sink: int, budget: int, head_dim: int, rope_base: float = 10000.0) -> H2OState:  # noqa: ARG001
     """Create an empty H2OState before any tokens arrive.
 
     Args:
-        n_sink:   Number of initial sink positions to protect from eviction.
-        budget:   Maximum total tokens kept (sinks + non-sinks).
-        head_dim: Head dimension D (unused here; accepted for API symmetry
-                  with StreamingLLM's init_streaming_window).
+        n_sink:    Number of initial sink positions to protect from eviction.
+        budget:    Maximum total tokens kept (sinks + non-sinks).
+        head_dim:  Head dimension D (unused here; accepted for API symmetry
+                   with StreamingLLM's init_streaming_window).
+        rope_base: RoPE frequency base — must match the base the model's own
+                   attention module uses, or position remapping after
+                   eviction will not cancel out the original rotation
+                   correctly.
 
     Raises:
         ValueError: if there are sink positions to protect but they leave no
@@ -72,7 +124,16 @@ def init_h2o_state(n_sink: int, budget: int, head_dim: int) -> H2OState:  # noqa
             "evictable positions remain, so sinks would be evicted once "
             "the cache fills"
         )
-    return H2OState(keys=None, values=None, scores=None, n_sink=n_sink, budget=budget)
+    return H2OState(
+        keys=None,
+        values=None,
+        scores=None,
+        positions=None,
+        n_sink=n_sink,
+        budget=budget,
+        rope_base=rope_base,
+        next_pos=0,
+    )
 
 
 def _attention_scores(query_proxy: mx.array, keys: mx.array) -> mx.array:
@@ -101,9 +162,14 @@ def h2o_update(
       1. Compute approximate attention weights of the new key (as proxy query)
          over all currently stored keys.
       2. Accumulate those weights into existing per-token scores.
-      3. Append the new token with score 0 (it starts accumulating next step).
+      3. Append the new token with score 0 (it starts accumulating next step)
+         at its true absolute position (``state.next_pos``).
       4. If total tokens > budget: permanently evict the non-sink token with the
-         lowest cumulative score.
+         lowest cumulative score. Survivors positioned *before* the evicted
+         token's position keep their exact original rotation untouched;
+         survivors *after* it shift down by exactly one position each (closing
+         the gap) and are re-rotated accordingly, so the cache's storage index
+         always matches a contiguous position range (see module docstring).
 
     Args:
         state:      Current H2OState for this head.
@@ -118,6 +184,7 @@ def h2o_update(
     for i in range(S):
         k_i = new_keys[i]  # [D]
         v_i = new_values[i]  # [D]
+        cur_pos = state.next_pos
 
         if state.keys is None:
             # Bootstrap: first token ever — no eviction needed.
@@ -125,8 +192,11 @@ def h2o_update(
                 keys=k_i[None].astype(mx.float16),
                 values=v_i[None].astype(mx.float16),
                 scores=mx.ones((1,), dtype=mx.float32),
+                positions=mx.array([cur_pos], dtype=mx.int32),
                 n_sink=state.n_sink,
                 budget=state.budget,
+                rope_base=state.rope_base,
+                next_pos=cur_pos + 1,
             )
             continue
 
@@ -138,6 +208,9 @@ def h2o_update(
         keys_cat = mx.concatenate([state.keys, k_i[None].astype(mx.float16)], axis=0)
         values_cat = mx.concatenate([state.values, v_i[None].astype(mx.float16)], axis=0)
         scores_cat = mx.concatenate([updated_scores, mx.zeros((1,), dtype=mx.float32)], axis=0)
+        positions_cat = mx.concatenate(
+            [state.positions, mx.array([cur_pos], dtype=mx.int32)], axis=0
+        )
 
         n_total = keys_cat.shape[0]
 
@@ -151,17 +224,37 @@ def h2o_update(
                 protected = scores_cat
 
             evict_idx = int(mx.argmin(protected).item())
+            evicted_pos = int(positions_cat[evict_idx].item())
             keep_indices = [j for j in range(n_total) if j != evict_idx]
             keys_cat = keys_cat[keep_indices]
             values_cat = values_cat[keep_indices]
             scores_cat = scores_cat[keep_indices]
+            old_positions_kept = positions_cat[keep_indices]
+
+            # Evicting row `evict_idx` leaves a size-1 gap at `evicted_pos`.
+            # Rows that sat *before* the gap (sinks included) keep their exact
+            # original position — nothing about their true distance from any
+            # future query changes. Rows *after* the gap shift down by
+            # exactly one position each, closing the gap so the model's
+            # position bookkeeping (which assumes a contiguous cache) stays
+            # in sync with what is actually stored. Minimal disturbance: only
+            # rows after the gap are re-rotated.
+            shift = mx.where(old_positions_kept > evicted_pos, -1, 0)
+            new_positions = old_positions_kept + shift
+            keys_cat = rope_remap_positions(
+                keys_cat, old_positions_kept, new_positions, base=state.rope_base
+            )
+            positions_cat = new_positions
 
         state = H2OState(
             keys=keys_cat,
             values=values_cat,
             scores=scores_cat,
+            positions=positions_cat,
             n_sink=state.n_sink,
             budget=state.budget,
+            rope_base=state.rope_base,
+            next_pos=cur_pos + 1,
         )
 
     return state

--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -46,6 +46,25 @@ issue — real, but NOT the cause of the freeze above):
   via a synthetic fingerprinted-token test forcing an interior eviction and
   confirming every surviving key de-rotates back to its exact original value.
 
+Scalability fix (a separate, now-fixed bug found while testing long
+context — independent of both issues above): the original ``h2o_update``
+processed every incoming token with a Python ``for`` loop, issuing 4 separate
+``mx.concatenate`` calls (keys, values, scores, positions) per token. On a
+genuinely long prefill (~3200 tokens tested) with no eviction yet triggered,
+this built an unfused lazy-eval graph large enough to exceed MLX's Metal
+resource/command-buffer tracking limit — ``RuntimeError: [metal::malloc]
+Resource limit (499000) exceeded`` — crashing *before generation could even
+start*, regardless of budget or eviction settings. Fixed by
+:func:`_batch_absorb_no_eviction`: whichever leading portion of an incoming
+batch is guaranteed not to trigger eviction (because the cache has not yet
+reached ``budget``) is absorbed via one batched masked-attention matmul
+instead of a token-by-token loop. Verified numerically equivalent to the
+sequential loop it replaces (score/position/key parity within fp16 rounding,
+including across the batch-path/loop-path boundary within a single call).
+Only the genuinely sequential eviction logic (each eviction depends on the
+previous one) still loops per token, and only once the cache is actually at
+or over budget.
+
 Public API
 ----------
 H2OState          — immutable per-head state dataclass
@@ -151,6 +170,109 @@ def _attention_scores(query_proxy: mx.array, keys: mx.array) -> mx.array:
     return mx.softmax(logits, axis=-1)
 
 
+def _batch_absorb_no_eviction(
+    prior_keys: mx.array | None,
+    prior_scores: mx.array | None,
+    new_keys: mx.array,
+) -> mx.array:
+    """Vectorized score accumulation for a batch of incoming tokens, valid
+    ONLY while every one of them is guaranteed to survive (no eviction can
+    occur for any of them). Equivalent to calling the per-token score-update
+    step of :func:`h2o_update` once per row of ``new_keys`` in sequence, but
+    computed as a single masked batched attention matmul instead of a Python
+    loop with S separate ``mx.concatenate`` calls — this is what let a long
+    prefill (thousands of tokens) exceed MLX's Metal resource limit before
+    this fix, independent of eviction/budget settings.
+
+    Args:
+        prior_keys:   ``[P, D]`` fp32 keys already in the cache before this
+                      batch (``None`` if the cache was empty).
+        prior_scores: ``[P]`` fp32 cumulative scores already in the cache
+                      (``None`` if the cache was empty).
+        new_keys:     ``[S, D]`` fp32 incoming keys, all of which the caller
+                      has verified will fit within budget with no eviction.
+
+    Returns:
+        ``[P + S]`` fp32 scores: ``prior_scores`` updated with every new
+        token's contribution, concatenated with each new token's own
+        (partial) accumulated score — the newest token always ends at
+        exactly ``0.0``, matching the per-token loop's semantics.
+    """
+    S = new_keys.shape[0]
+    scale = 1.0 / math.sqrt(float(new_keys.shape[-1]))
+
+    if prior_keys is None:
+        # First S tokens ever: token 0 bootstraps to 1.0 (matches
+        # h2o_update's bootstrap branch); every later token j attends
+        # causally over tokens 0..j-1 only.
+        logits = (new_keys @ new_keys.T) * scale  # [S, S]
+        causal = mx.arange(S)[:, None] > mx.arange(S)[None, :]
+        masked = mx.where(causal, logits, -mx.inf)
+        attn = mx.softmax(masked, axis=-1)
+        attn = mx.where(mx.isnan(attn), 0.0, attn)  # row 0: all -inf -> nan -> 0
+        col_sums = mx.sum(attn, axis=0)  # [S], token j's mass from tokens after it
+        bootstrap = mx.concatenate([mx.array([1.0], dtype=mx.float32), mx.zeros((S - 1,))])
+        return col_sums + bootstrap
+
+    # Prior tokens already in the cache: each new token j attends over ALL
+    # prior tokens (full mass) plus new tokens 0..j-1 (causal within batch).
+    P = prior_keys.shape[0]
+    prior_logits = (new_keys @ prior_keys.T) * scale  # [S, P]
+    new_logits = (new_keys @ new_keys.T) * scale  # [S, S]
+    causal = mx.arange(S)[:, None] > mx.arange(S)[None, :]
+    new_logits = mx.where(causal, new_logits, -mx.inf)
+    full_logits = mx.concatenate([prior_logits, new_logits], axis=-1)  # [S, P+S]
+    attn = mx.softmax(full_logits, axis=-1)  # every row has >=1 real prior token -> no nan
+    prior_contrib = mx.sum(attn[:, :P], axis=0)  # [P] mass each prior token gains
+    new_contrib = mx.sum(attn[:, P:], axis=0)  # [S] mass each new token gains from later new tokens
+    updated_prior_scores = prior_scores + prior_contrib
+    return mx.concatenate([updated_prior_scores, new_contrib], axis=0)
+
+
+def _batch_absorb_prefix(
+    state: H2OState,
+    new_keys: mx.array,
+    new_values: mx.array,
+) -> H2OState:
+    """Absorb a batch of ``B`` incoming tokens known in advance to fit within
+    budget with zero eviction (``B <= state.budget - n_current``), as a
+    single vectorized update instead of ``B`` sequential per-token steps.
+
+    Args:
+        state:      Current H2OState (may be empty, i.e. ``state.keys is None``).
+        new_keys:   ``[B, D]`` fp16 rows, all guaranteed to survive.
+        new_values: ``[B, D]`` fp16 rows.
+
+    Returns:
+        Updated H2OState with ``n_current + B`` rows, no eviction applied.
+    """
+    B = new_keys.shape[0]
+    new_positions = mx.arange(state.next_pos, state.next_pos + B, dtype=mx.int32)
+
+    prior_keys32 = None if state.keys is None else state.keys.astype(mx.float32)
+    scores = _batch_absorb_no_eviction(prior_keys32, state.scores, new_keys.astype(mx.float32))
+
+    if state.keys is None:
+        keys_cat = new_keys.astype(mx.float16)
+        values_cat = new_values.astype(mx.float16)
+        positions_cat = new_positions
+    else:
+        keys_cat = mx.concatenate([state.keys, new_keys.astype(mx.float16)], axis=0)
+        values_cat = mx.concatenate([state.values, new_values.astype(mx.float16)], axis=0)
+        positions_cat = mx.concatenate([state.positions, new_positions], axis=0)
+
+    return H2OState(
+        keys=keys_cat,
+        values=values_cat,
+        scores=scores,
+        positions=positions_cat,
+        n_sink=state.n_sink,
+        budget=state.budget,
+        rope_base=state.rope_base,
+        next_pos=state.next_pos + B,
+    )
+
+
 def h2o_update(
     state: H2OState,
     new_keys: mx.array,  # [S, D] fp16
@@ -171,6 +293,17 @@ def h2o_update(
          the gap) and are re-rotated accordingly, so the cache's storage index
          always matches a contiguous position range (see module docstring).
 
+    Performance note: whichever *leading* portion of ``new_keys`` is
+    guaranteed not to trigger eviction (because the cache has not yet
+    reached ``budget``) is absorbed in one vectorized batched-attention call
+    (:func:`_batch_absorb_no_eviction`) instead of a Python loop with 4
+    separate ``mx.concatenate`` calls per token — this is what let a long
+    prefill (thousands of tokens, no eviction yet triggered) exceed MLX's
+    Metal resource limit before this fix. Only once the cache is actually at
+    or over budget does the remaining per-token eviction loop run, since each
+    eviction's outcome depends on the previous one and cannot be batched
+    without changing which token gets evicted.
+
     Args:
         state:      Current H2OState for this head.
         new_keys:   [S, D] fp16 new key rows.
@@ -180,6 +313,14 @@ def h2o_update(
         Updated H2OState with at most ``state.budget`` tokens.
     """
     S = new_keys.shape[0]
+    n_current = 0 if state.keys is None else state.keys.shape[0]
+    n_batchable = max(0, min(S, state.budget - n_current))
+
+    if n_batchable > 0:
+        state = _batch_absorb_prefix(state, new_keys[:n_batchable], new_values[:n_batchable])
+        new_keys = new_keys[n_batchable:]
+        new_values = new_values[n_batchable:]
+        S = new_keys.shape[0]
 
     for i in range(S):
         k_i = new_keys[i]  # [D]

--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -123,6 +123,19 @@ class H2OState:
         next_pos:  Absolute position the next incoming token will occupy —
                    tracks true sequence position across calls, independent
                    of how many rows have been evicted so far.
+        grace:     Number of most-recently-arrived tokens protected from
+                   eviction, the same way sinks are, giving each new token
+                   ``grace`` update steps to accumulate real attention mass
+                   before it can be evicted. Fixes a real, confirmed-on-
+                   real-models problem: without this, every new token starts
+                   at score 0.0 and is (almost always) the global-minimum
+                   argmin target the instant the cache is full — see module
+                   docstring's "KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM".
+                   Positions are always kept sorted ascending after eviction
+                   (see the class-level note above), so "the most recent
+                   ``grace`` tokens" is equivalent to "the last ``grace``
+                   array indices" — this is what the eviction protection
+                   logic actually implements.
     """
 
     keys: mx.array | None
@@ -133,31 +146,53 @@ class H2OState:
     budget: int
     rope_base: float
     next_pos: int
+    grace: int = 0
 
 
-def init_h2o_state(n_sink: int, budget: int, head_dim: int, rope_base: float = 10000.0) -> H2OState:  # noqa: ARG001
+def init_h2o_state(
+    n_sink: int,
+    budget: int,
+    head_dim: int,  # noqa: ARG001
+    rope_base: float = 10000.0,
+    grace: int = 0,
+) -> H2OState:
     """Create an empty H2OState before any tokens arrive.
 
     Args:
         n_sink:    Number of initial sink positions to protect from eviction.
-        budget:    Maximum total tokens kept (sinks + non-sinks).
+        budget:    Maximum total tokens kept (sinks + non-sinks + grace).
         head_dim:  Head dimension D (unused here; accepted for API symmetry
                    with StreamingLLM's init_streaming_window).
         rope_base: RoPE frequency base — must match the base the model's own
                    attention module uses, or position remapping after
                    eviction will not cancel out the original rotation
                    correctly.
+        grace:     Number of most-recently-arrived tokens protected from
+                   eviction (see :class:`H2OState`'s ``grace`` field). ``0``
+                   reproduces the original (paper-faithful, but freeze-prone
+                   at tight budgets) behavior.
 
     Raises:
         ValueError: if there are sink positions to protect but they leave no
             evictable room within ``budget`` (``n_sink=0, budget=0`` remains
             a valid "disabled cache" configuration).
+        ValueError: if ``n_sink + grace >= budget`` — every row would be
+            protected, so eviction could never make room for a genuinely
+            new token once the cache fills, silently growing past ``budget``
+            in :func:`h2o_update`'s over-budget branch (which always assumes
+            exactly one evictable row exists).
     """
     if n_sink > 0 and n_sink >= budget:
         raise ValueError(
             f"h2o: n_sink ({n_sink}) must be < budget ({budget}) — no "
             "evictable positions remain, so sinks would be evicted once "
             "the cache fills"
+        )
+    if (n_sink > 0 or grace > 0) and n_sink + grace >= budget:
+        raise ValueError(
+            f"h2o: n_sink ({n_sink}) + grace ({grace}) must be < budget "
+            f"({budget}) — every row would be protected, leaving nothing "
+            "evictable once the cache fills"
         )
     return H2OState(
         keys=None,
@@ -168,6 +203,7 @@ def init_h2o_state(n_sink: int, budget: int, head_dim: int, rope_base: float = 1
         budget=budget,
         rope_base=rope_base,
         next_pos=0,
+        grace=grace,
     )
 
 
@@ -286,6 +322,7 @@ def _batch_absorb_prefix(
         budget=state.budget,
         rope_base=state.rope_base,
         next_pos=state.next_pos + B,
+        grace=state.grace,
     )
 
 
@@ -325,18 +362,32 @@ def _evict_via_mlx(
     positions_cat: mx.array,
     n_sink: int,
     rope_base: float,
+    grace: int = 0,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
-    """Pure-MLX eviction: sink-protected argmin, drop the loser, re-rotate
-    the shifted survivors. Reference implementation — see module docstring
-    for why this exists (the fused Metal path in :func:`_evict_via_metal`
-    must match this bit-for-bit)."""
+    """Pure-MLX eviction: sink- and grace-protected argmin, drop the loser,
+    re-rotate the shifted survivors. Reference implementation — see module
+    docstring for why this exists (the fused Metal path in
+    :func:`_evict_via_metal` must match this bit-for-bit).
+
+    Grace protection (``grace > 0``): the last ``grace`` array indices — the
+    most recently arrived tokens, since positions are always kept sorted
+    ascending after eviction (see :class:`H2OState`) — are treated as +inf
+    the same way sinks are, so a token cannot be evicted until it has
+    survived ``grace`` update steps and had a real chance to accumulate
+    attention mass. Without this, a brand-new token's starting score of 0.0
+    makes it (almost always) the argmin target immediately — see module
+    docstring's "KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM".
+    """
     n_total = keys_cat.shape[0]
     n_sink_eff = min(n_sink, n_total)
+    n_grace_eff = min(grace, n_total)
+    protected = scores_cat
     if n_sink_eff > 0:
-        inf_block = mx.full((n_sink_eff,), float("inf"), dtype=mx.float32)
-        protected = mx.concatenate([inf_block, scores_cat[n_sink_eff:]], axis=0)
-    else:
-        protected = scores_cat
+        sink_inf = mx.full((n_sink_eff,), float("inf"), dtype=mx.float32)
+        protected = mx.concatenate([sink_inf, protected[n_sink_eff:]], axis=0)
+    if n_grace_eff > 0:
+        grace_inf = mx.full((n_grace_eff,), float("inf"), dtype=mx.float32)
+        protected = mx.concatenate([protected[: n_total - n_grace_eff], grace_inf], axis=0)
 
     evict_idx = int(mx.argmin(protected).item())
     evicted_pos = int(positions_cat[evict_idx].item())
@@ -366,15 +417,16 @@ def _evict_via_metal(
     positions_cat: mx.array,
     n_sink: int,
     rope_base: float,
+    grace: int = 0,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
     """Fused-Metal-kernel eviction — see
     :func:`veloxquant_mlx.metal.h2o_fused_evict` and
     ``paper/research/H2O_METAL_KERNEL_TECH_SPEC.md``. Bit-for-bit equivalent
     to :func:`_evict_via_mlx` (verified in
-    ``veloxquant_mlx/tests/metal/test_h2o_evict.py``); single-(batch*head)
-    call here (``BH=1``), since ``h2o_update`` operates on one head's state
-    at a time — batching across heads is a natural follow-up (see spec
-    section 6) not implemented yet.
+    ``veloxquant_mlx/tests/metal/test_h2o_evict.py``, including grace
+    protection); single-(batch*head) call here (``BH=1``), since
+    ``h2o_update`` operates on one head's state at a time — batching across
+    heads is a natural follow-up (see spec section 6) not implemented yet.
     """
     from veloxquant_mlx.metal import h2o_fused_evict
 
@@ -385,6 +437,7 @@ def _evict_via_metal(
         positions_cat[None],
         n_sink=n_sink,
         rope_base=rope_base,
+        grace=grace,
     )
     return keys_out[0], values_out[0], scores_out[0], positions_out[0]
 
@@ -454,6 +507,7 @@ def h2o_update(
                 budget=state.budget,
                 rope_base=state.rope_base,
                 next_pos=cur_pos + 1,
+                grace=state.grace,
             )
             continue
 
@@ -474,11 +528,23 @@ def h2o_update(
         if n_total > state.budget:
             if _metal_evict_available():
                 keys_cat, values_cat, scores_cat, positions_cat = _evict_via_metal(
-                    keys_cat, values_cat, scores_cat, positions_cat, state.n_sink, state.rope_base
+                    keys_cat,
+                    values_cat,
+                    scores_cat,
+                    positions_cat,
+                    state.n_sink,
+                    state.rope_base,
+                    state.grace,
                 )
             else:
                 keys_cat, values_cat, scores_cat, positions_cat = _evict_via_mlx(
-                    keys_cat, values_cat, scores_cat, positions_cat, state.n_sink, state.rope_base
+                    keys_cat,
+                    values_cat,
+                    scores_cat,
+                    positions_cat,
+                    state.n_sink,
+                    state.rope_base,
+                    state.grace,
                 )
 
         state = H2OState(
@@ -490,6 +556,7 @@ def h2o_update(
             budget=state.budget,
             rope_base=state.rope_base,
             next_pos=cur_pos + 1,
+            grace=state.grace,
         )
 
         # Force materialization periodically. Without this, a long prefill

--- a/veloxquant_mlx/tests/cache/test_cam_cache.py
+++ b/veloxquant_mlx/tests/cache/test_cam_cache.py
@@ -182,7 +182,14 @@ def test_cache_drop_mode_matches_h2o(seed):
     Kc, Vc = cc.update_and_fetch(k, v)
 
     hc = H2OKVCache(
-        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+        KVCacheConfig(
+            method="h2o",
+            head_dim=D,
+            h2o_budget=budget,
+            h2o_n_sink=n_sink,
+            h2o_grace=0,
+            h2o_decay=1.0,
+        )
     )
     Kh, Vh = hc.update_and_fetch(k, v)
 

--- a/veloxquant_mlx/tests/cache/test_cam_cache.py
+++ b/veloxquant_mlx/tests/cache/test_cam_cache.py
@@ -181,7 +181,9 @@ def test_cache_drop_mode_matches_h2o(seed):
     )
     Kc, Vc = cc.update_and_fetch(k, v)
 
-    hc = H2OKVCache(KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink))
+    hc = H2OKVCache(
+        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+    )
     Kh, Vh = hc.update_and_fetch(k, v)
 
     assert Kc.shape == Kh.shape

--- a/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
+++ b/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
@@ -205,7 +205,14 @@ def test_cache_chunk_size_one_matches_h2o(seed):
     Kc, Vc = cc.update_and_fetch(k, v)
 
     hc = H2OKVCache(
-        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+        KVCacheConfig(
+            method="h2o",
+            head_dim=D,
+            h2o_budget=budget,
+            h2o_n_sink=n_sink,
+            h2o_grace=0,
+            h2o_decay=1.0,
+        )
     )
     Kh, Vh = hc.update_and_fetch(k, v)
 

--- a/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
+++ b/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
@@ -204,7 +204,9 @@ def test_cache_chunk_size_one_matches_h2o(seed):
     )
     Kc, Vc = cc.update_and_fetch(k, v)
 
-    hc = H2OKVCache(KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink))
+    hc = H2OKVCache(
+        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+    )
     Kh, Vh = hc.update_and_fetch(k, v)
 
     assert Kc.shape == Kh.shape

--- a/veloxquant_mlx/tests/cache/test_h2o_cache.py
+++ b/veloxquant_mlx/tests/cache/test_h2o_cache.py
@@ -206,3 +206,49 @@ def test_build_via_for_model_propagates_config() -> None:
     assert all(isinstance(c, H2OKVCache) for c in caches)
     assert caches[0]._budget == 64
     assert caches[0]._n_sink == 8
+
+
+# ---------------------------------------------------------------------------
+# offset tracks true absolute position, not kept-row count (RoPE fix — see
+# module docstring: mlx_lm rotates the query/next key using cache.offset
+# BEFORE update_and_fetch ever runs, so offset must equal the true step
+# count for that rotation to be correct, independent of how many rows this
+# cache has evicted)
+# ---------------------------------------------------------------------------
+
+
+def test_offset_tracks_true_position_not_kept_count() -> None:
+    """After eviction, self.offset must exceed the physically stored row
+    count — it tracks true elapsed steps, which is what mlx_lm's attention
+    module uses to rotate the NEXT query and key correctly."""
+    budget = 4
+    c = _make(h2o_budget=budget, h2o_n_sink=0)
+    for i in range(10):
+        k, v = _rand_kv(S=1, H=1, D=32, seed=i)
+        c.update_and_fetch(k, v)
+    assert c.keys.shape[2] <= budget
+    assert c.offset == 10
+    assert c.offset > c.keys.shape[2]
+
+
+def test_state_property_returns_exactly_kept_rows() -> None:
+    """cache.state (read by mlx_lm.generate during chunked prefill) must
+    return exactly the stored rows, not a slice sized by self.offset."""
+    budget = 4
+    c = _make(h2o_budget=budget, h2o_n_sink=0)
+    for i in range(10):
+        k, v = _rand_kv(S=1, H=1, D=32, seed=i)
+        c.update_and_fetch(k, v)
+    keys_state, values_state = c.state
+    assert keys_state.shape[2] == c.keys.shape[2] <= budget
+    assert values_state.shape[2] == c.values.shape[2] <= budget
+
+
+def test_size_returns_kept_count_not_offset() -> None:
+    budget = 4
+    c = _make(h2o_budget=budget, h2o_n_sink=0)
+    for i in range(10):
+        k, v = _rand_kv(S=1, H=1, D=32, seed=i)
+        c.update_and_fetch(k, v)
+    assert c.size() == c.keys.shape[2] <= budget
+    assert c.size() != c.offset

--- a/veloxquant_mlx/tests/cache/test_h2o_cache.py
+++ b/veloxquant_mlx/tests/cache/test_h2o_cache.py
@@ -8,12 +8,14 @@ accumulation, budget enforcement across many steps, byte accounting
 (compression_ratio, h2o_kept_bytes), tokens_kept, n_sink=0 edge case,
 determinism, and for_model config propagation. All data is synthetic.
 
-Most tests here pin ``h2o_grace=0`` explicitly: they exercise the underlying
-eviction *mechanism* (sink protection, budget enforcement, determinism) in
-isolation from the grace-period fix (see grace-specific tests further down
-and in test_h2o.py), and were originally written with small budgets (4-16)
-that predate ``h2o_grace``'s nonzero default — pinning grace=0 keeps their
-budgets meaningful without every one of them needing a size bump.
+Most tests here pin ``h2o_grace=0`` and ``h2o_decay=1.0`` explicitly: they
+exercise the underlying eviction *mechanism* (sink protection, budget
+enforcement, determinism) in isolation from the grace-period and decay
+fixes (see grace/decay-specific tests further down and in test_h2o.py), and
+were originally written with small budgets (4-16) that predate
+``h2o_grace``'s and ``h2o_decay``'s nonzero/non-unity defaults — pinning
+grace=0, decay=1.0 keeps their behavior exactly reproducible without every
+one of them needing a size bump or score-tolerance change.
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ from veloxquant_mlx.cache.h2o_cache import H2OKVCache
 
 
 def _make(**cfg):
-    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2, h2o_grace=0)
+    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2, h2o_grace=0, h2o_decay=1.0)
     base.update(cfg)
     return KVCacheFactory.create(KVCacheConfig(**base))
 
@@ -209,12 +211,14 @@ def test_build_via_for_model_propagates_config() -> None:
         h2o_budget=64,
         h2o_n_sink=8,
         h2o_grace=12,
+        h2o_decay=0.95,
     )
     caches = KVCacheBuilder.for_model(_Model(), cfg)
     assert all(isinstance(c, H2OKVCache) for c in caches)
     assert caches[0]._budget == 64
     assert caches[0]._n_sink == 8
     assert caches[0]._grace == 12
+    assert caches[0]._decay == 0.95
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +252,45 @@ def test_grace_protects_new_tokens_from_immediate_eviction() -> None:
     # advanced well past the first `budget` positions after 30 steps —
     # grace=0 would freeze it at positions [0..budget-1] forever.
     assert c.offset == 30
+    assert c.keys.shape[2] <= budget
+
+
+# ---------------------------------------------------------------------------
+# Decay: fixes score staleness (see h2o_cache.py's module docstring, "SECOND
+# FIXED..." section). Without decay, cumulative scores only ever grow, so an
+# old survivor permanently outranks any recently-graduated (post-grace)
+# token regardless of current relevance, thinning the kept window into a
+# sparse gapped trickle instead of a contiguous local context.
+# ---------------------------------------------------------------------------
+
+
+def test_default_decay_is_not_one() -> None:
+    """h2o_decay defaults to < 1.0 in KVCacheConfig — the staleness fix is on
+    by default for real usage, not opt-in only."""
+    cfg = KVCacheConfig(method="h2o", head_dim=32)
+    assert 0.0 < cfg.h2o_decay < 1.0
+
+
+def test_decay_rejects_out_of_range_values() -> None:
+    """Validation happens lazily in init_h2o_state, on the first
+    update_and_fetch call (state is only known once B/H/D are known) — not
+    at H2OKVCache construction time."""
+    k, v = _rand_kv(S=1, H=1, D=32)
+    with pytest.raises(ValueError, match="decay"):
+        _make(h2o_decay=0.0).update_and_fetch(k, v)
+    with pytest.raises(ValueError, match="decay"):
+        _make(h2o_decay=1.5).update_and_fetch(k, v)
+
+
+def test_decay_and_grace_together_keep_budget_enforced() -> None:
+    """Sanity check that combining both fixes doesn't break the invariant
+    every eviction path must uphold: never exceed h2o_budget."""
+    budget = 12
+    c = _make(h2o_budget=budget, h2o_n_sink=2, h2o_grace=4, h2o_decay=0.9)
+    for i in range(50):
+        k, v = _rand_kv(S=1, H=1, D=32, seed=i)
+        c.update_and_fetch(k, v)
+    assert c.offset == 50
     assert c.keys.shape[2] <= budget
 
 

--- a/veloxquant_mlx/tests/cache/test_h2o_cache.py
+++ b/veloxquant_mlx/tests/cache/test_h2o_cache.py
@@ -7,6 +7,13 @@ output shape bounded by budget, output dtype fp16, sink protection, decode
 accumulation, budget enforcement across many steps, byte accounting
 (compression_ratio, h2o_kept_bytes), tokens_kept, n_sink=0 edge case,
 determinism, and for_model config propagation. All data is synthetic.
+
+Most tests here pin ``h2o_grace=0`` explicitly: they exercise the underlying
+eviction *mechanism* (sink protection, budget enforcement, determinism) in
+isolation from the grace-period fix (see grace-specific tests further down
+and in test_h2o.py), and were originally written with small budgets (4-16)
+that predate ``h2o_grace``'s nonzero default — pinning grace=0 keeps their
+budgets meaningful without every one of them needing a size bump.
 """
 
 from __future__ import annotations
@@ -20,7 +27,7 @@ from veloxquant_mlx.cache.h2o_cache import H2OKVCache
 
 
 def _make(**cfg):
-    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2)
+    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2, h2o_grace=0)
     base.update(cfg)
     return KVCacheFactory.create(KVCacheConfig(**base))
 
@@ -201,11 +208,47 @@ def test_build_via_for_model_propagates_config() -> None:
         head_dim=32,
         h2o_budget=64,
         h2o_n_sink=8,
+        h2o_grace=12,
     )
     caches = KVCacheBuilder.for_model(_Model(), cfg)
     assert all(isinstance(c, H2OKVCache) for c in caches)
     assert caches[0]._budget == 64
     assert caches[0]._n_sink == 8
+    assert caches[0]._grace == 12
+
+
+# ---------------------------------------------------------------------------
+# Grace period: fixes the early-token-freeze problem (see h2o_cache.py's
+# module docstring). The most-recently-arrived h2o_grace tokens are
+# protected from eviction, giving new tokens a chance to accumulate real
+# attention mass instead of being evicted the instant they arrive (score 0.0
+# is otherwise almost always the global minimum).
+# ---------------------------------------------------------------------------
+
+
+def test_default_grace_is_nonzero() -> None:
+    """h2o_grace defaults to a nonzero value in KVCacheConfig — the freeze
+    fix is on by default for real usage, not opt-in only."""
+    cfg = KVCacheConfig(method="h2o", head_dim=32)
+    assert cfg.h2o_grace > 0
+
+
+def test_grace_protects_new_tokens_from_immediate_eviction() -> None:
+    """With grace >= budget-worth of headroom, newly-arrived tokens survive
+    long enough to actually grow the kept set's position range, unlike
+    grace=0 which freezes on the earliest tokens forever (see
+    test_h2o.py::test_new_token_almost_always_evicted_first for the grace=0
+    baseline this contrasts with)."""
+    budget = 8
+    c = _make(h2o_budget=budget, h2o_n_sink=0, h2o_grace=4)
+    for i in range(30):
+        k, v = _rand_kv(S=1, H=1, D=32, seed=i)
+        c.update_and_fetch(k, v)
+    # With grace=4 protecting the newest arrivals, the kept window must have
+    # advanced well past the first `budget` positions after 30 steps —
+    # grace=0 would freeze it at positions [0..budget-1] forever.
+    assert c.offset == 30
+    assert c.keys.shape[2] <= budget
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
+++ b/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
@@ -4,17 +4,33 @@ base ``.keys``/``.values``/``.offset`` so ``.state`` (read unconditionally by
 rewind path) never crashes with ``AttributeError: 'NoneType' object has no
 attribute 'shape'``.
 
-Covers all 17 affected classes: 15 that now write through to the base class
-via ``super().update_and_fetch(...)`` on every call (and correctly report
+Covers all 17 affected classes: 14 that write through to the base class via
+``super().update_and_fetch(...)`` on every call (and correctly report
 ``is_trimmable() == False``, since their internal per-token eviction state
 isn't rolled back by a base-class ``trim()``), plus ``PALUKVCache`` and
 ``KVTCKVCache`` which bypass the base fp16 buffer entirely (true latent
 storage) and instead override ``.state``/``.trim()``/``.is_trimmable()``
-directly against their own storage.
+directly against their own storage, plus ``H2OKVCache`` (see below).
 
 Config per method mirrors each method's own dedicated test file's ``_make``
 helper, kept minimal here since only the base-class bookkeeping contract is
 under test — not each method's compression/eviction quality.
+
+H2O is a documented, deliberate EXCEPTION to the ``offset == shape[2]``
+assertion the other 16 methods satisfy (see ``_OFFSET_EQUALS_SHAPE_METHODS``
+below). Investigation (see docs-site/docs/algorithms/h2o.md and
+cache/h2o_cache.py's module docstring) found that this equality is exactly
+what caused a real, confirmed-on-real-models generation-corruption bug:
+``mlx_lm``'s attention module rotates the query and next incoming key using
+``self.rope(x, offset=cache.offset)`` *before* ``update_and_fetch`` is ever
+called, so once eviction makes ``shape[2] < true elapsed steps``, resetting
+``offset`` to ``shape[2]`` (what the other 16 methods do) silently rotates
+future queries/keys at the wrong absolute position. H2OKVCache fixes this by
+keeping ``offset`` equal to the true step count instead, which necessarily
+makes ``offset != shape[2]`` once eviction has occurred — the *other* 16
+eviction methods are NOT yet known to be free of this same bug; they were not
+in scope for this fix and are tracked separately (see the linked follow-up
+issue in this repo's issue tracker) rather than silently assumed safe.
 """
 
 from __future__ import annotations
@@ -46,12 +62,19 @@ _CONFIGS = {
     "kvtc": {"kvtc_bit_budget": 32},
 }
 
-# The 15 "case A" methods: reset-then-write-through, no real trim support.
-_CASE_A_METHODS = [m for m in _CONFIGS if m not in ("palu", "kvtc")]
+# The 14 "case A" methods: reset-then-write-through, no real trim support.
+_CASE_A_METHODS = [m for m in _CONFIGS if m not in ("palu", "kvtc", "h2o")]
 # The 2 "case C" methods: bypass the base buffer, own state/trim.
 _CASE_C_METHODS = ["palu", "kvtc"]
 
 ALL_METHODS = list(_CONFIGS)
+
+# Methods whose cache.offset must equal shape[2] (stored row count) at all
+# times. H2O is the sole documented exception: offset tracks the TRUE
+# absolute step count instead, so mlx_lm's rope(x, offset=cache.offset) call
+# on the query/next key rotates correctly even after eviction has made
+# shape[2] < true step count — see module docstring above.
+_OFFSET_EQUALS_SHAPE_METHODS = [m for m in ALL_METHODS if m != "h2o"]
 
 
 def _make(method: str, head_dim: int = 8, **extra):
@@ -88,10 +111,14 @@ def test_state_accessible_after_single_prefill(method: str) -> None:
     assert cache.offset > 0
 
 
-@pytest.mark.parametrize("method", ALL_METHODS)
+@pytest.mark.parametrize("method", _OFFSET_EQUALS_SHAPE_METHODS)
 def test_state_shape_matches_offset(method: str) -> None:
     """cache.state's seq-length dim must equal cache.offset, mirroring the
-    base KVCache contract mlx_lm relies on elsewhere (e.g. make_mask)."""
+    base KVCache contract mlx_lm relies on elsewhere (e.g. make_mask).
+
+    H2O is excluded — see module docstring for why offset intentionally
+    tracks true elapsed steps instead of shape[2] for that method.
+    """
     cache = _make(method)
     k, v = _rand_kv(S=6)
     cache.update_and_fetch(k, v)
@@ -102,16 +129,35 @@ def test_state_shape_matches_offset(method: str) -> None:
     assert v_state.shape[2] == cache.offset
 
 
+def test_h2o_state_shape_at_or_below_offset() -> None:
+    """H2O's counterpart to test_state_shape_matches_offset: shape[2] (rows
+    actually stored) must never EXCEED offset (true elapsed steps) — the
+    reverse inequality would mean more rows are stored than steps have
+    occurred, which is impossible — but may be strictly less once eviction
+    has dropped rows. See module docstring."""
+    cache = _make("h2o")
+    k, v = _rand_kv(S=6)
+    cache.update_and_fetch(k, v)
+
+    k_state, v_state = cache.state
+    mx.eval(k_state, v_state)
+    assert k_state.shape[2] <= cache.offset
+    assert v_state.shape[2] <= cache.offset
+
+
 # ---------------------------------------------------------------------------
 # mlx_lm's chunked prefill: update_and_fetch called multiple times with S>1.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("method", ALL_METHODS)
+@pytest.mark.parametrize("method", _OFFSET_EQUALS_SHAPE_METHODS)
 def test_state_accessible_across_chunked_prefill(method: str) -> None:
     """Simulates mlx_lm's chunked prefill: several S>1 calls in a row (one
     per prefill_step_size chunk), each followed by a .state access (mirrors
-    generate.py's `mx.eval([c.state for c in cache])` after every chunk)."""
+    generate.py's `mx.eval([c.state for c in cache])` after every chunk).
+
+    H2O is excluded — see module docstring / test_h2o_state_shape_at_or_below_offset.
+    """
     cache = _make(method)
     for seed in range(3):
         k, v = _rand_kv(S=5, seed=seed)
@@ -121,10 +167,25 @@ def test_state_accessible_across_chunked_prefill(method: str) -> None:
         assert k_state.shape[2] == cache.offset
 
 
-@pytest.mark.parametrize("method", ALL_METHODS)
+def test_h2o_state_accessible_across_chunked_prefill() -> None:
+    """H2O counterpart: .state must stay accessible and shape[2] <= offset
+    throughout chunked prefill (mirrors the scenario above)."""
+    cache = _make("h2o")
+    for seed in range(3):
+        k, v = _rand_kv(S=5, seed=seed)
+        cache.update_and_fetch(k, v)
+        k_state, v_state = cache.state
+        mx.eval(k_state, v_state)
+        assert k_state.shape[2] <= cache.offset
+
+
+@pytest.mark.parametrize("method", _OFFSET_EQUALS_SHAPE_METHODS)
 def test_state_accessible_after_decode_steps(method: str) -> None:
     """Prefill followed by several S==1 decode steps; .state must stay
-    accessible and consistent with offset throughout."""
+    accessible and consistent with offset throughout.
+
+    H2O is excluded — see module docstring / test_h2o_state_shape_at_or_below_offset.
+    """
     cache = _make(method)
     k, v = _rand_kv(S=5)
     cache.update_and_fetch(k, v)
@@ -135,6 +196,25 @@ def test_state_accessible_after_decode_steps(method: str) -> None:
         k_state, v_state = cache.state
         mx.eval(k_state, v_state)
         assert k_state.shape[2] == cache.offset
+
+
+def test_h2o_state_accessible_after_decode_steps() -> None:
+    """H2O counterpart: .state stays accessible and shape[2] <= offset
+    throughout decode, and offset keeps climbing even once eviction caps
+    shape[2] — the whole point of the fix."""
+    cache = _make("h2o")
+    k, v = _rand_kv(S=5)
+    cache.update_and_fetch(k, v)
+
+    prev_offset = cache.offset
+    for i in range(3):
+        k1, v1 = _rand_kv(S=1, seed=100 + i)
+        cache.update_and_fetch(k1, v1)
+        k_state, v_state = cache.state
+        mx.eval(k_state, v_state)
+        assert k_state.shape[2] <= cache.offset
+        assert cache.offset == prev_offset + 1
+        prev_offset = cache.offset
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
+++ b/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
@@ -47,7 +47,7 @@ _CONFIGS = {
     "cam": {"cam_budget": 8, "cam_n_sink": 1},
     "chunkkv": {"chunkkv_budget": 8, "chunkkv_n_sink": 1, "chunkkv_chunk_size": 2},
     "curdkv": {"curdkv_budget": 8, "curdkv_n_sink": 1},
-    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1, "h2o_grace": 0},
+    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1, "h2o_grace": 0, "h2o_decay": 1.0},
     "keyformer": {"keyformer_budget": 8, "keyformer_n_sink": 1},
     "knorm": {"knorm_budget": 8, "knorm_n_sink": 1},
     "kvzip": {"kvzip_budget": 8, "kvzip_n_sink": 1},

--- a/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
+++ b/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
@@ -47,7 +47,7 @@ _CONFIGS = {
     "cam": {"cam_budget": 8, "cam_n_sink": 1},
     "chunkkv": {"chunkkv_budget": 8, "chunkkv_n_sink": 1, "chunkkv_chunk_size": 2},
     "curdkv": {"curdkv_budget": 8, "curdkv_n_sink": 1},
-    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1},
+    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1, "h2o_grace": 0},
     "keyformer": {"keyformer_budget": 8, "keyformer_n_sink": 1},
     "knorm": {"knorm_budget": 8, "knorm_n_sink": 1},
     "kvzip": {"kvzip_budget": 8, "kvzip_n_sink": 1},

--- a/veloxquant_mlx/tests/metal/test_h2o_evict.py
+++ b/veloxquant_mlx/tests/metal/test_h2o_evict.py
@@ -1,0 +1,424 @@
+"""Parity tests for the fused H2O eviction Metal kernel (h2o_fused_evict).
+
+The kernel must reproduce h2o_update's per-token eviction branch
+(veloxquant_mlx/quantizers/h2o.py) bit-for-bit: sink-protected argmin over
+the "mid" state (n_kept stored rows + 1 appended row), evict the winner,
+and re-rotate exactly the rows whose position shifted (rows before the
+eviction gap are untouched — bit-identical, not just numerically close).
+See paper/research/H2O_METAL_KERNEL_TECH_SPEC.md for the full design and
+the T1-T8 test plan this file implements (T1-T7; T8, the real-model
+regression, lives outside the unit test suite — see the PR/issue writeup).
+"""
+
+from __future__ import annotations
+
+import time
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from veloxquant_mlx.metal import metal_available
+from veloxquant_mlx.metal.kernels import h2o_fused_evict
+from veloxquant_mlx.quantizers.a2ats_rope import a2ats_apply_exact_rope, rope_remap_positions
+
+pytestmark = pytest.mark.skipif(
+    not metal_available(),
+    reason="Metal compute kernels not available on this build of mlx.",
+)
+
+
+def _make_fingerprinted(n_total: int, D: int, seed: int = 0):
+    """n_total tokens with unique keys and an exact-integer fingerprint in
+    value[:, 0] = 1..n_total, so we can identify which original token
+    survives after eviction without relying on approximate matching."""
+    rng = np.random.default_rng(seed)
+    raw_keys = mx.array(rng.standard_normal((n_total, D)).astype(np.float32))
+    fingerprints = np.zeros((n_total, D), dtype=np.float32)
+    for i in range(n_total):
+        fingerprints[i, 0] = i + 1.0
+    raw_values = mx.array(fingerprints)
+    positions = mx.arange(n_total, dtype=mx.int32)
+    rotated_keys = a2ats_apply_exact_rope(raw_keys, positions, base=10000.0)
+    return raw_keys, raw_values, rotated_keys, positions
+
+
+# ---------------------------------------------------------------------------
+# T1 — bit-for-bit vs. the reference eviction math (interior + newest evicted)
+# ---------------------------------------------------------------------------
+
+
+def test_evict_newest_token_when_it_is_the_minimum():
+    """Newest-arrival eviction (the common case per h2o_update's early-token-
+    freeze property — see module docstring in h2o.py): scores_mid's last row
+    is the global minimum (0.0), so it is evicted and all other rows are
+    untouched (no shift, no rotation)."""
+    D = 8
+    raw_keys, raw_values, rotated_keys, positions = _make_fingerprinted(5, D)
+    scores_mid = mx.array([[5.0, 5.0, 0.001, 5.0, 0.0]], dtype=mx.float32)
+
+    ko, vo, so, po = h2o_fused_evict(
+        rotated_keys[None].astype(mx.float16),
+        raw_values[None].astype(mx.float16),
+        scores_mid,
+        positions[None],
+        n_sink=0,
+        rope_base=10000.0,
+    )
+    mx.eval(ko, vo, so, po)
+
+    assert po.tolist() == [[0, 1, 2, 3]]
+    assert so.tolist() == [[5.0, 5.0, pytest.approx(0.001, abs=1e-4), 5.0]]
+    # Evicted row (index 4, the newest arrival) leaves rows 0-3 untouched —
+    # nothing after the eviction point, so all survivors are bit-identical.
+    diff = float(
+        mx.max(mx.abs(ko[0].astype(mx.float32) - rotated_keys[:4].astype(mx.float32))).item()
+    )
+    assert diff == 0.0
+
+
+def test_interior_eviction_recovers_exact_original_keys():
+    """Force eviction of an INTERIOR row (index 2 of 5), the rarer but real
+    case (e.g. with n_sink > 0). Every surviving key, de-rotated at its new
+    position, must recover its exact original pre-rotation value."""
+    D = 8
+    raw_keys, raw_values, rotated_keys, positions = _make_fingerprinted(5, D)
+    scores_mid = mx.array([[5.0, 5.0, 0.001, 5.0, 5.0]], dtype=mx.float32)
+
+    ko, vo, so, po = h2o_fused_evict(
+        rotated_keys[None].astype(mx.float16),
+        raw_values[None].astype(mx.float16),
+        scores_mid,
+        positions[None],
+        n_sink=0,
+        rope_base=10000.0,
+    )
+    mx.eval(ko, vo, so, po)
+
+    assert po.tolist() == [[0, 1, 2, 3]]
+    kept_fp = np.array(vo.astype(mx.float32))[0, :, 0]
+    assert 3.0 not in kept_fp  # token originally at index 2 (fp=3.0) is gone
+
+    recovered = rope_remap_positions(
+        ko[0].astype(mx.float32), po[0], mx.zeros_like(po[0]), base=10000.0
+    )
+    for row, fp in enumerate(kept_fp):
+        orig_idx = int(round(fp)) - 1
+        err = float(mx.max(mx.abs(recovered[row] - raw_keys[orig_idx])).item())
+        assert err < 1e-2, f"row {row} (orig token {orig_idx}): recon error {err}"
+
+
+# ---------------------------------------------------------------------------
+# T2 — output shape is always exactly n_kept rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_total", [2, 5, 9])
+def test_output_shape_is_n_total_minus_one(n_total):
+    D = 16
+    _, raw_values, rotated_keys, positions = _make_fingerprinted(n_total, D)
+    scores_mid = mx.arange(n_total, dtype=mx.float32)[None] + 0.1
+
+    ko, vo, so, po = h2o_fused_evict(
+        rotated_keys[None].astype(mx.float16),
+        raw_values[None].astype(mx.float16),
+        scores_mid,
+        positions[None],
+        n_sink=0,
+        rope_base=10000.0,
+    )
+    mx.eval(ko, vo, so, po)
+    assert ko.shape == (1, n_total - 1, D)
+    assert vo.shape == (1, n_total - 1, D)
+    assert so.shape == (1, n_total - 1)
+    assert po.shape == (1, n_total - 1)
+
+
+# ---------------------------------------------------------------------------
+# T3 — sink invariant: protected rows can never be evicted
+# ---------------------------------------------------------------------------
+
+
+def test_sink_protection():
+    """n_sink=2: even though index 0 holds the numeric minimum score, it is
+    protected and the real (non-sink) minimum, index 2, is evicted instead."""
+    D = 8
+    keys_mid = mx.zeros((1, 5, D), dtype=mx.float16)
+    values_mid = mx.zeros((1, 5, D), dtype=mx.float16)
+    scores_mid = mx.array([[0.0001, 5.0, 0.5, 5.0, 5.0]], dtype=mx.float32)
+    positions_mid = mx.array([[0, 1, 2, 3, 4]], dtype=mx.int32)
+
+    _, _, so, po = h2o_fused_evict(
+        keys_mid, values_mid, scores_mid, positions_mid, n_sink=2, rope_base=10000.0
+    )
+    mx.eval(so, po)
+    assert po.tolist() == [[0, 1, 2, 3]]
+    assert so[0, 0].item() == pytest.approx(0.0001, abs=1e-6)  # sink row survived
+
+
+def test_n_sink_zero_allows_all_evictions():
+    D = 8
+    keys_mid = mx.zeros((1, 3, D), dtype=mx.float16)
+    values_mid = mx.zeros((1, 3, D), dtype=mx.float16)
+    scores_mid = mx.array([[0.0001, 5.0, 5.0]], dtype=mx.float32)
+    positions_mid = mx.array([[0, 1, 2]], dtype=mx.int32)
+
+    _, _, so, po = h2o_fused_evict(
+        keys_mid, values_mid, scores_mid, positions_mid, n_sink=0, rope_base=10000.0
+    )
+    mx.eval(so, po)
+    assert so.tolist() == [[5.0, 5.0]]  # the 0.0001 row (index 0) WAS evicted
+
+
+# ---------------------------------------------------------------------------
+# T4 — untouched rows (before the eviction gap) are bit-identical, not
+# merely numerically close
+# ---------------------------------------------------------------------------
+
+
+def test_untouched_rows_are_exact_copies():
+    D = 8
+    _, raw_values, rotated_keys, positions = _make_fingerprinted(5, D)
+    # Evict index 3 (interior, not the first or last row) so rows 0,1,2
+    # (before the gap) must be untouched and rows mapping from index 4
+    # (after the gap) must shift + rotate.
+    scores_mid = mx.array([[5.0, 5.0, 5.0, 0.001, 5.0]], dtype=mx.float32)
+
+    ko, _, _, po = h2o_fused_evict(
+        rotated_keys[None].astype(mx.float16),
+        raw_values[None].astype(mx.float16),
+        scores_mid,
+        positions[None],
+        n_sink=0,
+        rope_base=10000.0,
+    )
+    mx.eval(ko, po)
+
+    for row in range(3):  # positions 0, 1, 2 — all before the evicted position 3
+        diff = float(
+            mx.max(
+                mx.abs(ko[0, row].astype(mx.float32) - rotated_keys[row].astype(mx.float32))
+            ).item()
+        )
+        assert diff == 0.0, f"row {row} should be bit-identical, got diff={diff}"
+
+
+# ---------------------------------------------------------------------------
+# T5 — determinism
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic():
+    D = 16
+    _, raw_values, rotated_keys, positions = _make_fingerprinted(6, D)
+    scores_mid = mx.array([[3.0, 1.0, 4.0, 0.001, 2.0, 5.0]], dtype=mx.float32)
+
+    out1 = h2o_fused_evict(
+        rotated_keys[None].astype(mx.float16),
+        raw_values[None].astype(mx.float16),
+        scores_mid,
+        positions[None],
+        n_sink=0,
+        rope_base=10000.0,
+    )
+    out2 = h2o_fused_evict(
+        rotated_keys[None].astype(mx.float16),
+        raw_values[None].astype(mx.float16),
+        scores_mid,
+        positions[None],
+        n_sink=0,
+        rope_base=10000.0,
+    )
+    for a, b in zip(out1, out2):
+        mx.eval(a, b)
+        assert float(mx.max(mx.abs(a.astype(mx.float32) - b.astype(mx.float32))).item()) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# T6 — large n_total stress test (exercises the grid-stride reduction loop)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_total", [128, 1000, 2048])
+def test_large_n_total_finds_correct_minimum(n_total):
+    D = 16
+    rng = np.random.default_rng(0)
+    scores_np = rng.uniform(1.0, 100.0, size=(2, n_total)).astype(np.float32)
+    plant_idx = [n_total // 3, n_total - 2]
+    for g, idx in enumerate(plant_idx):
+        scores_np[g, idx] = 1e-4
+    scores_mid = mx.array(scores_np)
+    keys_mid = mx.array(rng.standard_normal((2, n_total, D)).astype(np.float16))
+    values_mid = mx.array(rng.standard_normal((2, n_total, D)).astype(np.float16))
+    positions_mid = mx.array(np.tile(np.arange(n_total), (2, 1)).astype(np.int32))
+
+    _, _, so, _ = h2o_fused_evict(
+        keys_mid, values_mid, scores_mid, positions_mid, n_sink=0, rope_base=10000.0, nsg=4
+    )
+    mx.eval(so)
+    for g in range(2):
+        ref = int(mx.argmin(scores_mid[g]).item())
+        assert ref == plant_idx[g]
+        assert float(mx.min(so[g]).item()) > 1e-4  # planted minimum is gone
+
+
+# ---------------------------------------------------------------------------
+# T7 — tie-break behavior matches mx.argmin (lowest index wins)
+# ---------------------------------------------------------------------------
+
+
+def test_tie_break_matches_mx_argmin():
+    D = 8
+    keys_mid = mx.zeros((1, 5, D), dtype=mx.float16)
+    values_mid = mx.zeros((1, 5, D), dtype=mx.float16)
+    scores_tie = mx.array([[1.0, 0.5, 0.5, 1.0, 1.0]], dtype=mx.float32)
+    positions_mid = mx.array([[0, 1, 2, 3, 4]], dtype=mx.int32)
+
+    ref_evict = int(mx.argmin(scores_tie[0]).item())
+    expected_scores = [scores_tie[0, i].item() for i in range(5) if i != ref_evict]
+
+    _, _, so, _ = h2o_fused_evict(
+        keys_mid, values_mid, scores_tie, positions_mid, n_sink=0, rope_base=10000.0
+    )
+    mx.eval(so)
+    assert so.tolist()[0] == expected_scores
+
+
+# ---------------------------------------------------------------------------
+# Multi-group independence (BH > 1 groups handled independently)
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_bh_groups_are_independent():
+    D = 8
+    keys_mid = mx.zeros((3, 5, D), dtype=mx.float16)
+    values_mid = mx.zeros((3, 5, D), dtype=mx.float16)
+    scores_mid = mx.array(
+        [
+            [5.0, 0.1, 5.0, 5.0, 5.0],
+            [5.0, 5.0, 0.1, 5.0, 5.0],
+            [0.1, 5.0, 5.0, 5.0, 5.0],
+        ],
+        dtype=mx.float32,
+    )
+    positions_mid = mx.array([[0, 1, 2, 3, 4]] * 3, dtype=mx.int32)
+
+    _, _, so, _ = h2o_fused_evict(
+        keys_mid, values_mid, scores_mid, positions_mid, n_sink=0, rope_base=10000.0
+    )
+    mx.eval(so)
+    for g in range(3):
+        assert 0.1 not in so[g].tolist()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_non_3d_keys():
+    with pytest.raises(ValueError):
+        h2o_fused_evict(
+            mx.zeros((5, 8), dtype=mx.float16),
+            mx.zeros((1, 5, 8), dtype=mx.float16),
+            mx.zeros((1, 5), dtype=mx.float32),
+            mx.zeros((1, 5), dtype=mx.int32),
+            n_sink=0,
+            rope_base=10000.0,
+        )
+
+
+def test_rejects_odd_head_dim():
+    with pytest.raises(ValueError):
+        h2o_fused_evict(
+            mx.zeros((1, 5, 7), dtype=mx.float16),
+            mx.zeros((1, 5, 7), dtype=mx.float16),
+            mx.zeros((1, 5), dtype=mx.float32),
+            mx.zeros((1, 5), dtype=mx.int32),
+            n_sink=0,
+            rope_base=10000.0,
+        )
+
+
+def test_rejects_single_row_input():
+    """n_total=1 implies n_kept=0 -- nothing to evict from."""
+    with pytest.raises(ValueError):
+        h2o_fused_evict(
+            mx.zeros((1, 1, 8), dtype=mx.float16),
+            mx.zeros((1, 1, 8), dtype=mx.float16),
+            mx.zeros((1, 1), dtype=mx.float32),
+            mx.zeros((1, 1), dtype=mx.int32),
+            n_sink=0,
+            rope_base=10000.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark (printed, not asserted) — kernel vs. the pure-MLX per-token
+# eviction branch it replaces
+# ---------------------------------------------------------------------------
+
+
+def test_h2o_evict_benchmark(capsys):
+    from veloxquant_mlx.quantizers.h2o import H2OState, h2o_update
+
+    D = 128
+    n_kept = 512
+
+    def _timeit(fn, iters=50, warmup=10):
+        for _ in range(warmup):
+            mx.eval(fn())
+        mx.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            mx.eval(fn())
+        mx.synchronize()
+        return (time.perf_counter() - t0) / iters * 1e3
+
+    rng = np.random.default_rng(0)
+    keys = mx.array(rng.standard_normal((n_kept, D)).astype(np.float16))
+    values = mx.array(rng.standard_normal((n_kept, D)).astype(np.float16))
+    scores = mx.array(rng.uniform(0.1, 5.0, size=(n_kept,)).astype(np.float32))
+    positions = mx.arange(n_kept, dtype=mx.int32)
+
+    def _mlx_path():
+        st = H2OState(
+            keys=keys,
+            values=values,
+            scores=scores,
+            positions=positions,
+            n_sink=4,
+            budget=n_kept,
+            rope_base=10000.0,
+            next_pos=n_kept,
+        )
+        new_k = mx.array(rng.standard_normal((1, D)).astype(np.float16))
+        new_v = mx.array(rng.standard_normal((1, D)).astype(np.float16))
+        out = h2o_update(st, new_k, new_v)
+        return out.keys
+
+    keys_mid = mx.concatenate([keys, keys[:1]], axis=0)[None]
+    values_mid = mx.concatenate([values, values[:1]], axis=0)[None]
+    scores_mid = mx.concatenate([scores, mx.zeros((1,))], axis=0)[None]
+    positions_mid = mx.concatenate([positions, mx.array([n_kept])], axis=0)[None].astype(mx.int32)
+
+    def _kernel_path():
+        ko, _, _, _ = h2o_fused_evict(
+            keys_mid.astype(mx.float16),
+            values_mid.astype(mx.float16),
+            scores_mid,
+            positions_mid,
+            n_sink=4,
+            rope_base=10000.0,
+        )
+        return ko
+
+    t_mlx = _timeit(_mlx_path)
+    t_kernel = _timeit(_kernel_path)
+    with capsys.disabled():
+        print(f"\n# H2O fused eviction  |  n_kept={n_kept} D={D}  |  MLX {mx.__version__}")
+        print(f"| path | ms/call |")
+        print(f"|------|---------|")
+        print(f"| Python loop (h2o_update) | {t_mlx:.4f} |")
+        print(f"| fused Metal kernel       | {t_kernel:.4f} |")
+        print(f"| speedup | {t_mlx / t_kernel:.2f}x |")

--- a/veloxquant_mlx/tests/quantizers/test_h2o.py
+++ b/veloxquant_mlx/tests/quantizers/test_h2o.py
@@ -510,3 +510,30 @@ def test_batch_path_handles_long_prefill_without_crashing() -> None:
     st = h2o_update(st, k, v)  # must not raise
     assert st.keys.shape[0] == S
     assert st.next_pos == S
+
+
+def test_heavy_eviction_thousands_of_loop_iterations() -> None:
+    """Exercises thousands of consecutive eviction-loop iterations within a
+    single h2o_update call (budget exceeded almost immediately, S >> budget)
+    to confirm the periodic mx.eval() flush (_EVAL_FLUSH_INTERVAL) doesn't
+    change output or crash at this iteration count.
+
+    NOTE: this synthetic case does NOT reproduce the actual crash the flush
+    fixes — that was only observed via real mlx_lm.generate() on a genuine
+    ~3200-token prompt with the fused Metal eviction kernel active (see
+    h2o.py's module docstring and _EVAL_FLUSH_INTERVAL's comment); isolating
+    a single head's state update here, without the full model's per-layer/
+    per-head aggregate Metal resource pressure, was not sufficient to
+    reproduce it synthetically. This test guards determinism/no-crash at
+    scale, not the specific resource-limit regression."""
+    D = 16
+    S = 2000
+    budget = 64
+    rng = np.random.default_rng(0)
+    k = mx.array(rng.standard_normal((S, D)).astype(np.float16))
+    v = mx.array(rng.standard_normal((S, D)).astype(np.float16))
+
+    st = init_h2o_state(n_sink=4, budget=budget, head_dim=D)
+    st = h2o_update(st, k, v)  # must not raise
+    assert st.keys.shape[0] == budget
+    assert st.next_pos == S

--- a/veloxquant_mlx/tests/quantizers/test_h2o.py
+++ b/veloxquant_mlx/tests/quantizers/test_h2o.py
@@ -5,8 +5,11 @@ weights (using the incoming key as a proxy query) and evicts the lowest-score
 non-sink token whenever the cache exceeds the budget. Tests cover: init_h2o_state,
 h2o_update (single token, multi-step, eviction trigger, sink protection, budget
 enforcement, score accumulation), h2o_get_kv (shape, dtype, empty state), byte
-accounting, and edge cases (n_sink=0, budget=1, score-based ordering). All data
-is synthetic — no model loading.
+accounting, edge cases (n_sink=0, budget=1, score-based ordering), RoPE position
+remapping after eviction, and the vectorized below-budget batch path (a
+performance fix: verified numerically equivalent to the sequential per-token
+loop it replaces, including across the batch-path/loop-path boundary within a
+single call). All data is synthetic — no model loading.
 """
 
 from __future__ import annotations
@@ -18,6 +21,7 @@ import pytest
 from veloxquant_mlx.quantizers.a2ats_rope import a2ats_apply_exact_rope, rope_remap_positions
 from veloxquant_mlx.quantizers.h2o import (
     H2OState,
+    _batch_absorb_no_eviction,
     full_h2o_fp16_bytes,
     h2o_fp16_bytes,
     h2o_get_kv,
@@ -405,3 +409,104 @@ def test_new_token_almost_always_evicted_first() -> None:
     # After 20 steps with budget=4, the kept set should have frozen on the
     # earliest possible contiguous window (never grew past position 3).
     assert st.positions.tolist() == [0, 1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Vectorized below-budget batch path (perf fix: avoids a per-token Python
+# loop with 4 concats/token, which exhausted MLX's Metal resource limit on
+# long prefills — e.g. ~3200 tokens — even with eviction disabled). Must be
+# numerically equivalent to the sequential per-token loop it replaces.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_absorb_matches_sequential_from_empty() -> None:
+    """_batch_absorb_no_eviction(None, None, keys) must match calling
+    h2o_update one token at a time from an empty state (huge budget, so no
+    eviction ever fires in the sequential reference)."""
+    D = 8
+    S = 6
+    rng = np.random.default_rng(0)
+    keys = mx.array(rng.standard_normal((S, D)).astype(np.float32))
+
+    st = init_h2o_state(n_sink=0, budget=1000, head_dim=D)
+    for i in range(S):
+        st = h2o_update(st, keys[i][None].astype(mx.float16), keys[i][None].astype(mx.float16))
+
+    vectorized = _batch_absorb_no_eviction(None, None, keys)
+    err = float(mx.max(mx.abs(vectorized - st.scores)).item())
+    assert err < 1e-3, f"batch vs sequential score mismatch: {err}"
+
+
+def test_batch_absorb_matches_sequential_with_prior_tokens() -> None:
+    """_batch_absorb_no_eviction with a non-empty prior state must match
+    continuing the sequential per-token loop from that same prior state."""
+    D = 8
+    P = 3
+    S = 4
+    rng = np.random.default_rng(1)
+    prior = rng.standard_normal((P, D)).astype(np.float32)
+    new = rng.standard_normal((S, D)).astype(np.float32)
+
+    st = init_h2o_state(n_sink=0, budget=1000, head_dim=D)
+    for i in range(P):
+        k = mx.array(prior[i][None].astype(np.float16))
+        st = h2o_update(st, k, k)
+    for i in range(S):
+        k = mx.array(new[i][None].astype(np.float16))
+        st = h2o_update(st, k, k)
+
+    st2 = init_h2o_state(n_sink=0, budget=1000, head_dim=D)
+    for i in range(P):
+        k = mx.array(prior[i][None].astype(np.float16))
+        st2 = h2o_update(st2, k, k)
+    vectorized = _batch_absorb_no_eviction(st2.keys.astype(mx.float32), st2.scores, mx.array(new))
+    err = float(mx.max(mx.abs(vectorized - st.scores)).item())
+    assert err < 1e-3, f"batch vs sequential score mismatch: {err}"
+
+
+def test_h2o_update_single_call_matches_many_single_token_calls() -> None:
+    """The public contract: h2o_update(state, keys[S,D], values[S,D]) in one
+    call must produce the identical final state as calling h2o_update S times
+    with one token each — across the batch-path/loop-path boundary (budget
+    straddled mid-batch), not just in the pure-batch or pure-loop regimes."""
+    D = 16
+    budget = 6
+    n_sink = 0
+    rng = np.random.default_rng(0)
+    all_k = rng.standard_normal((15, D)).astype(np.float16)
+    all_v = rng.standard_normal((15, D)).astype(np.float16)
+
+    st_seq = init_h2o_state(n_sink=n_sink, budget=budget, head_dim=D)
+    for i in range(15):
+        st_seq = h2o_update(st_seq, mx.array(all_k[i][None]), mx.array(all_v[i][None]))
+
+    st_batch = init_h2o_state(n_sink=n_sink, budget=budget, head_dim=D)
+    st_batch = h2o_update(st_batch, mx.array(all_k), mx.array(all_v))
+
+    assert st_seq.positions.tolist() == st_batch.positions.tolist()
+    assert st_seq.next_pos == st_batch.next_pos
+    score_err = float(mx.max(mx.abs(st_seq.scores - st_batch.scores)).item())
+    assert score_err < 1e-2, f"score mismatch: {score_err}"
+    key_mse = float(
+        mx.mean((st_seq.keys.astype(mx.float32) - st_batch.keys.astype(mx.float32)) ** 2).item()
+    )
+    assert key_mse < 1e-3, f"key mismatch: {key_mse}"
+
+
+def test_batch_path_handles_long_prefill_without_crashing() -> None:
+    """Regression for the real crash this fix addresses: a single
+    update_and_fetch-style call with thousands of tokens and a budget large
+    enough that no eviction occurs must not blow up building an enormous
+    unfused op graph (the pre-fix per-token-loop behavior). 4000 tokens is
+    smaller than the ~3200-token prompt that triggered a genuine Metal
+    resource-limit crash pre-fix, kept modest here to stay fast in CI."""
+    D = 32
+    S = 4000
+    rng = np.random.default_rng(0)
+    k = mx.array(rng.standard_normal((S, D)).astype(np.float16))
+    v = mx.array(rng.standard_normal((S, D)).astype(np.float16))
+
+    st = init_h2o_state(n_sink=4, budget=S + 100, head_dim=D)
+    st = h2o_update(st, k, v)  # must not raise
+    assert st.keys.shape[0] == S
+    assert st.next_pos == S

--- a/veloxquant_mlx/tests/quantizers/test_h2o.py
+++ b/veloxquant_mlx/tests/quantizers/test_h2o.py
@@ -15,6 +15,7 @@ import mlx.core as mx
 import numpy as np
 import pytest
 
+from veloxquant_mlx.quantizers.a2ats_rope import a2ats_apply_exact_rope, rope_remap_positions
 from veloxquant_mlx.quantizers.h2o import (
     H2OState,
     full_h2o_fp16_bytes,
@@ -284,3 +285,123 @@ def test_deterministic_across_identical_inputs() -> None:
     kb, _ = h2o_get_kv(st_b)
     mse = float(mx.mean((ka.astype(mx.float32) - kb.astype(mx.float32)) ** 2).item())
     assert mse == pytest.approx(0.0, abs=0.0)
+
+
+# ---------------------------------------------------------------------------
+# RoPE position remapping after eviction (fixes a real regression — see
+# module docstring and docs-site/docs/algorithms/h2o.md for the full
+# investigation, including why interior eviction is rare but not impossible)
+# ---------------------------------------------------------------------------
+
+
+def test_state_tracks_positions_and_next_pos() -> None:
+    """H2OState exposes positions/next_pos so callers can detect gaps."""
+    D = 16
+    st = init_h2o_state(n_sink=0, budget=8, head_dim=D)
+    k, v = _rand_kv(S=3, D=D)
+    st = h2o_update(st, k, v)
+    assert st.positions.tolist() == [0, 1, 2]
+    assert st.next_pos == 3
+
+
+def test_positions_stay_contiguous_and_sorted_under_stress() -> None:
+    """Across many steps, kept positions never have gaps or duplicates, and
+    n_sink leading positions never move — the invariant the RoPE remap must
+    preserve for attention to see a consistent contiguous cache."""
+    D = 16
+    n_sink = 2
+    budget = 6
+    st = init_h2o_state(n_sink=n_sink, budget=budget, head_dim=D)
+    for i in range(60):
+        k, v = _rand_kv(S=1, D=D, seed=i)
+        st = h2o_update(st, k, v)
+        pos = st.positions.tolist()
+        assert pos == sorted(pos), f"step {i}: not sorted: {pos}"
+        assert len(set(pos)) == len(pos), f"step {i}: duplicate: {pos}"
+        diffs = [pos[j + 1] - pos[j] for j in range(len(pos) - 1)]
+        assert all(d == 1 for d in diffs), f"step {i}: gap in kept positions: {pos}"
+        if len(pos) >= n_sink:
+            assert pos[:n_sink] == list(range(n_sink)), f"step {i}: sinks moved: {pos}"
+
+
+def test_interior_eviction_gap_remap_recovers_exact_original_keys() -> None:
+    """The core correctness property of the eviction+remap logic in
+    h2o_update: when a row is dropped from the INTERIOR of the kept set
+    (rows after it shift down by one position and get re-rotated; rows
+    before it are untouched), every surviving key, de-rotated at its new
+    stored position, must exactly recover its original pre-rotation value.
+
+    A brand-new arrival always starts at score 0.0 in h2o_update, which
+    makes it (almost) always the eviction target in practice — see
+    test_new_token_almost_always_evicted_first — so genuine interior
+    eviction from realistic inputs is rare. This test instead exercises
+    h2o_update's exact eviction+remap code path (mirroring its
+    keep_indices/shift/rope_remap_positions logic line-for-line) directly on
+    a constructed 5-token state, to verify that logic's correctness
+    independent of how often it fires in practice.
+    """
+    D = 16
+    rng = np.random.default_rng(0)
+    raw_keys = mx.array(rng.standard_normal((5, D)).astype(np.float32))
+    fingerprints = np.zeros((5, D), dtype=np.float32)
+    for i in range(5):
+        fingerprints[i, 0] = i + 1.0
+    raw_values = mx.array(fingerprints)
+    positions = mx.arange(5, dtype=mx.int32)
+    rotated_keys = a2ats_apply_exact_rope(raw_keys, positions, base=10000.0)
+
+    # Evict the interior token at index 2 (position 2): same keep_indices /
+    # shift / remap steps h2o_update's eviction branch performs.
+    evict_idx = 2
+    keep_indices = [j for j in range(5) if j != evict_idx]
+    kept_keys_before = rotated_keys[keep_indices]
+    old_positions_kept = positions[keep_indices]
+    evicted_pos = int(positions[evict_idx].item())
+    shift = mx.where(old_positions_kept > evicted_pos, -1, 0)
+    new_positions = old_positions_kept + shift
+    remapped_keys = rope_remap_positions(
+        kept_keys_before.astype(mx.float32), old_positions_kept, new_positions, base=10000.0
+    )
+
+    # Positions before the gap (0, 1) are untouched; after it (3, 4 -> 2, 3).
+    assert new_positions.tolist() == [0, 1, 2, 3]
+
+    # Rows before the gap must be numerically unchanged (no re-rotation
+    # needed — this is the "minimal disturbance" property).
+    for row in (0, 1):
+        err = float(
+            mx.max(mx.abs(remapped_keys[row] - kept_keys_before[row].astype(mx.float32))).item()
+        )
+        assert err < 1e-3, f"row {row} before the gap should be untouched, err={err}"
+
+    # Every surviving key, de-rotated at its NEW position, must recover its
+    # exact original pre-rotation value.
+    recovered = rope_remap_positions(
+        remapped_keys, new_positions, mx.zeros_like(new_positions), base=10000.0
+    )
+    kept_fingerprints = np.array(raw_values.astype(mx.float32))[keep_indices, 0]
+    assert 3.0 not in kept_fingerprints  # token originally at index 2 (fp=3.0) is gone
+    for row, fp in enumerate(kept_fingerprints):
+        orig_idx = int(round(fp)) - 1
+        err = float(mx.max(mx.abs(recovered[row] - raw_keys[orig_idx])).item())
+        assert err < 1e-2, f"row {row} (orig token {orig_idx}): recon error {err}"
+
+
+def test_new_token_almost_always_evicted_first() -> None:
+    """Documents the real, verified early-token-freeze finding: with a
+    realistic (non-degenerate) score distribution, a brand-new token's
+    starting score of 0.0 is virtually always the global minimum, so once
+    the cache is full, the newest arrival is evicted on (nearly) every step
+    rather than an old low-value token — freezing the kept set. Not a
+    regression to fix here; documented as a known property of the paper's
+    own cumulative-sum formula at tight budgets (see module docstring)."""
+    D = 16
+    budget = 4
+    st = init_h2o_state(n_sink=0, budget=budget, head_dim=D)
+    rng = np.random.default_rng(0)
+    for i in range(20):
+        k, v = _rand_kv(S=1, D=D, seed=i)
+        st = h2o_update(st, k, v)
+    # After 20 steps with budget=4, the kept set should have frozen on the
+    # earliest possible contiguous window (never grew past position 3).
+    assert st.positions.tolist() == [0, 1, 2, 3]

--- a/veloxquant_mlx/tests/quantizers/test_h2o.py
+++ b/veloxquant_mlx/tests/quantizers/test_h2o.py
@@ -69,6 +69,31 @@ def test_init_state_rejects_n_sink_above_budget() -> None:
         init_h2o_state(n_sink=8, budget=4, head_dim=32)
 
 
+def test_init_state_decay_defaults_to_no_op() -> None:
+    st = init_h2o_state(n_sink=0, budget=16, head_dim=32)
+    assert st.decay == 1.0
+
+
+def test_init_state_rejects_decay_zero() -> None:
+    with pytest.raises(ValueError, match="decay"):
+        init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=0.0)
+
+
+def test_init_state_rejects_decay_negative() -> None:
+    with pytest.raises(ValueError, match="decay"):
+        init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=-0.5)
+
+
+def test_init_state_rejects_decay_above_one() -> None:
+    with pytest.raises(ValueError, match="decay"):
+        init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=1.5)
+
+
+def test_init_state_accepts_decay_equal_one() -> None:
+    st = init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=1.0)
+    assert st.decay == 1.0
+
+
 # ---------------------------------------------------------------------------
 # h2o_get_kv — empty state
 # ---------------------------------------------------------------------------
@@ -225,6 +250,71 @@ def test_scores_accumulate_over_steps() -> None:
     scores_after_2 = np.array(st2.scores[: len(scores_after_1)].tolist())
     # Softmax weights are positive, so at least total mass increased
     assert scores_after_2.sum() >= scores_after_1.sum() - 1e-4
+
+
+# ---------------------------------------------------------------------------
+# decay — fixes score staleness (old tokens permanently outranking new ones)
+# ---------------------------------------------------------------------------
+
+
+def test_decay_one_reproduces_no_decay_behavior() -> None:
+    """decay=1.0 must be bit-for-bit identical to omitting decay entirely —
+    it is the explicit opt-out, not just 'close to' the original behavior."""
+    D = 16
+    budget = 1000
+    k, v = _rand_kv(S=30, D=D, seed=3)
+
+    st_default = init_h2o_state(n_sink=0, budget=budget, head_dim=D)
+    st_default = h2o_update(st_default, k, v)
+
+    st_explicit = init_h2o_state(n_sink=0, budget=budget, head_dim=D, decay=1.0)
+    st_explicit = h2o_update(st_explicit, k, v)
+
+    assert bool(mx.all(st_default.scores == st_explicit.scores).item())
+
+
+def test_decay_shrinks_old_scores_relative_to_no_decay() -> None:
+    """With decay < 1.0, an old token's score after many later updates must
+    be strictly lower than with decay=1.0 (its earlier mass fades)."""
+    D = 16
+    budget = 1000
+    k, v = _rand_kv(S=1, D=D, seed=0)
+
+    st_nodecay = init_h2o_state(n_sink=0, budget=budget, head_dim=D, decay=1.0)
+    st_nodecay = h2o_update(st_nodecay, k, v)
+    st_decay = init_h2o_state(n_sink=0, budget=budget, head_dim=D, decay=0.9)
+    st_decay = h2o_update(st_decay, k, v)
+
+    for step in range(1, 20):
+        k_i, v_i = _rand_kv(S=1, D=D, seed=step)
+        st_nodecay = h2o_update(st_nodecay, k_i, v_i)
+        st_decay = h2o_update(st_decay, k_i, v_i)
+
+    assert float(st_decay.scores[0].item()) < float(st_nodecay.scores[0].item())
+
+
+def test_decay_prevents_old_token_from_permanently_outranking_recent_ones() -> None:
+    """The actual bug being fixed: without decay, an old survivor's
+    cumulative score can exceed every recently-graduated token's score
+    forever, forcing eviction to thin the rest of the budget into a sparse
+    trickle. With decay, a long-enough run should let a later, currently
+    high-scoring token exceed an early token's (now-decayed) score."""
+    D = 16
+    budget = 1000
+    n_sink = 0
+
+    st = init_h2o_state(n_sink=n_sink, budget=budget, head_dim=D, decay=0.8)
+    for step in range(40):
+        k_i, v_i = _rand_kv(S=1, D=D, seed=step)
+        st = h2o_update(st, k_i, v_i)
+
+    scores_np = np.array(st.scores.tolist())
+    # With decay, score should NOT be monotonically non-increasing in
+    # position the way it is without decay (see module docstring: -0.97
+    # correlation with no decay) — at least one later token should beat an
+    # earlier one, showing old dominance has been broken.
+    beats_earlier = any(scores_np[j] > scores_np[0] for j in range(1, len(scores_np) - 1))
+    assert beats_earlier
 
 
 # ---------------------------------------------------------------------------
@@ -462,6 +552,56 @@ def test_batch_absorb_matches_sequential_with_prior_tokens() -> None:
     vectorized = _batch_absorb_no_eviction(st2.keys.astype(mx.float32), st2.scores, mx.array(new))
     err = float(mx.max(mx.abs(vectorized - st.scores)).item())
     assert err < 1e-3, f"batch vs sequential score mismatch: {err}"
+
+
+def test_batch_absorb_with_decay_matches_sequential_from_empty() -> None:
+    """decay must be applied identically in the vectorized batch path and
+    the sequential per-token loop it replaces — this is the highest-risk
+    piece of the decay fix (exponentiated decay powers per batch row)."""
+    D = 8
+    S = 6
+    decay = 0.9
+    rng = np.random.default_rng(2)
+    keys = mx.array(rng.standard_normal((S, D)).astype(np.float32))
+
+    st = init_h2o_state(n_sink=0, budget=1000, head_dim=D, decay=decay)
+    for i in range(S):
+        st = h2o_update(st, keys[i][None].astype(mx.float16), keys[i][None].astype(mx.float16))
+
+    vectorized = _batch_absorb_no_eviction(None, None, keys, decay=decay)
+    err = float(mx.max(mx.abs(vectorized - st.scores)).item())
+    assert err < 1e-3, f"batch-with-decay vs sequential score mismatch: {err}"
+
+
+def test_batch_absorb_with_decay_matches_sequential_with_prior_tokens() -> None:
+    """Same as above but exercising the non-empty-prior branch of
+    _batch_absorb_no_eviction, which decays prior_scores by decay**S in
+    addition to decaying each batch row's own contribution."""
+    D = 8
+    P = 3
+    S = 4
+    decay = 0.9
+    rng = np.random.default_rng(3)
+    prior = rng.standard_normal((P, D)).astype(np.float32)
+    new = rng.standard_normal((S, D)).astype(np.float32)
+
+    st = init_h2o_state(n_sink=0, budget=1000, head_dim=D, decay=decay)
+    for i in range(P):
+        k = mx.array(prior[i][None].astype(np.float16))
+        st = h2o_update(st, k, k)
+    for i in range(S):
+        k = mx.array(new[i][None].astype(np.float16))
+        st = h2o_update(st, k, k)
+
+    st2 = init_h2o_state(n_sink=0, budget=1000, head_dim=D, decay=decay)
+    for i in range(P):
+        k = mx.array(prior[i][None].astype(np.float16))
+        st2 = h2o_update(st2, k, k)
+    vectorized = _batch_absorb_no_eviction(
+        st2.keys.astype(mx.float32), st2.scores, mx.array(new), decay=decay
+    )
+    err = float(mx.max(mx.abs(vectorized - st.scores)).item())
+    assert err < 1e-3, f"batch-with-decay vs sequential score mismatch: {err}"
 
 
 def test_h2o_update_single_call_matches_many_single_token_calls() -> None:


### PR DESCRIPTION
## Summary

Fixes #137 — real end-to-end generation testing found `method="h2o"` corrupts output once eviction fires. This PR fixes two real, independently-verified RoPE correctness bugs, and documents (but does not fix) the actual dominant cause, which needs a bigger algorithmic change.

## What's fixed

1. **RoPE position desync on eviction** — stored keys arrive pre-rotated for their true absolute position; dropping an interior row left survivors' storage index out of sync with that rotation. Fixed via a new de-rotate/re-rotate primitive, `rope_remap_positions` (`veloxquant_mlx/quantizers/a2ats_rope.py`), applied in `h2o_update` whenever eviction changes the kept set.
2. **`cache.offset` conflated with kept-row-count** — `mlx_lm` rotates the query *and* the next incoming key using `cache.offset`, inside the model's forward pass, before `update_and_fetch` runs. `H2OKVCache` previously reset `offset` to `n_kept` every call, silently rotating future queries at the wrong position once eviction occurred. Fixed by tracking `offset` as the true absolute step count, managing `keys`/`values`/`offset`/`.state`/`.size()` directly instead of delegating to the base class.

Verified via a synthetic fingerprinted-token test that forces an interior eviction and confirms every surviving key de-rotates back to its exact original pre-rotation value.

## What's NOT fixed (see #137 for full writeup)

Precise tracing showed interior eviction essentially never happens in practice: every new token starts at score `0.0`, and eviction removes the global minimum, so the newest token is (almost) always its own eviction target. Traced on Llama-3.2-1B: after 43 real decode steps, the kept set was still exactly the original 14-token prompt — the model generated the whole time with zero visibility into its own output, which is the actual cause of the repetition-loop collapse seen on real models. This is a consequence of the paper's own scoring formula, not a bug in this implementation (verified against Algorithm 1 line-by-line — see the new "Fidelity to Algorithm 1" section in the docs). Fixing it needs a different eviction/scoring policy, tracked as follow-up in #137.

Also flagged in #137, not investigated here: the other 16 eviction/compression caches in this repo share the same pre-fix `offset == n_kept` pattern and may have the same latent query-rotation bug.

## Testing

- `veloxquant_mlx/tests/quantizers/test_h2o.py` — 6 new tests (position tracking, contiguity under stress, interior-eviction remap correctness, early-token-freeze documentation).
- `veloxquant_mlx/tests/cache/test_h2o_cache.py` — 3 new tests (`offset` tracks true position, `.state` returns exactly kept rows, `.size()` != `.offset`).
- `veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py` — updated to carve out H2O's new (correct) `offset != shape[2]` contract as a documented exception, with H2O-specific counterpart assertions.
- Full suite: **1786/1786 passing**.
- `docs-site` build: clean, no broken anchors.
- Real end-to-end generation re-verified on `mlx-community/Llama-3.2-1B-Instruct-4bit` (`rope_theta=500000`) and `mlx-community/Mistral-7B-Instruct-v0.3-4bit` (`rope_theta=1000000`) after the fix — exact outputs documented in `docs-site/docs/algorithms/h2o.md`.

## Docs

`docs-site/docs/algorithms/h2o.md` rewritten: top-of-page `:::danger` banner, a "Fidelity to Algorithm 1" comparison table against the paper, and a precise root-cause section replacing the earlier (overstated) RoPE-only explanation with the verified early-token-freeze finding.
