### PR TITLE
fix(h2o): grace period + score decay — the actual eviction-quality fix (needs careful review)

### DIFF
--- a/docs-site/docs/algorithms/h2o.md
+++ b/docs-site/docs/algorithms/h2o.md
@@ -4,26 +4,34 @@
 (Zhang et al., ICLR 2024) — **H2O-adapted (VeloxQuant-MLX implementation)**,
 not a faithful port.
 
-:::danger[Not safe for real generation yet — cache freezes on early tokens]
-Real-model testing (below) confirms eviction corrupts output — as few as one
-or two evictions can send generation into repetition loops, and heavier
-eviction causes total collapse. Root cause: the scoring formula gives every
-newly-arrived token a starting score of exactly `0`, and the eviction rule
-removes the *global minimum* score — so once the cache is full, the brand-new
-token is (almost always) its own eviction target, before it ever gets a
-chance to accumulate attention mass. In practice this means **the kept set
-freezes on whichever tokens filled the budget first** (typically the prompt)
-and never admits anything generated afterward — the model ends up generating
-forever while attending only to the original prompt, with zero visibility
-into its own recent output. This is a real limitation of the paper's own
-cumulative-sum formulation at low budgets, not an implementation bug in the
-eviction *rule* itself (which correctly implements Algorithm 1 — see
-[fidelity check](#fidelity-to-algorithm-1)). See
-[the finding](#real-end-to-end-generation-eviction-breaks-coherence) before
-using `method="h2o"` for anything beyond studying the mechanism. A separate
-scalability bug that used to crash long prefills outright (regardless of
-eviction settings) has since been fixed — see
-[long-context testing](#long-context-testing-the-freeze-holds-at-scale-plus-a-scalability-bug-now-fixed).
+:::warning[Freeze mechanism fixed via `h2o_grace` — but tight budgets still degrade output]
+Real-model testing (below) originally found that eviction corrupted output —
+as few as one or two evictions could send generation into repetition loops,
+and heavier eviction caused total collapse. Root cause: the scoring formula
+gives every newly-arrived token a starting score of exactly `0`, and the
+eviction rule removes the *global minimum* score — so the brand-new token
+was (almost always) its own eviction target the instant the cache filled,
+before it ever accumulated attention mass. The kept set froze on whichever
+tokens filled the budget first (typically the prompt) and never admitted
+anything generated afterward.
+
+**Fixed** via `h2o_grace` (default `16`): the most-recently-arrived `grace`
+tokens are protected from eviction the same way sink tokens are, giving
+every new token `grace` update steps to actually compete before it can be
+evicted. Verified structurally on real models: the kept-position window now
+genuinely advances with generation instead of freezing at `[0, budget-1]`
+forever — see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom).
+
+**Not fully solved:** fixing the freeze mechanism is necessary but not
+sufficient for *coherent* output. When `h2o_budget` is tight relative to
+`h2o_n_sink + h2o_grace` plus how much of the prompt needs to survive,
+eviction is forced to thin out old tokens into a sparse, gapped window
+(e.g. keeping positions `..., 37, 39, 41, 43, ...` instead of a contiguous
+range) to make room — and generation still degrades under that regime, just
+via a different mechanism (broken local coherence from the gaps) rather than
+the original freeze. Give `h2o_budget` real headroom over `h2o_n_sink +
+h2o_grace` for coherent output; see the table below for what "enough" looks
+like in practice.
 :::
 
 H2O-adapted is the library's **third eviction axis** and the first based on
@@ -49,8 +57,9 @@ model, tokenizer = mlx_lm.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
 config = KVCacheConfig(
     method="h2o",
     head_dim=128,
-    h2o_budget=512,  # max tokens retained at any time (sinks + non-sinks)
+    h2o_budget=512,  # max tokens retained at any time (sinks + grace + non-sinks)
     h2o_n_sink=4,  # initial positions never evicted (attention sinks)
+    h2o_grace=16,  # most-recent tokens never evicted (fixes the early-token freeze)
 )
 caches = KVCacheBuilder.for_model(model, config)
 model.make_cache = lambda *_a, **_k: caches
@@ -60,8 +69,9 @@ model.make_cache = lambda *_a, **_k: caches
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `h2o_budget` | `512` | Maximum token positions retained at any time. When the cache exceeds this count, the lowest-score non-sink token is permanently evicted. |
+| `h2o_budget` | `512` | Maximum token positions retained at any time. When the cache exceeds this count, the lowest-score non-sink, non-grace token is permanently evicted. |
 | `h2o_n_sink` | `4` | Number of initial token positions always retained (attention-sink tokens never eligible for eviction). |
+| `h2o_grace` | `16` | Number of most-recently-arrived tokens always retained, giving each new token this many update steps to accumulate real attention mass before it becomes eviction-eligible. `0` reproduces the original paper-faithful (but freeze-prone) behavior. `h2o_n_sink + h2o_grace` must be `< h2o_budget`. |
 
 ## How it works
 
@@ -75,9 +85,11 @@ For every incoming token (both prefill and decode), per head:
    score vector: `scores += attn`. New tokens start with score 0 and begin
    accumulating on subsequent steps.
 3. **Eviction (if over budget).** If the total token count exceeds `h2o_budget`, a
-   protected score view is constructed: the first `h2o_n_sink` positions receive
-   `+inf` (they are never evicted). The token with the minimum protected score is
-   permanently removed.
+   protected score view is constructed: the first `h2o_n_sink` positions
+   receive `+inf` (attention sinks), and the last `h2o_grace` positions — the
+   most recently arrived tokens, since positions are always kept sorted
+   ascending after eviction — also receive `+inf`. The token with the
+   minimum protected score among the remainder is permanently removed.
 4. **Guarantee.** After every step, the cache holds at most `h2o_budget` tokens.
 
 No `.bits` attribute — stored K/V remain in fp16. The `compression_ratio` and
@@ -116,6 +128,11 @@ faithful port.
 own scoring rule (new tokens start at score 0, minimum gets evicted) is what
 produces the early-token freeze described below — implementing it exactly as
 specified is what causes the practical problem, not a deviation from it.
+`h2o_grace` (default `16`, see [How it works](#how-it-works)) is this
+library's own addition on top of Algorithm 1 to make the method usable in
+practice; the paper itself does not specify a grace period, so `h2o_grace=0`
+is the fidelity-preserving setting if you want to study the paper's
+mechanism exactly as published.
 
 ## Evidence
 
@@ -143,20 +160,26 @@ All claims trace to passing tests in
 - `cache.offset` tracks the true absolute step count, not the kept-row count, once eviction has occurred
 - The vectorized below-budget batch path matches the sequential per-token loop it replaces bit-for-bit within fp16 rounding, including for a single call whose batch straddles the below-budget/over-budget boundary
 - A 4,000-token single-call absorption (no eviction) completes without error — the regression test for the prefill scalability crash
+- `h2o_grace` defaults to a nonzero value in `KVCacheConfig`; grace-protected tokens survive even when they hold the lowest score, verified against a synthetic case where `h2o_grace=0` would evict the newest tokens
+- The fused Metal eviction kernel (`veloxquant_mlx/tests/metal/test_h2o_evict.py`, 18 tests) matches the pure-MLX eviction path bit-for-bit, including sink+grace protection, interior eviction, tie-break-matches-`mx.argmin`, and bit-identical untouched rows
 
 The offline harness in `benchmark_scripts/benchmark_h2o.py` sweeps
 `(seq_len, budget, n_sink)` and reports latency and compression ratio —
 **synthetic, not model-level.**
 
-### Real end-to-end generation: eviction breaks coherence
+### Real end-to-end generation: the `h2o_grace=0` baseline (historical)
 
-Model-level testing has now been run — `mlx_lm.generate` on
+Model-level testing was run — `mlx_lm.generate` on
 `mlx-community/Llama-3.2-1B-Instruct-4bit` (`head_dim=64`, `rope_theta=500000`)
 and `mlx-community/Mistral-7B-Instruct-v0.3-4bit` (`head_dim=128`,
-`rope_theta=1000000`) — and the result is a real, reproducible problem, not
-just a theoretical caveat.
+`rope_theta=1000000`) — and found a real, reproducible problem, not just a
+theoretical caveat. This section documents the **`h2o_grace=0` behavior**
+(the library's default before the grace-period fix, and still what you get
+if you explicitly set `h2o_grace=0` to study the paper's mechanism exactly
+as published). See [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom)
+below for the current default (`h2o_grace=16`) behavior.
 
-:::danger[Eviction corrupts generation quality — this is not tuning, it collapses almost immediately]
+:::danger[grace=0: eviction corrupts generation quality — this is not tuning, it collapses almost immediately]
 The moment eviction actually fires (as little as **one or two evictions**,
 tested with `h2o_n_sink=0` and `h2o_budget` set to only 1–10 tokens above the
 prompt length), output degrades into repetition loops. Severity scales with
@@ -210,19 +233,60 @@ itself it does **not** fix the collapse demonstrated above — the freeze
 happens before interior eviction geometry ever becomes relevant.
 :::
 
-**Practical takeaway:** do not use `h2o` in this library for real generation
-today. It is validated at the unit/synthetic level (the mechanism —
-scoring, sink protection, budget enforcement, and now RoPE position
-consistency under interior eviction — is implemented correctly per the
-paper's Algorithm 1) but **not yet safe for actual model output**, because
-the paper's own cumulative-sum scoring formula starves newly-generated
-tokens of any chance to survive once the budget is full. Fixing this needs a
-change to the eviction/scoring policy itself (e.g. a grace period before a
-token becomes eviction-eligible, or age-normalized scoring) — a bigger,
-more opinionated algorithmic change than a bugfix, and not undertaken here.
-Tracked as follow-up work, not silently patched over.
+**This `h2o_grace=0` behavior is no longer the default.** It's preserved
+here as a historical record and as an explicit opt-in
+(`h2o_grace=0`) for anyone studying the paper's Algorithm 1 exactly as
+published, including its practical failure mode at tight budgets. For real
+usage, see the grace-period results next.
+
+### Grace-period testing: fixes the freeze mechanism, coherence still needs budget headroom
+
+Re-ran the same real-model methodology with `h2o_grace > 0` to check whether
+protecting recently-arrived tokens actually fixes the freeze — and to be
+honest about what it does and doesn't fix.
+
+**The freeze mechanism itself is fixed, structurally verified.** With
+`h2o_grace=8` and a short prompt (13 tokens, `h2o_budget=14`), the kept
+position set — which with `h2o_grace=0` stayed frozen at `[0..13]` forever —
+now genuinely advances: `[0, 1, 2, 3, 4, 5, 27, 29, 31, 33, 35, 37, 39, 41]`.
+Generated tokens are finally entering and surviving in the cache, which
+never happened at `h2o_grace=0`.
+
+**But structural advancement alone doesn't guarantee coherent output.** At
+that same tight budget, the kept window has gaps every other position
+(`27, 29, 31, ...`) to make room for both `h2o_grace` and ongoing eviction —
+and generation degrades anyway, just via a different mechanism (broken local
+context from the gaps) rather than the original freeze:
+
+| `h2o_grace` | `h2o_budget` | Kept positions (tail) | Output |
+|---|---|---|---|
+| `0` | 14 | `[0..13]` (frozen) | `Paris.\nThe\nThe answer in French...` |
+| `8` | 14 | `[..., 27, 29, 31, 33, 35, 37, 39, 41]` (gapped, but advancing) | `Paris.\nTheTheTheThe...` (still degenerates) |
+| `0` | 32 | `[0..31]` (frozen) | Long but eventually repetitive |
+| `16` | 32 | `[..., 21, 23, 25, ..., 51]` (gapped) | `...the largest largest largest...` (different repetition, still broken) |
+| `32` | 128 | `[..., 110, 111, ..., 119]` (**contiguous** — enough headroom that eviction barely fired) | **Coherent, on-topic** photosynthesis explanation |
+
+The pattern: **give `h2o_budget` real headroom over `h2o_n_sink + h2o_grace`
+plus how much of the prompt/generation actually needs to be live at once.**
+When there's enough room that eviction rarely or never fires (the
+`grace=32, budget=128` row), output is coherent. When budget is so tight
+that eviction must skip every other position just to keep the grace window
+open, local coherence breaks down regardless of whether the freeze mechanism
+itself is fixed — a token's neighbors matter for coherent local generation,
+not just "is it in the cache at all."
+
+**Practical guidance:** `h2o_grace` (default `16`) fixes the specific,
+provable bug (permanent freeze on the first `budget` tokens). It does not
+turn H2O into a cache that works well at very tight budgets — that was
+never really about the freeze alone. Size `h2o_budget` generously if you
+want coherent long-form generation; treat H2O at very tight budgets as still
+experimental.
 
 ### Long-context testing: the freeze holds at scale, plus a scalability bug (now fixed)
+
+*(Historical: results below predate the `h2o_grace` fix and use `h2o_grace=0`
+implicitly, since the field didn't exist yet when this section was written.
+Kept for the scalability-bug findings, which are independent of grace.)*
 
 The same methodology was repeated on a genuinely long prompt (~3,238 tokens)
 to check whether the early-token freeze above behaves differently at scale,
@@ -280,23 +344,25 @@ large enough to avoid heavy early eviction.
 
 ## When to use it
 
-**Today: nowhere in production.** The [confirmed eviction-corruption finding
-above](#real-end-to-end-generation-eviction-breaks-coherence) means this cache
-should not be pointed at real generation until position remapping is
-implemented — treat it as a reference implementation of the paper's scoring
-mechanism, validated at the unit/synthetic level only.
+**With `h2o_grace` at its default (`16`) and `h2o_budget` sized with real
+headroom** (see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom) —
+budget comfortably above `h2o_n_sink + h2o_grace` plus expected live context),
+H2O-adapted is a **budget-bounded cache that improves over recency-only
+eviction** (StreamingLLM) by using attention signal rather than position —
+heavy-hitter tokens (those consistently attended to) survive; recency is not
+the only criterion for retention.
 
-Once that's fixed, the intended niche is a **budget-bounded cache that
-improves over recency-only eviction** (StreamingLLM) by using attention
-signal rather than position — heavy-hitter tokens (those consistently
-attended to) survive; recency is not the only criterion for retention.
+**At very tight budgets**, treat it as still experimental: the permanent
+freeze is fixed, but coherent output at aggressive compression ratios is not
+guaranteed — see the gapped-window failure mode above.
 
 | Scenario | Recommended method |
 |----------|-------------------|
 | Compress all tokens uniformly | KIVI-2bit |
 | Hard cap on tokens, evict at prefill only | SnapKV-adapted |
 | Constant-memory, position-based eviction | StreamingLLM-adapted |
-| Constant-memory, importance-based eviction (continuous) | H2O-adapted — **not yet safe for real generation, see above** |
+| Constant-memory, importance-based eviction (continuous), budget has headroom | H2O-adapted |
+| Constant-memory, importance-based eviction at very tight budgets | Still experimental — see grace-period findings above |
 | Recover quality from aggressive quantization | GEAR |
 
 **See also:** [CaM-adapted](./cam) makes the same eviction choice as H2O but

--- a/docs-site/docs/algorithms/h2o.md
+++ b/docs-site/docs/algorithms/h2o.md
@@ -4,34 +4,49 @@
 (Zhang et al., ICLR 2024) — **H2O-adapted (VeloxQuant-MLX implementation)**,
 not a faithful port.
 
-:::warning[Freeze mechanism fixed via `h2o_grace` — but tight budgets still degrade output]
+:::warning[Two real bugs fixed (`h2o_grace`, `h2o_decay`) — tight budgets and a separate eviction-quality issue remain]
 Real-model testing (below) originally found that eviction corrupted output —
 as few as one or two evictions could send generation into repetition loops,
-and heavier eviction caused total collapse. Root cause: the scoring formula
-gives every newly-arrived token a starting score of exactly `0`, and the
-eviction rule removes the *global minimum* score — so the brand-new token
-was (almost always) its own eviction target the instant the cache filled,
-before it ever accumulated attention mass. The kept set froze on whichever
-tokens filled the budget first (typically the prompt) and never admitted
-anything generated afterward.
+and heavier eviction caused total collapse. Root cause #1: the scoring
+formula gives every newly-arrived token a starting score of exactly `0`, and
+the eviction rule removes the *global minimum* score — so the brand-new
+token was (almost always) its own eviction target the instant the cache
+filled, before it ever accumulated attention mass. The kept set froze on
+whichever tokens filled the budget first (typically the prompt) and never
+admitted anything generated afterward.
 
 **Fixed** via `h2o_grace` (default `16`): the most-recently-arrived `grace`
 tokens are protected from eviction the same way sink tokens are, giving
 every new token `grace` update steps to actually compete before it can be
-evicted. Verified structurally on real models: the kept-position window now
-genuinely advances with generation instead of freezing at `[0, budget-1]`
-forever — see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom).
+evicted.
 
-**Not fully solved:** fixing the freeze mechanism is necessary but not
-sufficient for *coherent* output. When `h2o_budget` is tight relative to
-`h2o_n_sink + h2o_grace` plus how much of the prompt needs to survive,
-eviction is forced to thin out old tokens into a sparse, gapped window
-(e.g. keeping positions `..., 37, 39, 41, 43, ...` instead of a contiguous
-range) to make room — and generation still degrades under that regime, just
-via a different mechanism (broken local coherence from the gaps) rather than
-the original freeze. Give `h2o_budget` real headroom over `h2o_n_sink +
-h2o_grace` for coherent output; see the table below for what "enough" looks
-like in practice.
+Fixing the freeze exposed root cause #2: scores are a running sum that never
+shrinks, so a token's total lifetime attention mass grows with its age
+regardless of current relevance. An old survivor can outscore every
+recently-graduated token forever, so — even with the freeze fixed — the kept
+window stayed pinned near the *start* of generation for hundreds of decode
+steps instead of tracking the current position (verified: after 400 decode
+steps at `h2o_budget=64, h2o_grace=16`, the kept window without decay was
+still `[4..74]`, essentially the prompt, while the model had moved on to
+position 415).
+
+**Fixed** via `h2o_decay` (default `0.98`): existing scores are
+multiplicatively decayed each update step before new mass is added, so old
+tokens' scores fade instead of accumulating forever. Verified: the same
+400-step run with decay advances the kept window to `[297..415]` — tracking
+current generation instead of being stuck near the prompt.
+
+**Not fully solved:** with both fixes, the kept window is a genuinely
+*recent*, mostly-contiguous set — but a separate, deeper issue remains at
+very tight budgets: eviction can still remove a token whose local context
+the model needs mid-generation (confirmed: identical output with
+`h2o_decay=1.0` and `h2o_decay=0.98` at `budget=128, grace=32` diverges from
+the no-eviction baseline at the exact point eviction starts, breaking
+`"thylakoid"` into `"th th th th..."`). This is **not** a grace or decay
+problem — a no-eviction control run on the same prompt stays coherent for
+the full 300 tokens — it's a remaining gap in the eviction *quality* itself.
+See [grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open)
+for the full data.
 :::
 
 H2O-adapted is the library's **third eviction axis** and the first based on
@@ -60,6 +75,7 @@ config = KVCacheConfig(
     h2o_budget=512,  # max tokens retained at any time (sinks + grace + non-sinks)
     h2o_n_sink=4,  # initial positions never evicted (attention sinks)
     h2o_grace=16,  # most-recent tokens never evicted (fixes the early-token freeze)
+    h2o_decay=0.98,  # per-step score decay (fixes old tokens permanently outranking new ones)
 )
 caches = KVCacheBuilder.for_model(model, config)
 model.make_cache = lambda *_a, **_k: caches
@@ -72,6 +88,7 @@ model.make_cache = lambda *_a, **_k: caches
 | `h2o_budget` | `512` | Maximum token positions retained at any time. When the cache exceeds this count, the lowest-score non-sink, non-grace token is permanently evicted. |
 | `h2o_n_sink` | `4` | Number of initial token positions always retained (attention-sink tokens never eligible for eviction). |
 | `h2o_grace` | `16` | Number of most-recently-arrived tokens always retained, giving each new token this many update steps to accumulate real attention mass before it becomes eviction-eligible. `0` reproduces the original paper-faithful (but freeze-prone) behavior. `h2o_n_sink + h2o_grace` must be `< h2o_budget`. |
+| `h2o_decay` | `0.98` | Multiplicative decay applied to every existing score each update step, before new attention mass is added. Fixes old tokens permanently outranking newer ones (scores otherwise only ever grow). Must be in `(0, 1]`; `1.0` disables decay and reproduces the original paper-faithful (but staleness-prone) behavior. |
 
 ## How it works
 
@@ -81,9 +98,12 @@ For every incoming token (both prefill and decode), per head:
    proxy query and attends to all currently stored key rows via scaled dot-product
    softmax: `attn = softmax(K_stored @ k_i / sqrt(D))`. This gives `[n_kept]`
    softmax weights for the existing cache entries.
-2. **Score accumulation.** The weights are added to the existing per-token cumulative
-   score vector: `scores += attn`. New tokens start with score 0 and begin
-   accumulating on subsequent steps.
+2. **Score accumulation, with decay.** Existing scores are first multiplied by
+   `h2o_decay` (default `0.98`), then the new weights are added:
+   `scores = scores * h2o_decay + attn`. New tokens start with score 0 and
+   begin accumulating on subsequent steps. Without decay (`h2o_decay=1.0`),
+   scores are a pure running sum that never shrinks — see the warning above
+   for why that lets old tokens permanently outrank newer ones.
 3. **Eviction (if over budget).** If the total token count exceeds `h2o_budget`, a
    protected score view is constructed: the first `h2o_n_sink` positions
    receive `+inf` (attention sinks), and the last `h2o_grace` positions — the
@@ -125,14 +145,16 @@ Documented as "H2O-adapted (key-as-query proxy)" throughout — never claimed as
 faithful port.
 
 **Not a fidelity gap, but a consequence of the formula itself:** the paper's
-own scoring rule (new tokens start at score 0, minimum gets evicted) is what
-produces the early-token freeze described below — implementing it exactly as
-specified is what causes the practical problem, not a deviation from it.
-`h2o_grace` (default `16`, see [How it works](#how-it-works)) is this
-library's own addition on top of Algorithm 1 to make the method usable in
-practice; the paper itself does not specify a grace period, so `h2o_grace=0`
-is the fidelity-preserving setting if you want to study the paper's
-mechanism exactly as published.
+own scoring rule (new tokens start at score 0, minimum gets evicted, scores
+accumulate as an unbounded running sum) is what produces both the
+early-token freeze and the score-staleness problem described below —
+implementing it exactly as specified is what causes the practical problems,
+not a deviation from it. `h2o_grace` (default `16`) and `h2o_decay` (default
+`0.98`, see [How it works](#how-it-works)) are this library's own additions
+on top of Algorithm 1 to make the method usable in practice; the paper
+itself specifies neither a grace period nor score decay, so `h2o_grace=0,
+h2o_decay=1.0` is the fidelity-preserving setting if you want to study the
+paper's mechanism exactly as published.
 
 ## Evidence
 
@@ -161,7 +183,9 @@ All claims trace to passing tests in
 - The vectorized below-budget batch path matches the sequential per-token loop it replaces bit-for-bit within fp16 rounding, including for a single call whose batch straddles the below-budget/over-budget boundary
 - A 4,000-token single-call absorption (no eviction) completes without error — the regression test for the prefill scalability crash
 - `h2o_grace` defaults to a nonzero value in `KVCacheConfig`; grace-protected tokens survive even when they hold the lowest score, verified against a synthetic case where `h2o_grace=0` would evict the newest tokens
-- The fused Metal eviction kernel (`veloxquant_mlx/tests/metal/test_h2o_evict.py`, 18 tests) matches the pure-MLX eviction path bit-for-bit, including sink+grace protection, interior eviction, tie-break-matches-`mx.argmin`, and bit-identical untouched rows
+- `h2o_decay` defaults to `< 1.0` in `KVCacheConfig`; `decay=1.0` is bit-for-bit identical to omitting decay; with decay, an old token's score after many later updates is strictly lower than without it, and a later token can out-score an earlier one (impossible under pure accumulation, where a 60-step synthetic run shows a -0.97 correlation between token age and score)
+- The vectorized batch-absorb path applies decay identically to the sequential per-token loop it replaces, verified to fp32-rounding precision in both the from-empty and nonempty-prior-state branches (the exponentiated per-row decay power is the highest-risk part of the decay implementation)
+- The fused Metal eviction kernel (`veloxquant_mlx/tests/metal/test_h2o_evict.py`, 18 tests) matches the pure-MLX eviction path bit-for-bit, including sink+grace protection, interior eviction, tie-break-matches-`mx.argmin`, and bit-identical untouched rows — decay is applied entirely in the score-accumulation step before either eviction path runs, so no kernel changes were needed for it
 
 The offline harness in `benchmark_scripts/benchmark_h2o.py` sweeps
 `(seq_len, budget, n_sink)` and reports latency and compression ratio —
@@ -176,8 +200,8 @@ and `mlx-community/Mistral-7B-Instruct-v0.3-4bit` (`head_dim=128`,
 theoretical caveat. This section documents the **`h2o_grace=0` behavior**
 (the library's default before the grace-period fix, and still what you get
 if you explicitly set `h2o_grace=0` to study the paper's mechanism exactly
-as published). See [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom)
-below for the current default (`h2o_grace=16`) behavior.
+as published). See [grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open)
+below for the current default (`h2o_grace=16, h2o_decay=0.98`) behavior.
 
 :::danger[grace=0: eviction corrupts generation quality — this is not tuning, it collapses almost immediately]
 The moment eviction actually fires (as little as **one or two evictions**,
@@ -239,48 +263,73 @@ here as a historical record and as an explicit opt-in
 published, including its practical failure mode at tight budgets. For real
 usage, see the grace-period results next.
 
-### Grace-period testing: fixes the freeze mechanism, coherence still needs budget headroom
+### Grace-and-decay testing: fixes window advancement, eviction quality at tight budgets remains open
 
-Re-ran the same real-model methodology with `h2o_grace > 0` to check whether
-protecting recently-arrived tokens actually fixes the freeze — and to be
-honest about what it does and doesn't fix.
+Re-ran the same real-model methodology with `h2o_grace > 0` and, once that
+exposed a second problem, with `h2o_decay < 1.0` on top of it — to check
+whether each fix does what it claims, and to be honest about what's still
+unsolved.
 
-**The freeze mechanism itself is fixed, structurally verified.** With
+**The freeze mechanism is fixed, structurally verified.** With
 `h2o_grace=8` and a short prompt (13 tokens, `h2o_budget=14`), the kept
 position set — which with `h2o_grace=0` stayed frozen at `[0..13]` forever —
 now genuinely advances: `[0, 1, 2, 3, 4, 5, 27, 29, 31, 33, 35, 37, 39, 41]`.
 Generated tokens are finally entering and surviving in the cache, which
 never happened at `h2o_grace=0`.
 
-**But structural advancement alone doesn't guarantee coherent output.** At
-that same tight budget, the kept window has gaps every other position
-(`27, 29, 31, ...`) to make room for both `h2o_grace` and ongoing eviction —
-and generation degrades anyway, just via a different mechanism (broken local
-context from the gaps) rather than the original freeze:
+**But grace alone doesn't mean the window tracks the *current* position.**
+Scores are a running sum that never shrinks, so a token that survived its
+grace window early in generation can keep outscoring every token that
+graduates afterward, indefinitely. Direct measurement at `h2o_budget=64,
+h2o_n_sink=4, h2o_grace=16`, generating 400 tokens: with `h2o_decay=1.0`
+(no decay), the kept window after 400 decode steps was
+`[4, 5, ..., 21, 24, 26, ..., 74]` plus a handful of the very latest
+tokens — essentially still the prompt, 300+ positions behind where
+generation actually was. With `h2o_decay=0.98`, the same run's kept window
+was `[297, 299, ..., 415]` — genuinely tracking the current position instead
+of clinging to the prompt.
 
-| `h2o_grace` | `h2o_budget` | Kept positions (tail) | Output |
+**Decay fixes window *advancement*, not the earlier gapped-window
+degradation by itself.** At the original tight-budget case from the freeze
+investigation (`h2o_budget=14, h2o_n_sink=2, h2o_grace=8`), the non-sink
+kept window has a steady gap-of-2 pattern (`..., 47, 49, 51, 53`) **with or
+without decay** — this specific pattern turned out to be a structural
+consequence of `h2o_budget - h2o_n_sink - h2o_grace` being very small (only
+4 "competable" slots), not a staleness artifact: the token that has *just*
+graduated out of the grace window is always the newest possible competable
+token, so it is close to sole minimum by construction regardless of decay
+strength. Confirmed with a controlled A/B (`h2o_budget=128, h2o_n_sink=2,
+h2o_grace=32` — enough headroom that this effect is negligible): the *kept
+positions and final generated text were byte-for-byte identical* between
+`h2o_decay=1.0` and `h2o_decay=0.98`, even though the underlying score
+magnitudes differed by ~8x (max score `24.16` vs `2.97`) — decay changed
+score *scale*, not eviction *order*, at this budget.
+
+**A separate, deeper issue remains, independent of grace and decay.** At
+`h2o_budget=128, h2o_n_sink=2, h2o_grace=32`, generation is coherent for a
+while and then breaks mid-word: `"...occurs in the th th th th..."` instead
+of `"...occurs in the thylakoid membranes..."`. This is identical between
+`h2o_decay=1.0` and `h2o_decay=0.98` (ruling out decay as cause or fix), and
+a **no-eviction control run** (`h2o_budget=10000`, same prompt, same seed)
+stays fully coherent for the entire 300-token generation — proving this
+specific break is caused by *an* eviction decision (some token whose local
+context the model needed was dropped at exactly the wrong moment), not by
+the freeze or staleness mechanisms already fixed, and not a general property
+of long generation on this model.
+
+| Fix | What it corrects | Verified how | Still not covered |
 |---|---|---|---|
-| `0` | 14 | `[0..13]` (frozen) | `Paris.\nThe\nThe answer in French...` |
-| `8` | 14 | `[..., 27, 29, 31, 33, 35, 37, 39, 41]` (gapped, but advancing) | `Paris.\nTheTheTheThe...` (still degenerates) |
-| `0` | 32 | `[0..31]` (frozen) | Long but eventually repetitive |
-| `16` | 32 | `[..., 21, 23, 25, ..., 51]` (gapped) | `...the largest largest largest...` (different repetition, still broken) |
-| `32` | 128 | `[..., 110, 111, ..., 119]` (**contiguous** — enough headroom that eviction barely fired) | **Coherent, on-topic** photosynthesis explanation |
+| `h2o_grace` | New tokens evicted before they can compete (starting score `0.0` is the global min) | Kept window structurally advances past `[0, budget-1]` | Doesn't stop *old* tokens from permanently dominating *newer* ones |
+| `h2o_decay` | Old tokens permanently outrank newer ones (scores never shrink) | Kept window tracks current position (`[297..415]` vs `[4..74]` at 400 steps) | Doesn't change eviction order once headroom is generous, and doesn't touch the gap-of-2 conveyor effect at very tight `budget - n_sink - grace` |
+| *(neither)* | A single eviction dropping context the model needed mid-generation | Ruled OUT grace/decay as cause via A/B + no-eviction control | **Open** — see [When to use it](#when-to-use-it) |
 
-The pattern: **give `h2o_budget` real headroom over `h2o_n_sink + h2o_grace`
-plus how much of the prompt/generation actually needs to be live at once.**
-When there's enough room that eviction rarely or never fires (the
-`grace=32, budget=128` row), output is coherent. When budget is so tight
-that eviction must skip every other position just to keep the grace window
-open, local coherence breaks down regardless of whether the freeze mechanism
-itself is fixed — a token's neighbors matter for coherent local generation,
-not just "is it in the cache at all."
-
-**Practical guidance:** `h2o_grace` (default `16`) fixes the specific,
-provable bug (permanent freeze on the first `budget` tokens). It does not
-turn H2O into a cache that works well at very tight budgets — that was
-never really about the freeze alone. Size `h2o_budget` generously if you
-want coherent long-form generation; treat H2O at very tight budgets as still
-experimental.
+**Practical guidance:** `h2o_grace` (default `16`) and `h2o_decay` (default
+`0.98`) fix two specific, provable bugs — permanent freeze and score
+staleness — and both are on by default. They do not turn H2O into a cache
+that is safe at very tight budgets: give `h2o_budget` real headroom over
+`h2o_n_sink + h2o_grace` (so the gap-of-2 conveyor effect stays negligible),
+and treat occasional mid-generation quality loss from a single bad eviction
+as a known, open limitation rather than a solved problem.
 
 ### Long-context testing: the freeze holds at scale, plus a scalability bug (now fixed)
 
@@ -344,17 +393,24 @@ large enough to avoid heavy early eviction.
 
 ## When to use it
 
-**With `h2o_grace` at its default (`16`) and `h2o_budget` sized with real
-headroom** (see [grace-period testing](#grace-period-testing-fixes-the-freeze-mechanism-coherence-still-needs-budget-headroom) —
+**With `h2o_grace` and `h2o_decay` at their defaults (`16`, `0.98`) and
+`h2o_budget` sized with real headroom** (see
+[grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open) —
 budget comfortably above `h2o_n_sink + h2o_grace` plus expected live context),
 H2O-adapted is a **budget-bounded cache that improves over recency-only
 eviction** (StreamingLLM) by using attention signal rather than position —
-heavy-hitter tokens (those consistently attended to) survive; recency is not
-the only criterion for retention.
+heavy-hitter tokens (those consistently attended to) survive, the kept
+window tracks the current generation position rather than freezing near the
+prompt, and recency is not the only criterion for retention.
 
-**At very tight budgets**, treat it as still experimental: the permanent
-freeze is fixed, but coherent output at aggressive compression ratios is not
-guaranteed — see the gapped-window failure mode above.
+**At very tight budgets, or for long generations where any single eviction
+mattering is a real risk**, treat it as still experimental: the permanent
+freeze and score-staleness bugs are fixed, but a single eviction can still
+remove context the model needed mid-generation, and very tight
+`h2o_budget - h2o_n_sink - h2o_grace` headroom reintroduces a structural
+gapped-window pattern independent of decay — see
+[grace-and-decay testing](#grace-and-decay-testing-fixes-window-advancement-eviction-quality-at-tight-budgets-remains-open)
+above.
 
 | Scenario | Recommended method |
 |----------|-------------------|
@@ -362,7 +418,7 @@ guaranteed — see the gapped-window failure mode above.
 | Hard cap on tokens, evict at prefill only | SnapKV-adapted |
 | Constant-memory, position-based eviction | StreamingLLM-adapted |
 | Constant-memory, importance-based eviction (continuous), budget has headroom | H2O-adapted |
-| Constant-memory, importance-based eviction at very tight budgets | Still experimental — see grace-period findings above |
+| Constant-memory, importance-based eviction at very tight budgets | Still experimental — see grace-and-decay findings above |
 | Recover quality from aggressive quantization | GEAR |
 
 **See also:** [CaM-adapted](./cam) makes the same eviction choice as H2O but

--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -193,6 +193,7 @@ class KVCacheConfig:
     h2o_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     h2o_n_sink: int = 4  # initial positions protected from eviction (attention sinks)
     h2o_rope_base: float = 10000.0  # RoPE base for post-eviction position remap; match the model
+    h2o_grace: int = 16  # most-recent tokens protected from eviction; fixes the early-token freeze
     # --- TOVA-adapted configuration (current-step attention-weight eviction, memoryless) ---
     tova_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     tova_n_sink: int = 4  # initial positions protected from eviction (attention sinks)

--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -194,6 +194,9 @@ class KVCacheConfig:
     h2o_n_sink: int = 4  # initial positions protected from eviction (attention sinks)
     h2o_rope_base: float = 10000.0  # RoPE base for post-eviction position remap; match the model
     h2o_grace: int = 16  # most-recent tokens protected from eviction; fixes the early-token freeze
+    h2o_decay: float = (
+        0.98  # per-step multiplicative decay on existing scores; fixes score staleness
+    )
     # --- TOVA-adapted configuration (current-step attention-weight eviction, memoryless) ---
     tova_budget: int = 512  # max tokens kept at any time (sinks + non-sinks)
     tova_n_sink: int = 4  # initial positions protected from eviction (attention sinks)

--- a/veloxquant_mlx/cache/h2o_cache.py
+++ b/veloxquant_mlx/cache/h2o_cache.py
@@ -53,6 +53,27 @@ equivalent between the two. ``h2o_grace=0`` reproduces the original
 (paper-faithful, freeze-prone) behavior exactly, for anyone who wants to
 study or reproduce that failure mode.
 
+SECOND FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM (found while verifying the
+fix above): fixing the freeze is necessary but not sufficient for coherent
+output at tight budgets. Scores are a running sum that never shrinks, so an
+old token's total lifetime attention mass grows with its age regardless of
+current relevance — confirmed empirically (correlation of -0.97 between
+token age and score in a synthetic run). An old survivor could therefore
+outscore every recently-graduated (post-grace) token forever, so the
+eviction argmin thinned the *rest* of the budget into a sparse, gapped kept
+window instead of a contiguous recent block — generation still degraded,
+just via broken local coherence from the gaps rather than the original
+permanent freeze.
+
+Fixed via ``h2o_decay`` (default 0.98): every existing score is
+multiplicatively decayed each update step, before new attention mass is
+added, so old tokens' scores fade instead of accumulating forever. Applied
+identically in both the per-token loop and the vectorized batch-absorb path
+(:func:`veloxquant_mlx.quantizers.h2o._batch_absorb_no_eviction`) — verified
+numerically equivalent between the two (fp32-rounding-only difference).
+``h2o_decay=1.0`` reproduces the original (paper-faithful, staleness-prone)
+behavior exactly.
+
 RoPE position remapping (a separate, narrower, and now-fixed correctness
 issue found during the same investigation — real, but NOT the cause of the
 freeze above, since interior eviction rarely happens once the freeze sets
@@ -138,6 +159,14 @@ class H2OKVCache(_MLXKVCache):
             starting score of 0.0 makes it almost always the eviction target
             the instant the cache is full, freezing the kept set on whichever
             tokens filled the budget first.
+            ``h2o_decay`` (float, default 0.98) — multiplicative per-step
+            decay on existing scores, applied before new attention mass is
+            added. Fixes a second real, confirmed-on-real-models problem
+            (see module docstring): without this, scores only ever grow, so
+            old tokens permanently outrank newer ones regardless of current
+            relevance, thinning the kept window into a sparse, gapped
+            trickle instead of a contiguous local context even with grace
+            fixing the freeze. Must be in ``(0, 1]``; ``1.0`` disables decay.
 
     Notes:
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
@@ -168,6 +197,7 @@ class H2OKVCache(_MLXKVCache):
         self._n_sink = int(getattr(config, "h2o_n_sink", 4))
         self._rope_base = float(getattr(config, "h2o_rope_base", 10000.0))
         self._grace = int(getattr(config, "h2o_grace", 16))
+        self._decay = float(getattr(config, "h2o_decay", 0.98))
 
         self._head_dim: int = 0
         self._states: list[H2OState] = []
@@ -187,7 +217,12 @@ class H2OKVCache(_MLXKVCache):
             self._head_dim = D
             self._states = [
                 init_h2o_state(
-                    self._n_sink, self._budget, D, rope_base=self._rope_base, grace=self._grace
+                    self._n_sink,
+                    self._budget,
+                    D,
+                    rope_base=self._rope_base,
+                    grace=self._grace,
+                    decay=self._decay,
                 )
                 for _ in range(B * H)
             ]

--- a/veloxquant_mlx/cache/h2o_cache.py
+++ b/veloxquant_mlx/cache/h2o_cache.py
@@ -28,21 +28,30 @@ Adaptation limitations (stated plainly):
     default and what Llama/Mistral/Qwen use — see
     :func:`veloxquant_mlx.quantizers.a2ats_rope.rope_remap_positions`.
 
-KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM (not fixed here — needs a different
-eviction/scoring policy, see docs-site/docs/algorithms/h2o.md for the full
-writeup): real end-to-end generation testing on Llama-3.2-1B and Mistral-7B
-showed generation degrading into repetition loops (mild) or total collapse
-(severe) once the cache fills. Root cause, verified precisely: every
-newly-arrived token starts at score 0.0, and eviction removes the
-global-minimum-score token, so the brand-new token is (almost always) its own
-eviction target the moment the budget is full — before it ever accumulates
-attention mass. Traced directly: after 43 true decode steps on Llama-3.2-1B,
-the kept set was still exactly the original prompt's positions; the model
-generated the entire time with zero visibility into its own output. This is
-what implementing the paper's own scoring formula correctly produces at tight
-budgets — not a deviation from the paper, and not fixed by anything in this
-module. A real fix needs a different eviction/scoring rule (e.g. a grace
-period before a token becomes eviction-eligible).
+FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM (see docs-site/docs/algorithms/h2o.md
+for the full writeup): real end-to-end generation testing on Llama-3.2-1B
+and Mistral-7B showed generation degrading into repetition loops (mild) or
+total collapse (severe) once the cache filled. Root cause, verified
+precisely: every newly-arrived token started at score 0.0, and eviction
+removes the global-minimum-score token, so the brand-new token was (almost
+always) its own eviction target the moment the budget was full — before it
+ever accumulated attention mass. Traced directly: after 43 true decode steps
+on Llama-3.2-1B, the kept set was still exactly the original prompt's
+positions; the model generated the entire time with zero visibility into its
+own output. This was what implementing the paper's own scoring formula
+without any grace period produces at tight budgets — not a deviation from
+the paper (the paper doesn't specify one either), but a real practical gap.
+
+Fixed via ``h2o_grace`` (default 16): the most-recently-arrived ``grace``
+tokens are protected from eviction the same way sink tokens are (treated as
++inf in the eviction argmin), giving every new token ``grace`` update steps
+to accumulate real attention mass before it becomes eviction-eligible at
+all. Implemented identically in both the pure-MLX eviction path
+(:func:`veloxquant_mlx.quantizers.h2o._evict_via_mlx`) and the fused Metal
+kernel (:func:`veloxquant_mlx.metal.h2o_fused_evict`) — verified bit-for-bit
+equivalent between the two. ``h2o_grace=0`` reproduces the original
+(paper-faithful, freeze-prone) behavior exactly, for anyone who wants to
+study or reproduce that failure mode.
 
 RoPE position remapping (a separate, narrower, and now-fixed correctness
 issue found during the same investigation — real, but NOT the cause of the
@@ -120,7 +129,15 @@ class H2OKVCache(_MLXKVCache):
             ``h2o_n_sink`` (int, default 4)   — leading positions never evicted,
             ``h2o_rope_base`` (float, default 10000.0) — RoPE frequency base,
             must match the model's own attention RoPE base for post-eviction
-            position remapping to cancel out the original rotation correctly.
+            position remapping to cancel out the original rotation correctly,
+            ``h2o_grace`` (int, default 16) — most-recently-arrived tokens
+            protected from eviction, giving each new token this many update
+            steps to accumulate real attention mass before it becomes
+            eviction-eligible. Fixes a real, confirmed-on-real-models problem
+            (see module docstring): without this, a brand-new token's
+            starting score of 0.0 makes it almost always the eviction target
+            the instant the cache is full, freezing the kept set on whichever
+            tokens filled the budget first.
 
     Notes:
         No ``.bits`` attribute — stores and returns fp16 K/V directly.
@@ -150,6 +167,7 @@ class H2OKVCache(_MLXKVCache):
         self._budget = int(getattr(config, "h2o_budget", 512))
         self._n_sink = int(getattr(config, "h2o_n_sink", 4))
         self._rope_base = float(getattr(config, "h2o_rope_base", 10000.0))
+        self._grace = int(getattr(config, "h2o_grace", 16))
 
         self._head_dim: int = 0
         self._states: list[H2OState] = []
@@ -168,7 +186,9 @@ class H2OKVCache(_MLXKVCache):
             self._H = H
             self._head_dim = D
             self._states = [
-                init_h2o_state(self._n_sink, self._budget, D, rope_base=self._rope_base)
+                init_h2o_state(
+                    self._n_sink, self._budget, D, rope_base=self._rope_base, grace=self._grace
+                )
                 for _ in range(B * H)
             ]
 

--- a/veloxquant_mlx/metal/_h2o_evict.py
+++ b/veloxquant_mlx/metal/_h2o_evict.py
@@ -88,7 +88,7 @@ def _evict_reduce_kernel(nsg: int):
     if key not in _cache:
         _cache[key] = mx.fast.metal_kernel(
             name=f"h2o_evict_reduce_nsg{nsg}",
-            input_names=["scores_mid", "n_sink_arr"],
+            input_names=["scores_mid", "n_sink_arr", "n_grace_arr"],
             output_names=["evict_idx"],
             header=f"#define NSG_C {nsg}\n",
             source=_H2O_EVICT_REDUCE_SRC,
@@ -129,9 +129,10 @@ def h2o_fused_evict(
     positions_mid: mx.array,
     n_sink: int,
     rope_base: float,
+    grace: int = 0,
     nsg: int = 4,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
-    """Fused sink-protected argmin + evict + RoPE-remap, batched over (batch*head).
+    """Fused sink+grace-protected argmin + evict + RoPE-remap, batched over (batch*head).
 
     Matches ``h2o_update``'s per-token eviction branch bit-for-bit (see
     ``H2O_METAL_KERNEL_TECH_SPEC.md`` section 3). Caller must have already
@@ -155,6 +156,10 @@ def h2o_fused_evict(
                        the re-rotation of shifted rows will not cancel out
                        the original rotation correctly (same requirement as
                        ``rope_remap_positions``).
+        grace:         Number of most-recently-arrived rows (trailing array
+                       index — positions are always sorted ascending, see
+                       ``H2OState.grace``) protected from eviction, uniform
+                       across all BH groups.
         nsg:           SIMD-groups per threadgroup for the reduction kernel.
 
     Returns:
@@ -178,9 +183,10 @@ def h2o_fused_evict(
         raise ValueError(f"h2o_fused_evict: nsg={nsg} must be in 1..32")
 
     n_sink_arr = mx.array([n_sink], dtype=mx.uint32)
+    n_grace_arr = mx.array([grace], dtype=mx.uint32)
 
     (evict_idx,) = _evict_reduce_kernel(nsg)(
-        inputs=[scores_mid.astype(mx.float32), n_sink_arr],
+        inputs=[scores_mid.astype(mx.float32), n_sink_arr, n_grace_arr],
         grid=(BH * 32, nsg, 1),
         threadgroup=(32, nsg, 1),
         output_shapes=[(BH,)],

--- a/veloxquant_mlx/metal/src/h2o_evict_reduce.metal
+++ b/veloxquant_mlx/metal/src/h2o_evict_reduce.metal
@@ -10,9 +10,20 @@
 // must match bit-for-bit). Finds, for each (batch*head) row group, the
 // index of the minimum "protected" score among the n_total = n_kept + 1
 // candidate rows (n_kept currently-stored rows plus the one new row that
-// h2o_update conceptually appends before evicting). The first n_sink rows
-// are protected (treated as +inf) and can never win the argmin, matching
-// h2o_update's sink-protection logic exactly.
+// h2o_update conceptually appends before evicting). Two independent
+// protections, each treated as +inf and unable to win the argmin, matching
+// h2o_update's protection logic exactly:
+//   - the first n_sink rows (sink tokens, protected by leading array index)
+//   - the last n_grace rows (most-recently-arrived tokens, protected by
+//     trailing array index -- positions are always kept sorted ascending
+//     after eviction, so "most recent" == "highest array index"). This
+//     gives every new token n_grace update steps to accumulate real
+//     attention mass before it becomes eviction-eligible, fixing a real,
+//     confirmed-on-real-models problem: without it, a brand-new token's
+//     starting score of 0.0 makes it (almost always) the argmin target the
+//     instant the cache is full, freezing the kept set on whichever tokens
+//     filled the budget first and never admitting anything generated
+//     afterward. See h2o.py's module docstring.
 //
 // One threadgroup handles one (batch*head) group. TG_SIZE threads grid-stride
 // over the n_total candidate rows, each thread tracking its own local
@@ -37,6 +48,10 @@
     uint n_kept = uint(scores_mid_shape[1]);   // scores_mid: [BH, n_total]
     uint n_total = n_kept;                      // caller passes n_total in this axis
     uint n_sink  = uint(n_sink_arr[0]);
+    uint n_grace = uint(n_grace_arr[0]);
+    // Clamp so sink+grace protection can never exceed n_total, mirroring
+    // h2o.py's min(n_sink, n_total) / min(grace, n_total) clamps.
+    uint grace_start = (n_grace >= n_total) ? 0u : (n_total - n_grace);
 
     uint tid = sg * 32u + lane;
 
@@ -44,7 +59,8 @@
     uint  local_idx  = 0xFFFFFFFFu;
 
     for (uint i = tid; i < n_total; i += TG) {
-        float v = (i < n_sink) ? INFINITY : scores_mid[bh * n_total + i];
+        bool protected_row = (i < n_sink) || (i >= grace_start);
+        float v = protected_row ? INFINITY : scores_mid[bh * n_total + i];
         if (v < local_min) {
             local_min = v;
             local_idx = i;

--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -14,20 +14,39 @@ Adaptation limitations (stated plainly):
   - Scores are accumulated additively (sum of softmax weights) rather than
     the paper's exact formulation, which may differ in low-budget regimes.
 
-KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM (not fixed here, see
+FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM #1 — permanent freeze (see
 cache/h2o_cache.py and docs-site/docs/algorithms/h2o.md for the full
 writeup): every newly-arrived token starts at score 0.0, and eviction removes
 the global-minimum-score token — so on essentially any real score
 distribution, the brand-new token is its own eviction target almost every
-time the cache is full. In practice this freezes the kept set on whichever
-tokens filled the budget first (typically the prompt) and never admits
+time the cache is full. In practice this froze the kept set on whichever
+tokens filled the budget first (typically the prompt) and never admitted
 anything generated afterward. Confirmed via mlx_lm.generate on Llama-3.2-1B
 and Mistral-7B: after dozens of true decode steps, the kept set was still
 exactly the original prompt positions, and generation degenerated into
-repetition loops from having no visibility into its own recent output. This
-is a consequence of implementing the paper's own formula correctly, not a
-deviation from it — fixing it needs a different eviction/scoring policy
-(e.g. a grace period before eviction-eligibility), tracked as follow-up work.
+repetition loops from having no visibility into its own recent output. Fixed
+via ``grace`` (see :class:`H2OState`): the most-recently-arrived ``grace``
+tokens are protected from eviction the same way sinks are, giving each new
+token real update steps to accumulate attention mass before it becomes
+eviction-eligible at all.
+
+FIXED, CONFIRMED-ON-REAL-MODELS PROBLEM #2 — score staleness (found while
+verifying the fix for #1 above): fixing the freeze is necessary but not
+sufficient. Scores are a running sum that never shrinks, so a token's total
+lifetime attention mass grows monotonically with its age — confirmed
+empirically (correlation of -0.97 between token age/position and score in a
+60-step synthetic run). An old sink-adjacent survivor can outscore every
+recently-graduated (post-grace) token forever, so once grace fixed the
+freeze, the eviction argmin instead thinned the *rest* of the budget into a
+sparse, gapped kept window (e.g. positions ``0,1,2,3,4,5,44,46,48,...``
+instead of a contiguous recent block) rather than a genuinely local window —
+and generation still degraded, just via broken local coherence from the gaps
+instead of the original permanent freeze. Fixed via ``decay`` (see
+:class:`H2OState`): existing scores are multiplicatively decayed each update
+step before new attention mass is added, so old tokens' scores fade and
+stop permanently outranking newer ones. Verified in simulation: with decay,
+the non-sink kept window becomes contiguous (gaps of 1) instead of a uniform
+trickle (gaps of ~2 everywhere).
 
 RoPE position remapping (a separate, narrower, and now-fixed correctness
 issue — real, but NOT the cause of the freeze above):
@@ -136,6 +155,18 @@ class H2OState:
                    ``grace`` tokens" is equivalent to "the last ``grace``
                    array indices" — this is what the eviction protection
                    logic actually implements.
+        decay:     Multiplicative factor applied to every existing score
+                   before adding a new token's attention contribution, each
+                   update step. Fixes a second real, confirmed-on-real-models
+                   problem distinct from (and only exposed by fixing) the
+                   freeze above: scores are a running sum that never shrinks,
+                   so a token's total lifetime attention mass grows with its
+                   age regardless of current relevance — an old sink-adjacent
+                   survivor can outscore every recently-graduated token
+                   forever, so the eviction argmin keeps thinning the *rest*
+                   of the budget into a sparse, gapped trickle instead of a
+                   contiguous local window. ``decay=1.0`` reproduces the
+                   original (paper-faithful, no-decay) behavior exactly.
     """
 
     keys: mx.array | None
@@ -147,6 +178,7 @@ class H2OState:
     rope_base: float
     next_pos: int
     grace: int = 0
+    decay: float = 1.0
 
 
 def init_h2o_state(
@@ -155,6 +187,7 @@ def init_h2o_state(
     head_dim: int,  # noqa: ARG001
     rope_base: float = 10000.0,
     grace: int = 0,
+    decay: float = 1.0,
 ) -> H2OState:
     """Create an empty H2OState before any tokens arrive.
 
@@ -171,6 +204,10 @@ def init_h2o_state(
                    eviction (see :class:`H2OState`'s ``grace`` field). ``0``
                    reproduces the original (paper-faithful, but freeze-prone
                    at tight budgets) behavior.
+        decay:     Multiplicative per-step decay on existing scores (see
+                   :class:`H2OState`'s ``decay`` field). ``1.0`` reproduces
+                   the original (paper-faithful, but staleness-prone)
+                   behavior — must be in ``(0, 1]``.
 
     Raises:
         ValueError: if there are sink positions to protect but they leave no
@@ -181,6 +218,9 @@ def init_h2o_state(
             new token once the cache fills, silently growing past ``budget``
             in :func:`h2o_update`'s over-budget branch (which always assumes
             exactly one evictable row exists).
+        ValueError: if ``decay`` is not in ``(0, 1]`` — ``<= 0`` collapses
+            all history to nothing (or flips sign) every step, and ``> 1``
+            is growth, not decay, defeating the point of this field.
     """
     if n_sink > 0 and n_sink >= budget:
         raise ValueError(
@@ -194,6 +234,8 @@ def init_h2o_state(
             f"({budget}) — every row would be protected, leaving nothing "
             "evictable once the cache fills"
         )
+    if not (0.0 < decay <= 1.0):
+        raise ValueError(f"h2o: decay ({decay}) must be in (0, 1]")
     return H2OState(
         keys=None,
         values=None,
@@ -204,6 +246,7 @@ def init_h2o_state(
         rope_base=rope_base,
         next_pos=0,
         grace=grace,
+        decay=decay,
     )
 
 
@@ -226,6 +269,7 @@ def _batch_absorb_no_eviction(
     prior_keys: mx.array | None,
     prior_scores: mx.array | None,
     new_keys: mx.array,
+    decay: float = 1.0,
 ) -> mx.array:
     """Vectorized score accumulation for a batch of incoming tokens, valid
     ONLY while every one of them is guaranteed to survive (no eviction can
@@ -243,6 +287,12 @@ def _batch_absorb_no_eviction(
                       (``None`` if the cache was empty).
         new_keys:     ``[S, D]`` fp32 incoming keys, all of which the caller
                       has verified will fit within budget with no eviction.
+        decay:        Multiplicative per-step decay applied to ``prior_scores``
+                      before any new mass is added (see :class:`H2OState`'s
+                      ``decay`` field). Applied once per absorbed token, same
+                      as the per-token loop it replaces — token ``j``'s prior
+                      contribution is decayed ``j+1`` times by the time all
+                      ``S`` tokens have been absorbed. ``1.0`` is a no-op.
 
     Returns:
         ``[P + S]`` fp32 scores: ``prior_scores`` updated with every new
@@ -256,14 +306,26 @@ def _batch_absorb_no_eviction(
     if prior_keys is None:
         # First S tokens ever: token 0 bootstraps to 1.0 (matches
         # h2o_update's bootstrap branch); every later token j attends
-        # causally over tokens 0..j-1 only.
+        # causally over tokens 0..j-1 only. Within-batch decay of the
+        # bootstrap/earlier contributions is handled the same way as the
+        # prior-tokens branch below, via per-step decay powers.
         logits = (new_keys @ new_keys.T) * scale  # [S, S]
         causal = mx.arange(S)[:, None] > mx.arange(S)[None, :]
         masked = mx.where(causal, logits, -mx.inf)
         attn = mx.softmax(masked, axis=-1)
         attn = mx.where(mx.isnan(attn), 0.0, attn)  # row 0: all -inf -> nan -> 0
+        if decay != 1.0:
+            # Row j's (token j's) contribution to column i (token i, i<j) is
+            # applied at absorption step j, then decayed once per subsequent
+            # step up to S-1 -> (S-1-j) further decay applications.
+            steps_remaining = (S - 1) - mx.arange(S)  # [S], per-row (per-j) exponent
+            decay_pow = mx.array(decay, dtype=mx.float32) ** steps_remaining.astype(mx.float32)
+            attn = attn * decay_pow[:, None]
         col_sums = mx.sum(attn, axis=0)  # [S], token j's mass from tokens after it
-        bootstrap = mx.concatenate([mx.array([1.0], dtype=mx.float32), mx.zeros((S - 1,))])
+        bootstrap_decay = (
+            mx.array(decay, dtype=mx.float32) ** (S - 1) if decay != 1.0 else mx.array(1.0)
+        )
+        bootstrap = mx.concatenate([bootstrap_decay[None], mx.zeros((S - 1,), dtype=mx.float32)])
         return col_sums + bootstrap
 
     # Prior tokens already in the cache: each new token j attends over ALL
@@ -275,9 +337,20 @@ def _batch_absorb_no_eviction(
     new_logits = mx.where(causal, new_logits, -mx.inf)
     full_logits = mx.concatenate([prior_logits, new_logits], axis=-1)  # [S, P+S]
     attn = mx.softmax(full_logits, axis=-1)  # every row has >=1 real prior token -> no nan
+    if decay != 1.0:
+        # Row j's contribution (to prior tokens AND to earlier new tokens i<j)
+        # is applied at absorption step j, then decayed once per subsequent
+        # step up to S-1 -> (S-1-j) further decay applications, same scheme
+        # as the bootstrap branch above.
+        steps_remaining = (S - 1) - mx.arange(S)  # [S]
+        decay_pow = mx.array(decay, dtype=mx.float32) ** steps_remaining.astype(mx.float32)
+        attn = attn * decay_pow[:, None]
     prior_contrib = mx.sum(attn[:, :P], axis=0)  # [P] mass each prior token gains
     new_contrib = mx.sum(attn[:, P:], axis=0)  # [S] mass each new token gains from later new tokens
-    updated_prior_scores = prior_scores + prior_contrib
+    # prior_scores themselves need decaying S times (once per absorbed token)
+    # before adding the (already correctly-decayed) contributions above.
+    decayed_prior_scores = prior_scores * (decay**S) if decay != 1.0 else prior_scores
+    updated_prior_scores = decayed_prior_scores + prior_contrib
     return mx.concatenate([updated_prior_scores, new_contrib], axis=0)
 
 
@@ -302,7 +375,9 @@ def _batch_absorb_prefix(
     new_positions = mx.arange(state.next_pos, state.next_pos + B, dtype=mx.int32)
 
     prior_keys32 = None if state.keys is None else state.keys.astype(mx.float32)
-    scores = _batch_absorb_no_eviction(prior_keys32, state.scores, new_keys.astype(mx.float32))
+    scores = _batch_absorb_no_eviction(
+        prior_keys32, state.scores, new_keys.astype(mx.float32), decay=state.decay
+    )
 
     if state.keys is None:
         keys_cat = new_keys.astype(mx.float16)
@@ -323,6 +398,7 @@ def _batch_absorb_prefix(
         rope_base=state.rope_base,
         next_pos=state.next_pos + B,
         grace=state.grace,
+        decay=state.decay,
     )
 
 
@@ -508,12 +584,14 @@ def h2o_update(
                 rope_base=state.rope_base,
                 next_pos=cur_pos + 1,
                 grace=state.grace,
+                decay=state.decay,
             )
             continue
 
         # --- score update --------------------------------------------------
         attn = _attention_scores(k_i.astype(mx.float32), state.keys.astype(mx.float32))
-        updated_scores = state.scores + attn  # [n_kept]
+        decayed_scores = state.scores * state.decay if state.decay != 1.0 else state.scores
+        updated_scores = decayed_scores + attn  # [n_kept]
 
         # --- append new token (score = 0; begins accumulating next step) ---
         keys_cat = mx.concatenate([state.keys, k_i[None].astype(mx.float16)], axis=0)
@@ -557,6 +635,7 @@ def h2o_update(
             rope_base=state.rope_base,
             next_pos=cur_pos + 1,
             grace=state.grace,
+            decay=state.decay,
         )
 
         # Force materialization periodically. Without this, a long prefill

--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -123,6 +123,19 @@ class H2OState:
         next_pos:  Absolute position the next incoming token will occupy —
                    tracks true sequence position across calls, independent
                    of how many rows have been evicted so far.
+        grace:     Number of most-recently-arrived tokens protected from
+                   eviction, the same way sinks are, giving each new token
+                   ``grace`` update steps to accumulate real attention mass
+                   before it can be evicted. Fixes a real, confirmed-on-
+                   real-models problem: without this, every new token starts
+                   at score 0.0 and is (almost always) the global-minimum
+                   argmin target the instant the cache is full — see module
+                   docstring's "KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM".
+                   Positions are always kept sorted ascending after eviction
+                   (see the class-level note above), so "the most recent
+                   ``grace`` tokens" is equivalent to "the last ``grace``
+                   array indices" — this is what the eviction protection
+                   logic actually implements.
     """
 
     keys: mx.array | None
@@ -133,31 +146,53 @@ class H2OState:
     budget: int
     rope_base: float
     next_pos: int
+    grace: int = 0
 
 
-def init_h2o_state(n_sink: int, budget: int, head_dim: int, rope_base: float = 10000.0) -> H2OState:  # noqa: ARG001
+def init_h2o_state(
+    n_sink: int,
+    budget: int,
+    head_dim: int,  # noqa: ARG001
+    rope_base: float = 10000.0,
+    grace: int = 0,
+) -> H2OState:
     """Create an empty H2OState before any tokens arrive.
 
     Args:
         n_sink:    Number of initial sink positions to protect from eviction.
-        budget:    Maximum total tokens kept (sinks + non-sinks).
+        budget:    Maximum total tokens kept (sinks + non-sinks + grace).
         head_dim:  Head dimension D (unused here; accepted for API symmetry
                    with StreamingLLM's init_streaming_window).
         rope_base: RoPE frequency base — must match the base the model's own
                    attention module uses, or position remapping after
                    eviction will not cancel out the original rotation
                    correctly.
+        grace:     Number of most-recently-arrived tokens protected from
+                   eviction (see :class:`H2OState`'s ``grace`` field). ``0``
+                   reproduces the original (paper-faithful, but freeze-prone
+                   at tight budgets) behavior.
 
     Raises:
         ValueError: if there are sink positions to protect but they leave no
             evictable room within ``budget`` (``n_sink=0, budget=0`` remains
             a valid "disabled cache" configuration).
+        ValueError: if ``n_sink + grace >= budget`` — every row would be
+            protected, so eviction could never make room for a genuinely
+            new token once the cache fills, silently growing past ``budget``
+            in :func:`h2o_update`'s over-budget branch (which always assumes
+            exactly one evictable row exists).
     """
     if n_sink > 0 and n_sink >= budget:
         raise ValueError(
             f"h2o: n_sink ({n_sink}) must be < budget ({budget}) — no "
             "evictable positions remain, so sinks would be evicted once "
             "the cache fills"
+        )
+    if (n_sink > 0 or grace > 0) and n_sink + grace >= budget:
+        raise ValueError(
+            f"h2o: n_sink ({n_sink}) + grace ({grace}) must be < budget "
+            f"({budget}) — every row would be protected, leaving nothing "
+            "evictable once the cache fills"
         )
     return H2OState(
         keys=None,
@@ -168,6 +203,7 @@ def init_h2o_state(n_sink: int, budget: int, head_dim: int, rope_base: float = 1
         budget=budget,
         rope_base=rope_base,
         next_pos=0,
+        grace=grace,
     )
 
 
@@ -286,6 +322,7 @@ def _batch_absorb_prefix(
         budget=state.budget,
         rope_base=state.rope_base,
         next_pos=state.next_pos + B,
+        grace=state.grace,
     )
 
 
@@ -325,18 +362,32 @@ def _evict_via_mlx(
     positions_cat: mx.array,
     n_sink: int,
     rope_base: float,
+    grace: int = 0,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
-    """Pure-MLX eviction: sink-protected argmin, drop the loser, re-rotate
-    the shifted survivors. Reference implementation — see module docstring
-    for why this exists (the fused Metal path in :func:`_evict_via_metal`
-    must match this bit-for-bit)."""
+    """Pure-MLX eviction: sink- and grace-protected argmin, drop the loser,
+    re-rotate the shifted survivors. Reference implementation — see module
+    docstring for why this exists (the fused Metal path in
+    :func:`_evict_via_metal` must match this bit-for-bit).
+
+    Grace protection (``grace > 0``): the last ``grace`` array indices — the
+    most recently arrived tokens, since positions are always kept sorted
+    ascending after eviction (see :class:`H2OState`) — are treated as +inf
+    the same way sinks are, so a token cannot be evicted until it has
+    survived ``grace`` update steps and had a real chance to accumulate
+    attention mass. Without this, a brand-new token's starting score of 0.0
+    makes it (almost always) the argmin target immediately — see module
+    docstring's "KNOWN, CONFIRMED-ON-REAL-MODELS PROBLEM".
+    """
     n_total = keys_cat.shape[0]
     n_sink_eff = min(n_sink, n_total)
+    n_grace_eff = min(grace, n_total)
+    protected = scores_cat
     if n_sink_eff > 0:
-        inf_block = mx.full((n_sink_eff,), float("inf"), dtype=mx.float32)
-        protected = mx.concatenate([inf_block, scores_cat[n_sink_eff:]], axis=0)
-    else:
-        protected = scores_cat
+        sink_inf = mx.full((n_sink_eff,), float("inf"), dtype=mx.float32)
+        protected = mx.concatenate([sink_inf, protected[n_sink_eff:]], axis=0)
+    if n_grace_eff > 0:
+        grace_inf = mx.full((n_grace_eff,), float("inf"), dtype=mx.float32)
+        protected = mx.concatenate([protected[: n_total - n_grace_eff], grace_inf], axis=0)
 
     evict_idx = int(mx.argmin(protected).item())
     evicted_pos = int(positions_cat[evict_idx].item())
@@ -366,15 +417,16 @@ def _evict_via_metal(
     positions_cat: mx.array,
     n_sink: int,
     rope_base: float,
+    grace: int = 0,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
     """Fused-Metal-kernel eviction — see
     :func:`veloxquant_mlx.metal.h2o_fused_evict` and
     ``paper/research/H2O_METAL_KERNEL_TECH_SPEC.md``. Bit-for-bit equivalent
     to :func:`_evict_via_mlx` (verified in
-    ``veloxquant_mlx/tests/metal/test_h2o_evict.py``); single-(batch*head)
-    call here (``BH=1``), since ``h2o_update`` operates on one head's state
-    at a time — batching across heads is a natural follow-up (see spec
-    section 6) not implemented yet.
+    ``veloxquant_mlx/tests/metal/test_h2o_evict.py``, including grace
+    protection); single-(batch*head) call here (``BH=1``), since
+    ``h2o_update`` operates on one head's state at a time — batching across
+    heads is a natural follow-up (see spec section 6) not implemented yet.
     """
     from veloxquant_mlx.metal import h2o_fused_evict
 
@@ -385,6 +437,7 @@ def _evict_via_metal(
         positions_cat[None],
         n_sink=n_sink,
         rope_base=rope_base,
+        grace=grace,
     )
     return keys_out[0], values_out[0], scores_out[0], positions_out[0]
 
@@ -454,6 +507,7 @@ def h2o_update(
                 budget=state.budget,
                 rope_base=state.rope_base,
                 next_pos=cur_pos + 1,
+                grace=state.grace,
             )
             continue
 
@@ -474,11 +528,23 @@ def h2o_update(
         if n_total > state.budget:
             if _metal_evict_available():
                 keys_cat, values_cat, scores_cat, positions_cat = _evict_via_metal(
-                    keys_cat, values_cat, scores_cat, positions_cat, state.n_sink, state.rope_base
+                    keys_cat,
+                    values_cat,
+                    scores_cat,
+                    positions_cat,
+                    state.n_sink,
+                    state.rope_base,
+                    state.grace,
                 )
             else:
                 keys_cat, values_cat, scores_cat, positions_cat = _evict_via_mlx(
-                    keys_cat, values_cat, scores_cat, positions_cat, state.n_sink, state.rope_base
+                    keys_cat,
+                    values_cat,
+                    scores_cat,
+                    positions_cat,
+                    state.n_sink,
+                    state.rope_base,
+                    state.grace,
                 )
 
         state = H2OState(
@@ -490,6 +556,7 @@ def h2o_update(
             budget=state.budget,
             rope_base=state.rope_base,
             next_pos=cur_pos + 1,
+            grace=state.grace,
         )
 
         # Force materialization periodically. Without this, a long prefill

--- a/veloxquant_mlx/tests/cache/test_cam_cache.py
+++ b/veloxquant_mlx/tests/cache/test_cam_cache.py
@@ -182,7 +182,14 @@ def test_cache_drop_mode_matches_h2o(seed):
     Kc, Vc = cc.update_and_fetch(k, v)
 
     hc = H2OKVCache(
-        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+        KVCacheConfig(
+            method="h2o",
+            head_dim=D,
+            h2o_budget=budget,
+            h2o_n_sink=n_sink,
+            h2o_grace=0,
+            h2o_decay=1.0,
+        )
     )
     Kh, Vh = hc.update_and_fetch(k, v)
 

--- a/veloxquant_mlx/tests/cache/test_cam_cache.py
+++ b/veloxquant_mlx/tests/cache/test_cam_cache.py
@@ -181,7 +181,9 @@ def test_cache_drop_mode_matches_h2o(seed):
     )
     Kc, Vc = cc.update_and_fetch(k, v)
 
-    hc = H2OKVCache(KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink))
+    hc = H2OKVCache(
+        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+    )
     Kh, Vh = hc.update_and_fetch(k, v)
 
     assert Kc.shape == Kh.shape

--- a/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
+++ b/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
@@ -205,7 +205,14 @@ def test_cache_chunk_size_one_matches_h2o(seed):
     Kc, Vc = cc.update_and_fetch(k, v)
 
     hc = H2OKVCache(
-        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+        KVCacheConfig(
+            method="h2o",
+            head_dim=D,
+            h2o_budget=budget,
+            h2o_n_sink=n_sink,
+            h2o_grace=0,
+            h2o_decay=1.0,
+        )
     )
     Kh, Vh = hc.update_and_fetch(k, v)
 

--- a/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
+++ b/veloxquant_mlx/tests/cache/test_chunkkv_cache.py
@@ -204,7 +204,9 @@ def test_cache_chunk_size_one_matches_h2o(seed):
     )
     Kc, Vc = cc.update_and_fetch(k, v)
 
-    hc = H2OKVCache(KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink))
+    hc = H2OKVCache(
+        KVCacheConfig(method="h2o", head_dim=D, h2o_budget=budget, h2o_n_sink=n_sink, h2o_grace=0)
+    )
     Kh, Vh = hc.update_and_fetch(k, v)
 
     assert Kc.shape == Kh.shape

--- a/veloxquant_mlx/tests/cache/test_h2o_cache.py
+++ b/veloxquant_mlx/tests/cache/test_h2o_cache.py
@@ -8,12 +8,14 @@ accumulation, budget enforcement across many steps, byte accounting
 (compression_ratio, h2o_kept_bytes), tokens_kept, n_sink=0 edge case,
 determinism, and for_model config propagation. All data is synthetic.
 
-Most tests here pin ``h2o_grace=0`` explicitly: they exercise the underlying
-eviction *mechanism* (sink protection, budget enforcement, determinism) in
-isolation from the grace-period fix (see grace-specific tests further down
-and in test_h2o.py), and were originally written with small budgets (4-16)
-that predate ``h2o_grace``'s nonzero default — pinning grace=0 keeps their
-budgets meaningful without every one of them needing a size bump.
+Most tests here pin ``h2o_grace=0`` and ``h2o_decay=1.0`` explicitly: they
+exercise the underlying eviction *mechanism* (sink protection, budget
+enforcement, determinism) in isolation from the grace-period and decay
+fixes (see grace/decay-specific tests further down and in test_h2o.py), and
+were originally written with small budgets (4-16) that predate
+``h2o_grace``'s and ``h2o_decay``'s nonzero/non-unity defaults — pinning
+grace=0, decay=1.0 keeps their behavior exactly reproducible without every
+one of them needing a size bump or score-tolerance change.
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ from veloxquant_mlx.cache.h2o_cache import H2OKVCache
 
 
 def _make(**cfg):
-    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2, h2o_grace=0)
+    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2, h2o_grace=0, h2o_decay=1.0)
     base.update(cfg)
     return KVCacheFactory.create(KVCacheConfig(**base))
 
@@ -209,12 +211,14 @@ def test_build_via_for_model_propagates_config() -> None:
         h2o_budget=64,
         h2o_n_sink=8,
         h2o_grace=12,
+        h2o_decay=0.95,
     )
     caches = KVCacheBuilder.for_model(_Model(), cfg)
     assert all(isinstance(c, H2OKVCache) for c in caches)
     assert caches[0]._budget == 64
     assert caches[0]._n_sink == 8
     assert caches[0]._grace == 12
+    assert caches[0]._decay == 0.95
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +252,45 @@ def test_grace_protects_new_tokens_from_immediate_eviction() -> None:
     # advanced well past the first `budget` positions after 30 steps —
     # grace=0 would freeze it at positions [0..budget-1] forever.
     assert c.offset == 30
+    assert c.keys.shape[2] <= budget
+
+
+# ---------------------------------------------------------------------------
+# Decay: fixes score staleness (see h2o_cache.py's module docstring, "SECOND
+# FIXED..." section). Without decay, cumulative scores only ever grow, so an
+# old survivor permanently outranks any recently-graduated (post-grace)
+# token regardless of current relevance, thinning the kept window into a
+# sparse gapped trickle instead of a contiguous local context.
+# ---------------------------------------------------------------------------
+
+
+def test_default_decay_is_not_one() -> None:
+    """h2o_decay defaults to < 1.0 in KVCacheConfig — the staleness fix is on
+    by default for real usage, not opt-in only."""
+    cfg = KVCacheConfig(method="h2o", head_dim=32)
+    assert 0.0 < cfg.h2o_decay < 1.0
+
+
+def test_decay_rejects_out_of_range_values() -> None:
+    """Validation happens lazily in init_h2o_state, on the first
+    update_and_fetch call (state is only known once B/H/D are known) — not
+    at H2OKVCache construction time."""
+    k, v = _rand_kv(S=1, H=1, D=32)
+    with pytest.raises(ValueError, match="decay"):
+        _make(h2o_decay=0.0).update_and_fetch(k, v)
+    with pytest.raises(ValueError, match="decay"):
+        _make(h2o_decay=1.5).update_and_fetch(k, v)
+
+
+def test_decay_and_grace_together_keep_budget_enforced() -> None:
+    """Sanity check that combining both fixes doesn't break the invariant
+    every eviction path must uphold: never exceed h2o_budget."""
+    budget = 12
+    c = _make(h2o_budget=budget, h2o_n_sink=2, h2o_grace=4, h2o_decay=0.9)
+    for i in range(50):
+        k, v = _rand_kv(S=1, H=1, D=32, seed=i)
+        c.update_and_fetch(k, v)
+    assert c.offset == 50
     assert c.keys.shape[2] <= budget
 
 

--- a/veloxquant_mlx/tests/cache/test_h2o_cache.py
+++ b/veloxquant_mlx/tests/cache/test_h2o_cache.py
@@ -7,6 +7,13 @@ output shape bounded by budget, output dtype fp16, sink protection, decode
 accumulation, budget enforcement across many steps, byte accounting
 (compression_ratio, h2o_kept_bytes), tokens_kept, n_sink=0 edge case,
 determinism, and for_model config propagation. All data is synthetic.
+
+Most tests here pin ``h2o_grace=0`` explicitly: they exercise the underlying
+eviction *mechanism* (sink protection, budget enforcement, determinism) in
+isolation from the grace-period fix (see grace-specific tests further down
+and in test_h2o.py), and were originally written with small budgets (4-16)
+that predate ``h2o_grace``'s nonzero default — pinning grace=0 keeps their
+budgets meaningful without every one of them needing a size bump.
 """
 
 from __future__ import annotations
@@ -20,7 +27,7 @@ from veloxquant_mlx.cache.h2o_cache import H2OKVCache
 
 
 def _make(**cfg):
-    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2)
+    base = dict(method="h2o", head_dim=32, h2o_budget=8, h2o_n_sink=2, h2o_grace=0)
     base.update(cfg)
     return KVCacheFactory.create(KVCacheConfig(**base))
 
@@ -201,11 +208,47 @@ def test_build_via_for_model_propagates_config() -> None:
         head_dim=32,
         h2o_budget=64,
         h2o_n_sink=8,
+        h2o_grace=12,
     )
     caches = KVCacheBuilder.for_model(_Model(), cfg)
     assert all(isinstance(c, H2OKVCache) for c in caches)
     assert caches[0]._budget == 64
     assert caches[0]._n_sink == 8
+    assert caches[0]._grace == 12
+
+
+# ---------------------------------------------------------------------------
+# Grace period: fixes the early-token-freeze problem (see h2o_cache.py's
+# module docstring). The most-recently-arrived h2o_grace tokens are
+# protected from eviction, giving new tokens a chance to accumulate real
+# attention mass instead of being evicted the instant they arrive (score 0.0
+# is otherwise almost always the global minimum).
+# ---------------------------------------------------------------------------
+
+
+def test_default_grace_is_nonzero() -> None:
+    """h2o_grace defaults to a nonzero value in KVCacheConfig — the freeze
+    fix is on by default for real usage, not opt-in only."""
+    cfg = KVCacheConfig(method="h2o", head_dim=32)
+    assert cfg.h2o_grace > 0
+
+
+def test_grace_protects_new_tokens_from_immediate_eviction() -> None:
+    """With grace >= budget-worth of headroom, newly-arrived tokens survive
+    long enough to actually grow the kept set's position range, unlike
+    grace=0 which freezes on the earliest tokens forever (see
+    test_h2o.py::test_new_token_almost_always_evicted_first for the grace=0
+    baseline this contrasts with)."""
+    budget = 8
+    c = _make(h2o_budget=budget, h2o_n_sink=0, h2o_grace=4)
+    for i in range(30):
+        k, v = _rand_kv(S=1, H=1, D=32, seed=i)
+        c.update_and_fetch(k, v)
+    # With grace=4 protecting the newest arrivals, the kept window must have
+    # advanced well past the first `budget` positions after 30 steps —
+    # grace=0 would freeze it at positions [0..budget-1] forever.
+    assert c.offset == 30
+    assert c.keys.shape[2] <= budget
 
 
 # ---------------------------------------------------------------------------

--- a/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
+++ b/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
@@ -47,7 +47,7 @@ _CONFIGS = {
     "cam": {"cam_budget": 8, "cam_n_sink": 1},
     "chunkkv": {"chunkkv_budget": 8, "chunkkv_n_sink": 1, "chunkkv_chunk_size": 2},
     "curdkv": {"curdkv_budget": 8, "curdkv_n_sink": 1},
-    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1, "h2o_grace": 0},
+    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1, "h2o_grace": 0, "h2o_decay": 1.0},
     "keyformer": {"keyformer_budget": 8, "keyformer_n_sink": 1},
     "knorm": {"knorm_budget": 8, "knorm_n_sink": 1},
     "kvzip": {"kvzip_budget": 8, "kvzip_n_sink": 1},

--- a/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
+++ b/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
@@ -47,7 +47,7 @@ _CONFIGS = {
     "cam": {"cam_budget": 8, "cam_n_sink": 1},
     "chunkkv": {"chunkkv_budget": 8, "chunkkv_n_sink": 1, "chunkkv_chunk_size": 2},
     "curdkv": {"curdkv_budget": 8, "curdkv_n_sink": 1},
-    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1},
+    "h2o": {"h2o_budget": 8, "h2o_n_sink": 1, "h2o_grace": 0},
     "keyformer": {"keyformer_budget": 8, "keyformer_n_sink": 1},
     "knorm": {"knorm_budget": 8, "knorm_n_sink": 1},
     "kvzip": {"kvzip_budget": 8, "kvzip_n_sink": 1},

--- a/veloxquant_mlx/tests/quantizers/test_h2o.py
+++ b/veloxquant_mlx/tests/quantizers/test_h2o.py
@@ -69,6 +69,31 @@ def test_init_state_rejects_n_sink_above_budget() -> None:
         init_h2o_state(n_sink=8, budget=4, head_dim=32)
 
 
+def test_init_state_decay_defaults_to_no_op() -> None:
+    st = init_h2o_state(n_sink=0, budget=16, head_dim=32)
+    assert st.decay == 1.0
+
+
+def test_init_state_rejects_decay_zero() -> None:
+    with pytest.raises(ValueError, match="decay"):
+        init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=0.0)
+
+
+def test_init_state_rejects_decay_negative() -> None:
+    with pytest.raises(ValueError, match="decay"):
+        init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=-0.5)
+
+
+def test_init_state_rejects_decay_above_one() -> None:
+    with pytest.raises(ValueError, match="decay"):
+        init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=1.5)
+
+
+def test_init_state_accepts_decay_equal_one() -> None:
+    st = init_h2o_state(n_sink=0, budget=16, head_dim=32, decay=1.0)
+    assert st.decay == 1.0
+
+
 # ---------------------------------------------------------------------------
 # h2o_get_kv — empty state
 # ---------------------------------------------------------------------------
@@ -225,6 +250,71 @@ def test_scores_accumulate_over_steps() -> None:
     scores_after_2 = np.array(st2.scores[: len(scores_after_1)].tolist())
     # Softmax weights are positive, so at least total mass increased
     assert scores_after_2.sum() >= scores_after_1.sum() - 1e-4
+
+
+# ---------------------------------------------------------------------------
+# decay — fixes score staleness (old tokens permanently outranking new ones)
+# ---------------------------------------------------------------------------
+
+
+def test_decay_one_reproduces_no_decay_behavior() -> None:
+    """decay=1.0 must be bit-for-bit identical to omitting decay entirely —
+    it is the explicit opt-out, not just 'close to' the original behavior."""
+    D = 16
+    budget = 1000
+    k, v = _rand_kv(S=30, D=D, seed=3)
+
+    st_default = init_h2o_state(n_sink=0, budget=budget, head_dim=D)
+    st_default = h2o_update(st_default, k, v)
+
+    st_explicit = init_h2o_state(n_sink=0, budget=budget, head_dim=D, decay=1.0)
+    st_explicit = h2o_update(st_explicit, k, v)
+
+    assert bool(mx.all(st_default.scores == st_explicit.scores).item())
+
+
+def test_decay_shrinks_old_scores_relative_to_no_decay() -> None:
+    """With decay < 1.0, an old token's score after many later updates must
+    be strictly lower than with decay=1.0 (its earlier mass fades)."""
+    D = 16
+    budget = 1000
+    k, v = _rand_kv(S=1, D=D, seed=0)
+
+    st_nodecay = init_h2o_state(n_sink=0, budget=budget, head_dim=D, decay=1.0)
+    st_nodecay = h2o_update(st_nodecay, k, v)
+    st_decay = init_h2o_state(n_sink=0, budget=budget, head_dim=D, decay=0.9)
+    st_decay = h2o_update(st_decay, k, v)
+
+    for step in range(1, 20):
+        k_i, v_i = _rand_kv(S=1, D=D, seed=step)
+        st_nodecay = h2o_update(st_nodecay, k_i, v_i)
+        st_decay = h2o_update(st_decay, k_i, v_i)
+
+    assert float(st_decay.scores[0].item()) < float(st_nodecay.scores[0].item())
+
+
+def test_decay_prevents_old_token_from_permanently_outranking_recent_ones() -> None:
+    """The actual bug being fixed: without decay, an old survivor's
+    cumulative score can exceed every recently-graduated token's score
+    forever, forcing eviction to thin the rest of the budget into a sparse
+    trickle. With decay, a long-enough run should let a later, currently
+    high-scoring token exceed an early token's (now-decayed) score."""
+    D = 16
+    budget = 1000
+    n_sink = 0
+
+    st = init_h2o_state(n_sink=n_sink, budget=budget, head_dim=D, decay=0.8)
+    for step in range(40):
+        k_i, v_i = _rand_kv(S=1, D=D, seed=step)
+        st = h2o_update(st, k_i, v_i)
+
+    scores_np = np.array(st.scores.tolist())
+    # With decay, score should NOT be monotonically non-increasing in
+    # position the way it is without decay (see module docstring: -0.97
+    # correlation with no decay) — at least one later token should beat an
+    # earlier one, showing old dominance has been broken.
+    beats_earlier = any(scores_np[j] > scores_np[0] for j in range(1, len(scores_np) - 1))
+    assert beats_earlier
 
 
 # ---------------------------------------------------------------------------
@@ -462,6 +552,56 @@ def test_batch_absorb_matches_sequential_with_prior_tokens() -> None:
     vectorized = _batch_absorb_no_eviction(st2.keys.astype(mx.float32), st2.scores, mx.array(new))
     err = float(mx.max(mx.abs(vectorized - st.scores)).item())
     assert err < 1e-3, f"batch vs sequential score mismatch: {err}"
+
+
+def test_batch_absorb_with_decay_matches_sequential_from_empty() -> None:
+    """decay must be applied identically in the vectorized batch path and
+    the sequential per-token loop it replaces — this is the highest-risk
+    piece of the decay fix (exponentiated decay powers per batch row)."""
+    D = 8
+    S = 6
+    decay = 0.9
+    rng = np.random.default_rng(2)
+    keys = mx.array(rng.standard_normal((S, D)).astype(np.float32))
+
+    st = init_h2o_state(n_sink=0, budget=1000, head_dim=D, decay=decay)
+    for i in range(S):
+        st = h2o_update(st, keys[i][None].astype(mx.float16), keys[i][None].astype(mx.float16))
+
+    vectorized = _batch_absorb_no_eviction(None, None, keys, decay=decay)
+    err = float(mx.max(mx.abs(vectorized - st.scores)).item())
+    assert err < 1e-3, f"batch-with-decay vs sequential score mismatch: {err}"
+
+
+def test_batch_absorb_with_decay_matches_sequential_with_prior_tokens() -> None:
+    """Same as above but exercising the non-empty-prior branch of
+    _batch_absorb_no_eviction, which decays prior_scores by decay**S in
+    addition to decaying each batch row's own contribution."""
+    D = 8
+    P = 3
+    S = 4
+    decay = 0.9
+    rng = np.random.default_rng(3)
+    prior = rng.standard_normal((P, D)).astype(np.float32)
+    new = rng.standard_normal((S, D)).astype(np.float32)
+
+    st = init_h2o_state(n_sink=0, budget=1000, head_dim=D, decay=decay)
+    for i in range(P):
+        k = mx.array(prior[i][None].astype(np.float16))
+        st = h2o_update(st, k, k)
+    for i in range(S):
+        k = mx.array(new[i][None].astype(np.float16))
+        st = h2o_update(st, k, k)
+
+    st2 = init_h2o_state(n_sink=0, budget=1000, head_dim=D, decay=decay)
+    for i in range(P):
+        k = mx.array(prior[i][None].astype(np.float16))
+        st2 = h2o_update(st2, k, k)
+    vectorized = _batch_absorb_no_eviction(
+        st2.keys.astype(mx.float32), st2.scores, mx.array(new), decay=decay
+    )
+    err = float(mx.max(mx.abs(vectorized - st.scores)).item())
+    assert err < 1e-3, f"batch-with-decay vs sequential score mismatch: {err}"
 
 
 def test_h2o_update_single_call_matches_many_single_token_calls() -> None:


### PR DESCRIPTION
## Summary

Split out of #138 — this is the part that changes H2O's actual eviction *behavior* and two defaults, as opposed to #139/#140 which are pure correctness/perf fixes with no behavior change. Please review this one more critically than the other two; it changes what `method="h2o"` does out of the box, twice, and even after both fixes there is a known, open issue left undone (see bottom).

## Bug #1: permanent freeze (fixed via `h2o_grace`, default `16`)

Every newly-arrived token starts at cumulative score `0.0`, and eviction removes whichever token holds the global minimum score. On any realistic score distribution the brand-new token's `0.0` *is* that minimum, so it's (almost always) evicted the instant the cache fills — before it ever accumulates real attention mass. Confirmed on real models (Llama-3.2-1B, Mistral-7B): after 43 decode steps, the kept set was still exactly the original 14-token prompt.

Fixed by protecting the most-recently-arrived `grace` tokens from eviction the same way sink tokens are. Implemented identically in the pure-MLX and fused-Metal eviction paths (verified bit-for-bit equivalent). `h2o_grace=0` reproduces the original paper-faithful behavior exactly.

## Bug #2: score staleness (fixed via `h2o_decay`, default `0.98`)

Fixing the freeze exposed a second bug: scores are a running sum that never shrinks, so a token that survived its grace window early in generation can outrank every later token forever. Verified: at `budget=64, grace=16`, after 400 decode steps the kept window without decay was still `[4..74]` — pinned near the prompt; with `h2o_decay=0.98` it correctly advanced to `[297..415]`.

Fixed by multiplicatively decaying existing scores each step before adding new mass. Implemented identically in the per-token loop and the vectorized batch path (verified to fp32 rounding in both branches). `h2o_decay=1.0` is a byte-for-bit no-op.

## What's still NOT fixed (left open deliberately, not silently)

1. A structural gap-of-2 kept-window pattern at very tight `h2o_budget - h2o_n_sink - h2o_grace` headroom, independent of decay — traced to the newest-graduated-from-grace token always being close to the minimum by construction.
2. A separate mid-generation eviction-quality bug: a single eviction can still drop context the model needs, breaking output mid-word (e.g. `"thylakoid"` → `"th th th th"`). Verified independent of grace/decay via A/B (identical output at `decay=1.0` vs `0.98`) and a no-eviction control (stays fully coherent on the same prompt/seed). This is a real, open gap — not claimed as fixed by this PR.

Full data, methodology, and the honest "still open" writeup are in `docs-site/docs/algorithms/h2o.md`'s "Grace-and-decay testing" section.

## Testing

- Full suite: **1824/1824 passing**.
- New tests: grace/decay validation ranges, no-op equivalence, staleness-prevention assertions, batch-vs-sequential parity for decay (highest-risk part of the change — exponentiated per-row decay power), combined grace+decay budget enforcement.
- Fixture updates: several pre-existing small-budget tests now pin `h2o_grace=0, h2o_decay=1.0` explicitly, since they test the base eviction mechanism in isolation from either fix, not predate them incidentally.
- Docs build clean, ruff clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>