### PR TITLE
fix(registry): distinguish not-trimmable from crash-tier, unblocking the release gate

### DIFF
--- a/veloxquant_mlx/cache/registry.py
+++ b/veloxquant_mlx/cache/registry.py
@@ -46,8 +46,11 @@ __all__ = [
 DOCS_BASE = "https://veloxquant-mlx.netlify.app/algorithms"
 
 #: What ``veloxquant serve`` starts with when the user does not pick a method.
-#: Deliberately *not* ``KVCacheConfig``'s default (``turboquant_prod``), which
-#: is in the CRASHES tier — see #27 and the note in ``veloxquant_mlx/cli/serve.py``.
+#: This was originally chosen because ``KVCacheConfig`` defaulted to
+#: ``turboquant_prod``, which is CRASHES-tier (#27). Since f6e9434 the library
+#: default is ``turboquant_rvq`` — the same method — so the two now agree;
+#: the constant is kept so the launcher default stays explicit rather than
+#: silently tracking whatever the library default becomes next.
 DEFAULT_SERVE_METHOD = "turboquant_rvq"
 
 
@@ -58,10 +61,19 @@ class ServeTier(str, Enum):
     unreachable — it becomes reachable only when compressed storage is real
     (#27 option (d)). It exists so the UI has somewhere to put a method once
     that lands, instead of needing a new tier at that point.
+
+    ``NOT_TRIMMABLE`` exists because "cannot be trimmed" and "crashes" are
+    different facts and were previously conflated (#152). Every eviction cache
+    deliberately returns ``is_trimmable() -> False`` — ``trim()`` would roll
+    back only the base class's offset bookkeeping and not the internal
+    per-token eviction state, silently corrupting later calls. Those caches
+    serve correctly; only prompt-cache trimming is unavailable, so they must
+    not be reported to users as unavailable methods.
     """
 
     HONEST_BYTES = "honest_bytes"
     ACCOUNTING_ONLY = "accounting_only"
+    NOT_TRIMMABLE = "not_trimmable"
     CRASHES = "crashes"
 
     @property
@@ -69,10 +81,20 @@ class ServeTier(str, Enum):
         return self is not ServeTier.CRASHES
 
     @property
+    def is_trimmable(self) -> bool:
+        """False when ``mlx_lm.server`` must not call ``trim()`` on this cache.
+
+        Servable and trimmable are independent: a method can serve every
+        request correctly while refusing to have its prompt cache trimmed.
+        """
+        return self is not ServeTier.NOT_TRIMMABLE
+
+    @property
     def label(self) -> str:
         return {
             ServeTier.HONEST_BYTES: "available",
             ServeTier.ACCOUNTING_ONLY: "available",
+            ServeTier.NOT_TRIMMABLE: "available (no prompt-cache trimming)",
             ServeTier.CRASHES: "not available yet",
         }[self]
 
@@ -451,9 +473,16 @@ def _run_probe(method: str) -> tuple["ServeTier", Optional[str]]:
     except Exception as exc:
         return ServeTier.CRASHES, f"update_and_fetch failed: {type(exc).__name__}: {exc}"
 
+    # Not-trimmable is a *capability limit*, not a crash (#152). Every eviction
+    # cache returns is_trimmable() -> False on purpose, because trim() would
+    # roll back base-class offset bookkeeping without touching the internal
+    # per-token eviction state. Such a cache still serves every request
+    # correctly, so record the finding and keep probing rather than returning
+    # early — a cache that is both not-trimmable *and* fails deepcopy is still
+    # CRASHES, and returning here would hide that.
+    trimmable = True
     try:
-        if not can_trim_prompt_cache([cache]):
-            return ServeTier.CRASHES, "cache reports itself as not trimmable"
+        trimmable = bool(can_trim_prompt_cache([cache]))
     except Exception as exc:
         return ServeTier.CRASHES, f"trim probe failed: {type(exc).__name__}: {exc}"
 
@@ -464,6 +493,15 @@ def _run_probe(method: str) -> tuple["ServeTier", Optional[str]]:
             ServeTier.CRASHES,
             f"deepcopy failed ({type(exc).__name__}: {exc}); mlx_lm.server "
             "deepcopies cache entries per request.",
+        )
+
+    if not trimmable:
+        return (
+            ServeTier.NOT_TRIMMABLE,
+            "serves correctly, but reports is_trimmable() == False, so "
+            "mlx_lm.server cannot trim its prompt cache — trim() would roll "
+            "back offset bookkeeping without reverting internal eviction "
+            "state. Expected for eviction/compression caches (#152).",
         )
 
     # Serves correctly, but stores dequantized fp16 and so over-reports nbytes.

--- a/veloxquant_mlx/cli/methods.py
+++ b/veloxquant_mlx/cli/methods.py
@@ -14,7 +14,6 @@ import sys
 from veloxquant_mlx.cache.registry import (
     DEFAULT_SERVE_METHOD,
     MethodFamily,
-    ServeTier,
     TelemetryCoverage,
     list_methods,
 )
@@ -85,7 +84,10 @@ def main() -> None:
             print(f"    deviation: {info.paper_deviation}")
         print()
 
-    if any(i.serve_tier is ServeTier.ACCOUNTING_ONLY for i in infos):
+    # Keyed on is_servable, not on ACCOUNTING_ONLY specifically: NOT_TRIMMABLE
+    # methods are servable and equally accounting-only, so testing one tier
+    # would drop this caveat for the whole eviction family (#152).
+    if any(i.serve_tier.is_servable for i in infos):
         print(
             "Note: servable methods are accounting-only — byte counters measure "
             "compression\nfidelity, not runtime memory saved. See issue #27."

--- a/veloxquant_mlx/tests/cache/test_registry.py
+++ b/veloxquant_mlx/tests/cache/test_registry.py
@@ -34,6 +34,29 @@ EXPECTED_CRASHING = {
     "spectral",
 }
 
+# Eviction/compression caches that deliberately return is_trimmable() -> False
+# (17e83c3): trim() would roll back the base class's offset bookkeeping without
+# reverting internal per-token eviction state. They serve correctly — the probe
+# used to misreport them as CRASHES, which told users 15 working methods were
+# unavailable (#152).
+EXPECTED_NOT_TRIMMABLE = {
+    "amc",
+    "cam",
+    "chunkkv",
+    "curdkv",
+    "h2o",
+    "keyformer",
+    "knorm",
+    "kvzip",
+    "morphkv",
+    "nestedkv",
+    "pyramidkv",
+    "qfilters",
+    "squeeze",
+    "streaming_llm",
+    "tova",
+}
+
 
 def test_all_methods_discovered():
     assert len(all_method_names()) == EXPECTED_TOTAL
@@ -52,6 +75,39 @@ def test_crash_tier_matches_issue_27():
     assert len(servable) == EXPECTED_TOTAL - len(EXPECTED_CRASHING)
 
 
+def test_not_trimmable_methods_are_servable():
+    """The 15 eviction caches serve correctly; only trim() is unavailable (#152).
+
+    This is the regression guard for the bug that blocked the release gate:
+    the probe conflated "refuses to be trimmed" with "crashes", so these
+    methods were reported as unavailable in the control panel and gated out
+    of `veloxquant serve`.
+    """
+    not_trimmable = {i.name for i in list_methods() if i.serve_tier is ServeTier.NOT_TRIMMABLE}
+    assert not_trimmable == EXPECTED_NOT_TRIMMABLE
+
+    for info in list_methods():
+        if info.serve_tier is ServeTier.NOT_TRIMMABLE:
+            assert info.serve_tier.is_servable, f"{info.name} must remain servable"
+            assert not info.serve_tier.is_trimmable
+            assert info.unsupported_reason, f"{info.name} must explain the limitation"
+
+
+def test_servable_and_trimmable_are_independent():
+    """A tier may be servable-but-not-trimmable; only CRASHES is unservable."""
+    assert ServeTier.NOT_TRIMMABLE.is_servable
+    assert not ServeTier.NOT_TRIMMABLE.is_trimmable
+    assert not ServeTier.CRASHES.is_servable
+    assert ServeTier.ACCOUNTING_ONLY.is_servable
+    assert ServeTier.ACCOUNTING_ONLY.is_trimmable
+
+
+def test_not_trimmable_label_does_not_read_as_unavailable():
+    """The UI string must not tell users a working method is unavailable."""
+    label = ServeTier.NOT_TRIMMABLE.label
+    assert "available" in label and "not available" not in label
+
+
 def test_no_method_claims_honest_bytes_yet():
     """Guards #27's credibility rule.
 
@@ -63,22 +119,36 @@ def test_no_method_claims_honest_bytes_yet():
 
 
 def test_every_servable_method_is_accounting_only():
+    """No servable method may claim honest compressed bytes yet (#27 option (d)).
+
+    NOT_TRIMMABLE is accepted alongside ACCOUNTING_ONLY: it is an orthogonal
+    fact about ``trim()`` support, not a byte-accounting claim (#152). What
+    this test actually guards is that nothing reaches HONEST_BYTES early.
+    """
     for info in list_methods(servable_only=True):
-        assert info.serve_tier is ServeTier.ACCOUNTING_ONLY
+        assert info.serve_tier in (
+            ServeTier.ACCOUNTING_ONLY,
+            ServeTier.NOT_TRIMMABLE,
+        ), f"{info.name} is servable at unexpected tier {info.serve_tier}"
 
 
 def test_default_serve_method_is_servable():
-    """The launcher default must work, and must differ from the library default."""
-    info = get_method(DEFAULT_SERVE_METHOD)
-    assert info.serve_tier.is_servable
+    """The launcher default must work under ``mlx_lm.server``.
+
+    This used to also assert the *library* default was crash-tier, which was
+    true when the library defaulted to ``turboquant_prod``. Since f6e9434 it
+    defaults to ``turboquant_rvq``, which is servable — so that assertion was
+    pinning a fact that had already stopped being true rather than protecting
+    anything. What matters is only that the serve default itself is servable.
+    """
+    assert get_method(DEFAULT_SERVE_METHOD).serve_tier.is_servable
 
     from veloxquant_mlx.cache.base import KVCacheConfig
 
-    assert KVCacheConfig().method in EXPECTED_CRASHING, (
-        "library default is expected to be crash-tier; if that changed, the "
-        "serve default and its accompanying docs note should be revisited"
-    )
-    assert DEFAULT_SERVE_METHOD != KVCacheConfig().method
+    # The library default must also be servable — if it ever regresses to a
+    # crash-tier method, `veloxquant serve` and the three-line README example
+    # would disagree about what works.
+    assert get_method(KVCacheConfig().method).serve_tier.is_servable
 
 
 def test_unsupported_methods_explain_themselves():


### PR DESCRIPTION
Closes #152.

**Unblocks the release pipeline.** `release.yml` runs the full test suite as a gate, so the four failures on `master` were stopping every version bump, GitHub Release, TestPyPI and PyPI publish. This PR takes the suite to **2012 passed, 0 failed**.

## Root cause

Two individually-correct changes that were never reconciled:

| | |
|---|---|
| **`9312bdd`** (Jul 31) | Registry lands. `probe_serve_tier` classifies a cache as `CRASHES` when `can_trim_prompt_cache()` is False. |
| **`17e83c3`** (Aug 8) | 17 eviction/compression caches deliberately get `is_trimmable() -> False` — `trim()` would roll back the base class's offset bookkeeping without reverting internal per-token eviction state, silently corrupting later calls. |

From Aug 8 onward the probe read *"refuses to be trimmed"* as *"crashes"*, moving 15 methods into crash-tier.

## They do not crash

Verified directly — h2o completes prefill + decode and reports valid `nbytes`/`state`:

```
h2o survived prefill+decode: (1, 8, 18, 128)
nbytes ok: True     state ok: True
```

Grouping the 20 formerly-crash-tier methods by the probe's own reason makes the split obvious:

| Reason | Count | Real crash? |
|---|---|---|
| does not subclass `mlx_lm` KVCache → `AttributeError` on first request | 5 | **Yes** |
| "cache reports itself as not trimmable" | 15 | **No** — capability limit |

This mattered beyond CI: `CRASHES` renders as **"not available yet"** and gates `veloxquant serve`, so the bug told users that 15 working methods — most of the eviction family, and the *only* methods that actually reduce resident memory (🔻RSS in the README) — were unavailable.

## The fix

Adds `ServeTier.NOT_TRIMMABLE`:

- `is_servable` → **True** (these serve correctly)
- new `is_trimmable` property → **False**
- label: `"available (no prompt-cache trimming)"`

The probe now *records* the not-trimmable finding and keeps probing rather than returning early — so a cache that is both not-trimmable **and** fails `deepcopy` is still correctly `CRASHES`, which an early return would have hidden.

Crash-tier is back to the genuine 5: `polar`, `qjl`, `spectral`, `turboquant_mse`, `turboquant_prod`. `EXPECTED_CRASHING` was already correct — it was the *behavior* that drifted, so the fix is the probe, not the expected numbers.

CLI output after the fix:

```
h2o                eviction      available (no prompt-cache trimming)
    H2O: keeps 'heavy hitter' tokens by accumulated attention.
```

## Two further staleness fixes found while here

1. **`test_default_serve_method_is_servable`** asserted the *library* default is crash-tier. That was true when it defaulted to `turboquant_prod`; `f6e9434` changed it to `turboquant_rvq`, which is servable. The assertion was pinning a fact that had already stopped being true rather than protecting anything. It now asserts both defaults are servable — what the test's own docstring says it is for. The stale `DEFAULT_SERVE_METHOD` comment naming `turboquant_prod` is corrected too.

2. **`cli/methods.py`** gated its accounting-only footnote on `ACCOUNTING_ONLY` specifically, which would have silently dropped that caveat for the entire eviction family. Keyed on `is_servable` instead.

## Tests

Three regression guards added, pinning exactly what broke:

- `test_not_trimmable_methods_are_servable` — the 15-method set, each servable and each carrying an explanation.
- `test_servable_and_trimmable_are_independent` — the two properties are orthogonal; only `CRASHES` is unservable.
- `test_not_trimmable_label_does_not_read_as_unavailable` — the UI string can never again tell users a working method is unavailable.

## Review note

This is scoped to the registry bug and deliberately kept separate from #151 (already merged), since it fixes pre-existing behavior and changes the published support matrix. One thing worth a second opinion: **#27's docs matrix still describes a 35/5 split.** That number is still arithmetically right (35 servable / 5 crashing), but it no longer conveys that 15 of the 35 cannot be trimmed. Happy to follow up with a docs pass if you want that surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
