### PR TITLE
Rewrite the playground for a non-expert audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,11 +382,19 @@ knobs={'bit_width_inlier': 1, 'seed': 42}
 key_accounting_ratio≈7.5x
 resident_savings_likely=False
 kv_fp16_mb≈512.0  kv_compressed_mb_est≈68.27
-rationale: Zero-calibration default. Key accounting ~7.5x at head_dim=128.
-           Default path dequantizes into parent fp16 cache.
+rationale: The safe everyday pick: it works out of the box with no setup
+           step, and shrinks the key half of the cache by about 7.5x. It
+           unpacks each value back to full precision as it is read, so this
+           is a size measurement rather than a drop in live memory use.
 warnings:
-  - Tight RAM with a mid/large model: consider goal=max_context (rabitq)
-    or goal=constant_memory (eviction) for long prompts.
+  - RAM is tight for a model this size. For long prompts you will get more
+    out of 'Fit the longest conversation' (rabitq), which compresses the
+    whole cache, or 'Never grow past a fixed memory limit' (streaming_llm),
+    which caps it outright.
+  - This method measures smaller but may not free much actual RAM on short
+    prompts, because its default path unpacks values back to full precision
+    as it reads them. The size figure is real; treat it as a measure of how
+    well the data compresses, not as RAM you get back.
 ```
 
 Goals: `everyday`, `max_key_accounting`, `max_context`, `best_quality`, `constant_memory`. Add `--json` for machine-readable output, or `--seq-len` / `--n-layers` / `--n-kv-heads` / `--head-dim` to match a specific model. Also available in the browser via the [Compression Lab](https://veloxquant-mlx.netlify.app/playground.html).

--- a/landing/assets/playground.js
+++ b/landing/assets/playground.js
@@ -39,19 +39,34 @@ function recommend(req) {
     // Match Python's float repr (e.g. "2.0", "18.0"): the reference message
     // uses `~{weight_gb} GB` where weight_gb is always a float.
     const weightStr = Number.isInteger(weightGb) ? weightGb.toFixed(1) : String(weightGb);
-    warnings.push(
-      `${req.model_class} 4-bit weights (~${weightStr} GB) leave little ` +
-      `headroom on ${req.ram_gb} GB (est. headroom ${headroomGb.toFixed(1)} GB). ` +
-      "Prefer a smaller model, eviction, or full-KV compression."
-    );
+    // Negative headroom means the weights alone overrun the machine, so say
+    // "will not fit" rather than "barely fits" — the softer phrasing would
+    // read as a caution about a setup that is in fact impossible.
+    if (headroomGb < 0) {
+      warnings.push(
+        `A ${req.model_class} model will not fit in ${req.ram_gb} GB. Its ` +
+        `weights alone need ~${weightStr} GB, which is more than this Mac ` +
+        "has once macOS takes its share — you are about " +
+        `${Math.abs(headroomGb).toFixed(1)} GB short of any headroom. Pick a smaller ` +
+        "model."
+      );
+    } else {
+      warnings.push(
+        `A ${req.model_class} model barely fits in ${req.ram_gb} GB. Its ` +
+        `weights alone take ~${weightStr} GB, leaving about ` +
+        `${headroomGb.toFixed(1)} GB of headroom for everything else. Try a ` +
+        "smaller model, or pick a goal that caps memory."
+      );
+    }
   }
 
   const kvFp16 = estimateKvFp16Mb(req.n_layers, req.n_kv_heads, req.head_dim, req.seq_len);
 
   if (req.model_class === "1B") {
     warnings.push(
-      "Metal kernel launch overhead can dominate on tiny models; " +
-      "prefer RVQ or disable Metal if tok/s drops."
+      "On a model this small the GPU spends more time starting work than " +
+      "doing it, so compression can actually slow generation down. If speed " +
+      "drops, switch to turboquant_rvq or turn the Metal kernels off."
     );
   }
 
@@ -64,12 +79,16 @@ function recommend(req) {
     ratio = 7.5;
     resident = false;
     rationale =
-      "Zero-calibration default. Key accounting ~7.5x at head_dim=128. " +
-      "Default path dequantizes into parent fp16 cache.";
+      "The safe everyday pick: it works out of the box with no setup step, " +
+      "and shrinks the key half of the cache by about 7.5x. It unpacks each " +
+      "value back to full precision as it is read, so this is a size " +
+      "measurement rather than a drop in live memory use.";
     if (tight && ["7B", "14B", "32B"].includes(req.model_class)) {
       warnings.push(
-        "Tight RAM with a mid/large model: consider goal=max_context " +
-        "(rabitq) or goal=constant_memory (eviction) for long prompts."
+        "RAM is tight for a model this size. For long prompts you will get " +
+        "more out of 'Fit the longest conversation' (rabitq), which " +
+        "compresses the whole cache, or 'Never grow past a fixed memory " +
+        "limit' (streaming_llm), which caps it outright."
       );
     }
   } else if (req.goal === "max_key_accounting") {
@@ -78,41 +97,49 @@ function recommend(req) {
       key_codebook_bits: 8, value_codebook_bits: 8,
       key_sub_dim: 8, value_sub_dim: 8,
       use_metal_kernels: null,
-      note: "Requires one-time codebook calibration",
+      note: "Needs a one-time setup pass over sample data before first use",
     };
     ratio = 16.0;
     resident = false;
     rationale =
-      "Product VQ 1-bit path targets ~16x key accounting when " +
-      "head_dim is divisible by sub_dim=8. Needs calibration.";
+      "The smallest key cache on offer, around 16x. The trade is a one-time " +
+      "setup pass over sample data before you can use it, and the same " +
+      "unpack-on-read caveat as the everyday option.";
     if (req.head_dim % 8 !== 0) {
       warnings.push(
-        `head_dim=${req.head_dim} is not divisible by 8; ` +
-        "VecInfer sub_dim must divide head_dim."
+        "This model will not work with vecinfer: it splits each vector " +
+        `into groups of 8, and this model's head dimension ` +
+        `(${req.head_dim}) does not divide evenly by 8.`
       );
     }
   } else if (req.goal === "best_quality") {
     method = "spectral";
-    knobs = { bit_width_inlier: 3, note: "Requires spectral rotation calibration" };
+    knobs = {
+      bit_width_inlier: 3,
+      note: "Needs a one-time setup pass over sample data before first use",
+    };
     ratio = 5.3;
     resident = false;
     rationale =
-      "SpectralQuant targets better reconstruction at moderate " +
-      "compression via eigenbasis rotation (calibration required).";
+      "Compresses less (about 5.3x) but reconstructs the cache more " +
+      "faithfully, so answers stay closest to the uncompressed model. " +
+      "Needs a one-time setup pass over sample data.";
   } else if (req.goal === "max_context") {
     method = "rabitq";
     ratio = 6.0;
     resident = true;
     if (tight) {
-      knobs = { note: "1-bit keys + MSE-b4 values; prefer fused Metal path when available" };
+      knobs = { note: "Compresses the whole cache; turn on the Metal kernels if available" };
       rationale =
-        "Full-KV compression is more likely to free resident memory " +
-        "than key-only accounting methods on tight RAM.";
+        "Compresses both halves of the cache, so it genuinely gives RAM " +
+        "back rather than only measuring smaller. That matters most on a " +
+        "machine as tight as this one.";
     } else {
-      knobs = { note: "Full KV compression for longer context in fixed RAM" };
+      knobs = { note: "Compresses the whole cache, for longer chats in the same memory" };
       rationale =
-        "RaBitQ compresses keys and values. Better candidate for " +
-        "real context capacity gains than key-only RVQ accounting.";
+        "Compresses both halves of the cache, not just the keys, so the " +
+        "space it frees is real. That makes it the better choice when you " +
+        "want the longest possible conversation in the RAM you have.";
     }
   } else if (req.goal === "constant_memory") {
     method = "streaming_llm";
@@ -120,11 +147,14 @@ function recommend(req) {
     ratio = 1.0;
     resident = true;
     rationale =
-      "Structural eviction keeps a fixed sink + window. Cache token " +
-      "count stays bounded regardless of generation length.";
+      "Keeps the first few tokens plus a sliding window of recent ones and " +
+      "discards the rest, so memory use stops growing no matter how long " +
+      "the conversation runs.";
     warnings.push(
-      "Eviction drops tokens; quality depends on the task. " +
-      "For importance-based eviction try method=h2o instead."
+      "This works by forgetting older tokens, so the model can lose track of " +
+      "things said early in a long conversation. How much that hurts depends " +
+      "on the task. To drop the least-used tokens instead of simply the " +
+      "oldest, try method=h2o."
     );
   } else {
     throw new Error(`Unknown goal: ${req.goal}`);
@@ -132,16 +162,19 @@ function recommend(req) {
 
   if (["M1", "M2"].includes(req.chip) && ["14B", "32B"].includes(req.model_class)) {
     warnings.push(
-      `${req.chip} with ${req.model_class}: expect lower tok/s; ` +
-      "memory fit still depends mainly on unified RAM."
+      `A ${req.model_class} model on an ${req.chip} will generate text more ` +
+      "slowly than on a newer chip. Whether it fits at all, though, comes " +
+      "down to how much RAM you have rather than which chip it is."
     );
   }
 
   const compressedMb = ratio > 0 ? kvFp16 / ratio : kvFp16;
   if (!resident) {
     warnings.push(
-      "Resident RSS savings are unlikely at short context for this " +
-      "method's default path (accounting ratio still valid)."
+      "This method measures smaller but may not free much actual RAM on " +
+      "short prompts, because its default path unpacks values back to full " +
+      "precision as it reads them. The size figure is real; treat it as a " +
+      "measure of how well the data compresses, not as RAM you get back."
     );
   }
 
@@ -186,12 +219,12 @@ function renderPresets() {
     MODEL_PRESETS.map(
       (p) =>
         `<button type="button" class="pg-preset-chip" data-preset="${p.id}"
-           title="${p.n_layers} layers · ${p.n_kv_heads} KV heads · head_dim ${p.head_dim}">
+           title="Sets the exact shape for ${p.name}: ${p.n_layers} layers, ${p.n_kv_heads} KV heads, head dimension ${p.head_dim}">
            ${p.name}
          </button>`
     ).join("") +
     `<button type="button" class="pg-preset-chip pg-preset-custom" data-preset="custom"
-       title="Your own model shape">Custom</button>`;
+       title="Something else — set it up under Advanced">Something else</button>`;
 
   row.querySelectorAll("[data-preset]").forEach((btn) => {
     btn.addEventListener("click", () => {
@@ -249,7 +282,7 @@ const METHODS = {
   turboquant_rvq: {
     label: "TurboQuant-RVQ (everyday, zero-calibration)",
     short: "TurboQuant-RVQ",
-    blurb: "Zero-calibration everyday default.",
+    blurb: "Works out of the box. Start here.",
     ratio: 7.5,
     resident: false,
     config: 'KVCacheConfig(method="turboquant_rvq", bit_width_inlier=1, seed=42)',
@@ -257,7 +290,7 @@ const METHODS = {
   vecinfer: {
     label: "VecInfer (max key accounting, ~16×)",
     short: "VecInfer",
-    blurb: "Max key accounting; needs calibration.",
+    blurb: "Smallest of all, but needs a setup step first.",
     ratio: 16.0,
     resident: false,
     config: 'KVCacheConfig(method="vecinfer", key_codebook_bits=8, key_sub_dim=8)',
@@ -265,7 +298,7 @@ const METHODS = {
   rabitq: {
     label: "RaBitQ (full-KV, long context)",
     short: "RaBitQ",
-    blurb: "Full-KV compression for long context.",
+    blurb: "Frees real memory. Best for long chats.",
     ratio: 6.0,
     resident: true,
     config: 'KVCacheConfig(method="rabitq")',
@@ -273,7 +306,7 @@ const METHODS = {
   spectral: {
     label: "SpectralQuant (best quality, ~5.3×)",
     short: "SpectralQuant",
-    blurb: "Best reconstruction quality.",
+    blurb: "Keeps answers closest to the original.",
     ratio: 5.3,
     resident: false,
     config: 'KVCacheConfig(method="spectral", bit_width_inlier=3)',
@@ -281,7 +314,7 @@ const METHODS = {
   kivi: {
     label: "KIVI-2bit (per-channel keys, ~4× full-KV)",
     short: "KIVI-2bit",
-    blurb: "Per-channel keys, throughput-neutral.",
+    blurb: "Compresses less, but doesn't slow you down.",
     ratio: 4.0,
     resident: false,
     config: 'KVCacheConfig(method="kivi", bit_width_inlier=2)',
@@ -350,17 +383,19 @@ function readSharedShape() {
 // estimateKvFp16Mb and render "NaN MB" / "NaN%" across every card and bar.
 // Throws a clear, field-named message the panels surface as .pg-error —
 // the same failure path runRecommender already uses for the engine's throws.
+// Labels here must match what the field is actually called on screen, or the
+// error names a control the reader cannot find.
 const SHAPE_FIELDS = [
   ["n_layers", "Layers"],
   ["n_kv_heads", "KV heads"],
-  ["head_dim", "Head dim"],
-  ["seq_len", "Sequence length"],
+  ["head_dim", "Head dimension"],
+  ["seq_len", "Conversation length"],
 ];
 function assertValidShape(shape) {
   for (const [key, label] of SHAPE_FIELDS) {
     const v = shape[key];
     if (!Number.isFinite(v) || v < 1) {
-      throw new Error(`${label} must be a whole number ≥ 1.`);
+      throw new Error(`${label} needs to be a whole number, 1 or more.`);
     }
   }
   return shape;
@@ -588,6 +623,9 @@ function runRecommender() {
   const savedPct = Math.round((1 - res.kv_compressed_mb_estimate / res.kv_fp16_mb) * 100);
   const resident = res.resident_savings_likely;
   const cli = buildCliCommand(req);
+  // The raw ratio still ships — demoted out of the hero into "Why this one".
+  const r = res.key_accounting_ratio;
+  const ratioStr = Number.isInteger(r) ? r.toFixed(0) : r.toFixed(1);
 
   const warnHtml = res.warnings.length
     ? `<div class="pg-callouts">${res.warnings
@@ -599,26 +637,28 @@ function runRecommender() {
         .join("")}</div>`
     : `<div class="pg-callouts"><div class="pg-callout pg-callout-ok">
         <span class="pg-callout-ic" aria-hidden="true">✓</span>
-        <span>No warnings for this configuration.</span></div></div>`;
+        <span>Nothing to watch out for — this setup is a comfortable fit.</span></div></div>`;
 
-  // Pattern 1 — headline stat-card row (ratio · saved · resident state).
+  // Pattern 1 — headline stat-card row. Leads with the percentage because it
+  // is true for every method (see updateHeadline); the raw key-accounting
+  // ratio is demoted into the "How this works" band below, where the
+  // technical detail belongs.
   const statRow = renderStatRow(
     renderStatCard({
-      label: "Key-accounting ratio",
-      value: "0×",
-      id: "pg-hero-ratio",
-      to: res.key_accounting_ratio,
-    }) +
-    renderStatCard({
-      label: "KV cache saved",
+      label: "Smaller by",
       value: "0%",
+      hi: true,
       id: "pg-hero-saved",
       to: savedPct,
     }) +
+    renderStatCard({
+      label: "Notes take up",
+      value: `${fmtMb(res.kv_fp16_mb)} → ${fmtMb(res.kv_compressed_mb_estimate)}`,
+    }) +
     renderStatStatus({
-      label: "Resident RAM",
-      text: resident ? "Frees RAM" : "Accounting-only",
-      sub: resident ? "full-KV path" : "ratio still valid",
+      label: "Frees actual RAM?",
+      text: resident ? "Yes" : "Not on short chats",
+      sub: resident ? "shrinks live memory too" : "but the size drop is real",
       ok: resident,
     })
   );
@@ -626,67 +666,65 @@ function runRecommender() {
   // Pattern 3 — split-metric MODEL SHAPE readout above the memory bar.
   const splitCard = `<div class="pg-split">
     <div class="pg-split-cell">
-      <span class="pg-stat-lbl">KV @ fp16</span>
+      <span class="pg-stat-lbl">Without VeloxQuant</span>
       <span class="pg-stat-num">${esc(fmtMb(res.kv_fp16_mb))}</span>
     </div>
     <div class="pg-split-cell">
-      <span class="pg-stat-lbl">KV compressed</span>
+      <span class="pg-stat-lbl">With VeloxQuant</span>
       <span class="pg-stat-num">${esc(fmtMb(res.kv_compressed_mb_estimate))}</span>
     </div>
   </div>`;
 
   // Pattern 4 — copyable rows: reproduce-in-terminal CLI + knobs.
   const reproRows =
-    renderCopyRow("Reproduce in terminal", cli, "Copy CLI command") +
-    (knobsInline ? renderCopyRow("Knobs", knobsInline, "Copy knobs") : "");
+    renderCopyRow("Check this on your own Mac", cli, "Copy the command") +
+    (knobsInline ? renderCopyRow("Settings used", knobsInline, "Copy the settings") : "");
 
   $("rec-output").innerHTML = `
     <div class="pg-hero">
       <div class="pg-hero-head">
         <div class="pg-hero-badge">
-          <span class="pg-hero-badge-k">Recommended</span>
+          <span class="pg-hero-badge-k">Use this</span>
           <span class="pg-badge-method">${esc(res.method)}</span>
         </div>
         <span class="pg-pill ${resident ? "pg-pill-ok" : "pg-pill-muted"}">
-          ${resident ? "frees resident RAM" : "accounting-only"}
+          ${resident ? "gives memory back" : "smaller, but not always freed"}
           <button type="button" class="pg-tip" tabindex="0"
             aria-label="What does this mean?"
             data-tip="${resident
-              ? "This path actually shrinks the resident KV footprint in RAM, not just the accounting ratio."
-              : "The compression ratio is real, but the default path may keep an fp16 parent cache — so resident RAM may not drop at short context."}">?</button>
+              ? "This one shrinks the notes in memory as well as on paper, so your Mac really does get the space back."
+              : "The size drop is real, but this method unpacks each value again as it reads it — so on short chats your Mac may not actually free that memory."}">?</button>
         </span>
       </div>
 
       ${statRow}
 
-      ${renderBand("Recommended method", "cpu",
-        `<p class="pg-rationale">${esc(res.rationale)}</p>${knobsHtml}`)}
+      ${renderBand("Why this one", "cpu",
+        `<p class="pg-rationale">${esc(res.rationale)}</p>
+         <p class="pg-rationale-tech">Shrinks the key half of the cache about
+           <strong>${ratioStr}×</strong>.</p>${knobsHtml}`)}
 
-      ${renderBand("Memory vs context", "memory",
+      ${renderBand("How much space this saves", "memory",
         splitCard + renderMemoryBar(res.kv_fp16_mb, res.kv_compressed_mb_estimate, savedPct, "rec"))}
 
-      ${renderBand("Reproduce", "terminal", `<div class="pg-rows">${reproRows}</div>`)}
+      ${renderBand("Run this yourself", "terminal", `<div class="pg-rows">${reproRows}</div>`)}
 
-      ${renderBand("Notes & warnings", "warning", warnHtml)}
+      ${renderBand("Things to know", "warning", warnHtml)}
 
       <div class="pg-cta-row">
         <button type="button" class="pg-cta pg-cta-primary" id="pg-cta-lab"
           data-method="${esc(REC_TO_LAB_METHOD[res.method] || "turboquant_rvq")}">
-          Open in Compression Lab →
+          See how much fits →
         </button>
         <button type="button" class="pg-cta pg-cta-ghost" id="pg-cta-bench"
           data-bench="${esc(METHOD_TO_BENCH[res.method] || "metal")}">
-          See the benchmark →
+          Show me the proof →
         </button>
       </div>
     </div>
   `;
 
-  // Count the stat cards up and animate the bar after paint.
-  countUp($("pg-hero-ratio"), res.key_accounting_ratio, (v) => {
-    const r = Math.round(v * 10) / 10;
-    return (Number.isInteger(r) ? r.toFixed(0) : r.toFixed(1)) + "×";
-  });
+  // Count the stat card up and animate the bar after paint.
   countUp($("pg-hero-saved"), savedPct, (v) => Math.round(v) + "%");
   animateMemoryBar("rec", savedPct);
   wireCopyRows($("rec-output"));
@@ -715,18 +753,18 @@ function renderMemoryBar(fp16Mb, compMb, savedPct, scope) {
   return `
     <div class="pg-membar" data-scope="${scope}" data-comp-pct="${compPct.toFixed(2)}">
       <div class="pg-membar-row">
-        <span class="pg-membar-label">fp16 KV</span>
+        <span class="pg-membar-label">normally</span>
         <div class="pg-membar-track"><div class="pg-membar-fill fp16" style="width:100%"></div></div>
         <span class="pg-membar-val">${fmtMb(fp16Mb)}</span>
       </div>
       <div class="pg-membar-row">
-        <span class="pg-membar-label">compressed</span>
+        <span class="pg-membar-label">with VeloxQuant</span>
         <div class="pg-membar-track">
           <div class="pg-membar-fill comp" style="width:${startPct}%"></div>
         </div>
         <span class="pg-membar-val">${fmtMb(compMb)}</span>
       </div>
-      <p class="pg-saved">≈ <strong class="pg-saved-num" id="pg-saved-${scope}">${savedPct}%</strong> smaller KV cache</p>
+      <p class="pg-saved">≈ <strong class="pg-saved-num" id="pg-saved-${scope}">${savedPct}%</strong> less memory for the same conversation</p>
     </div>`;
 }
 
@@ -752,15 +790,18 @@ function animateMemoryBar(scope, savedPct) {
   countUp(savedEl, savedPct, (v) => Math.round(v) + "%");
 }
 
-/* Animated headline metric — "Fit up to N× more context on your Mac".
-   N is the recommender's own ratio; null clears it (on an input error). */
+/* Animated headline metric — "Your chatbot's notes get N% smaller."
+   Deliberately states the *size reduction*, not a context multiplier: the
+   percentage is unconditionally true for every method, whereas "N× more
+   context" is only true when resident_savings_likely, so the old headline
+   made a claim the accounting-only caveat further down had to walk back. */
 function updateHeadline(res) {
   const el = $("pg-headline");
   if (!el) return;
   if (!res) { el.textContent = ""; return; }
-  const r = res.key_accounting_ratio;
-  const rStr = Number.isInteger(r) ? r.toFixed(0) : r.toFixed(1);
-  el.innerHTML = `Fit up to <strong>${rStr}×</strong> more context on your Mac.`;
+  const savedPct = Math.round((1 - res.kv_compressed_mb_estimate / res.kv_fp16_mb) * 100);
+  el.innerHTML =
+    `Your chatbot's notes get <strong>${savedPct}% smaller</strong>.`;
 }
 
 /* ---------- Tab 2: Compression lab ---------- */
@@ -838,8 +879,8 @@ function writeBudget(gb, isAuto) {
   btn.classList.toggle("active", isAuto);
   const src = $("pg-budget-src");
   src.textContent = isAuto
-    ? `from ${parseInt($("pg-ram").value, 10)} GB Mac · auto`
-    : "manual";
+    ? `worked out from your ${parseInt($("pg-ram").value, 10)} GB Mac`
+    : "your own figure";
 }
 
 // User edited the number directly → drop to manual and recompute.
@@ -876,7 +917,7 @@ function runCompressionLab() {
   // framing the README uses for RaBitQ ("~103k tokens at 8 GB").
   const budgetGb = parseFloat($("pg-budget").value);
   if (!Number.isFinite(budgetGb) || budgetGb < MIN_KV_BUDGET_GB) {
-    $("lab-output").innerHTML = `<p class="pg-error">RAM budget for KV must be a number ≥ ${MIN_KV_BUDGET_GB} GB.</p>`;
+    $("lab-output").innerHTML = `<p class="pg-error">Memory you can spare needs to be ${MIN_KV_BUDGET_GB} GB or more.</p>`;
     return;
   }
   const budgetMb = budgetGb * 1024;
@@ -894,27 +935,30 @@ function runCompressionLab() {
   // mirroring resident_savings_likely in the recommender. Label it either way
   // so the lab keeps the same "nothing is faked" promise as the recommender.
   const residentCaveat = m.resident
-    ? `<p class="pg-lab-caveat is-ok">Full-KV path — this ${ratio}× reflects real resident-RAM savings.</p>`
-    : `<p class="pg-lab-caveat is-warn"><strong>Accounting-only:</strong> the ${ratio}× is a key-accounting bound.
-        This method's default path may keep an fp16 parent cache, so resident RAM
-        may not drop by the full factor at short context.</p>`;
+    ? `<p class="pg-lab-caveat is-ok">This method compresses the whole cache, so
+        your Mac really does get this memory back.</p>`
+    : `<p class="pg-lab-caveat is-warn"><strong>Worth knowing:</strong> this method
+        unpacks each value again as it reads it, so on shorter chats your Mac may
+        not free the full ${ratio}×. The size figure is honest — treat it as how well
+        the data compresses, not as memory handed back.</p>`;
 
   // At the derived floor, weights + OS reserve leave almost nothing for KV —
   // surface why, using the same framing as the recommender's headroom warning.
   const budgetFloorCaveat =
     autoBudget && deriveKvBudgetGb(parseInt($("pg-ram").value, 10), $("pg-model").value) <= MIN_KV_BUDGET_GB
-      ? `<p class="pg-lab-caveat is-warn">On this machine, weights + OS reserve leave little RAM for KV —
-          consider a smaller model, more RAM, or eviction (goal = constant memory).</p>`
+      ? `<p class="pg-lab-caveat is-warn">On this Mac, the model itself plus macOS leave
+          very little memory for the notes. Consider a smaller model, a Mac with more
+          memory, or the "never grow past a fixed memory limit" option.</p>`
       : "";
 
   // Pattern 1 — headline 2-card stat row: tokens @ fp16 vs with <method>.
   const statRow = renderStatRow(
     renderStatCard({
-      label: `Tokens @ fp16 · ${budgetGb} GB`,
+      label: `Words that fit in ${budgetGb} GB — normally`,
       value: tokensFp16.toLocaleString(),
     }) +
     renderStatCard({
-      label: `Tokens with ${m.short} · ${budgetGb} GB`,
+      label: `Words that fit with ${m.short}`,
       value: tokensComp.toLocaleString(),
       hi: true,
       id: "pg-tok-comp",
@@ -930,20 +974,20 @@ function runCompressionLab() {
 
     ${statRow}
 
-    ${renderBand("Context that fits", "chart",
+    ${renderBand("How long a conversation fits", "chart",
       `<p class="pg-book">≈ <strong>${book.pages.toLocaleString()} pages</strong> — about ${book.tangible}
-        <span class="pg-approx">approx · ~${TOKENS_PER_PAGE} tokens/page</span></p>
-       <p class="pg-saved">${ratio}× more context in the same RAM budget (KV-only linear estimate).</p>
+        <span class="pg-approx">rough estimate · counting ~${TOKENS_PER_PAGE} words a page</span></p>
+       <p class="pg-saved">That's ${ratio}× longer than you'd fit without it, in the same memory.</p>
        ${residentCaveat}
        ${budgetFloorCaveat}`)}
 
-    ${renderBand("Memory", "memory",
+    ${renderBand("Space used", "memory",
       renderMemoryBar(round2(fp16Mb), round2(compMb), savedPct, "lab"))}
 
-    ${renderBand("Integration snippet", "code",
+    ${renderBand("Add this to your code", "code",
       `<div class="pg-snippet">
         <div class="pg-snippet-head">
-          <span class="pg-snippet-note">Runs on any <code>mlx_lm</code> model</span>
+          <span class="pg-snippet-note">Three lines. Works with any <code>mlx_lm</code> model.</span>
           <button class="pg-copy" data-snippet>Copy</button>
         </div>
         <pre><code class="pg-code">${highlightSnippet(snippetFor(methodKey))}</code></pre>
@@ -1083,14 +1127,14 @@ async function runBenchViewer() {
     out.innerHTML = `<div class="pg-skeleton" aria-hidden="true">
       <div class="pg-skel-legend"><span></span><span></span></div>
       <div class="pg-skel-chart"></div>
-    </div><p class="pg-caption pg-muted">Loading measured benchmark data…</p>`;
+    </div><p class="pg-caption pg-muted">Loading the measured results…</p>`;
   }
 
   let data;
   try {
     data = await loadBench();
   } catch (e) {
-    out.innerHTML = `<p class="pg-error">Could not load benchmark data.</p>`;
+    out.innerHTML = `<p class="pg-error">Couldn't load the benchmark results. Try refreshing the page.</p>`;
     return;
   }
 
@@ -1107,7 +1151,8 @@ async function runBenchViewer() {
       yLabel: "speedup ×",
       valFmt: (v) => v.toFixed(1) + "×",
     });
-    caption = "Hand-written Metal quantize kernel vs pure-MLX, by sequence length S (B=1, H=8, D=128).";
+    caption = "How much faster our hand-written Apple GPU code compresses the cache, compared " +
+      "with doing the same work in plain MLX. Higher is better; S is the conversation length.";
     source = "figures/metal/results.json";
   } else if (which === "rabitq") {
     const rows = data.rabitq_falcon_memory;
@@ -1123,7 +1168,8 @@ async function runBenchViewer() {
       yLabel: "KV size (MB)",
       valFmt: (v) => v.toFixed(0),
     });
-    caption = "Full-KV memory, Falcon3-7B shape: fp16 vs RaBitQ (~5.95× smaller).";
+    caption = "Actual memory used by the notes on a Falcon3-7B model, with and without " +
+      "RaBitQ — about 5.95× smaller. Shorter bars are better.";
     source = "figures/RaBitQ/falcon/results.json";
   } else {
     // KIVI per-model throughput retention
@@ -1141,13 +1187,15 @@ async function runBenchViewer() {
       yLabel: "value",
       valFmt: (v) => (v >= 20 ? v.toFixed(0) : v.toFixed(2)),
     });
-    caption = `KIVI on ${model} (${m.chip}, ${m.ram_gb} GB): throughput retention vs key compression.`;
+    caption = `KIVI running ${model} on an ${m.chip} with ${m.ram_gb} GB. Blue shows how much ` +
+      "of the original speed is kept; purple shows how much smaller the cache got.";
     source = "figures/kivi/results_summary.json";
   }
 
-  out.innerHTML = `${renderBand("Chart", "chart", chart)}
+  out.innerHTML = `${renderBand("Measured results", "chart", chart)}
     <p class="pg-provenance"><span class="pg-prov-dot" aria-hidden="true"></span>
-      Measured on real hardware · source <code>${source}</code></p>
+      Measured on a real Mac, not estimated · you can check the raw numbers in
+      <code>${source}</code></p>
     <p class="pg-caption">${caption}</p>`;
 
   growBars(out);
@@ -1248,6 +1296,21 @@ function selectBench(key) {
   runBenchViewer();
 }
 
+// Translate the raw conversation length into pages, so the number under the
+// field means something without knowing what a token is. Reuses bookScale so
+// the page count here and in the lab can never disagree.
+function updateSeqHint() {
+  const hint = $("pg-seq-hint");
+  if (!hint) return;
+  const seq = parseInt($("pg-seqlen").value, 10);
+  if (!Number.isFinite(seq) || seq < 1) {
+    hint.textContent = "";
+    return;
+  }
+  const { pages } = bookScale(seq);
+  hint.textContent = `${seq.toLocaleString()} words ≈ ${pages.toLocaleString()} page${pages === 1 ? "" : "s"}`;
+}
+
 // Reflect the current architecture shape in the collapsed Advanced summary,
 // so a newcomer sees what's inside without expanding it.
 function updateAdvancedHint() {
@@ -1266,6 +1329,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const recompute = () => {
     markActivePreset();
     updateAdvancedHint();
+    updateSeqHint();
     runRecommender();
     runCompressionLab();
   };
@@ -1352,6 +1416,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   markActivePreset();
   updateAdvancedHint();
+  updateSeqHint();
   renderSegmentedBench(); // reflects any restored ?bench= value
   syncBenchModelPicker();
   runRecommender();

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -1878,6 +1878,36 @@ footer {
   color: var(--accent);
   font-variant-numeric: tabular-nums;
 }
+/* Plain-language primer — collapsed by default so it never gets between a
+   returning visitor and the controls, but defines "KV cache" for a newcomer
+   before any control asks them to care about it. */
+.pg-primer {
+  max-width: 640px;
+  margin: 1.4rem auto 0;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card-bg, var(--bg));
+}
+.pg-primer summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.7rem 1rem;
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.pg-primer summary::-webkit-details-marker { display: none; }
+.pg-primer summary::before { content: "▸ "; color: var(--accent); }
+.pg-primer[open] summary::before { content: "▾ "; }
+.pg-primer p {
+  margin: 0 1rem 0.9rem;
+  font-size: 0.86rem;
+  color: var(--muted);
+  line-height: 1.65;
+}
+.pg-primer strong { color: var(--text); }
+
 .pg-trust {
   max-width: 660px;
   margin: 0.9rem auto 0;
@@ -1916,6 +1946,9 @@ footer {
   gap: 0.9rem;
 }
 .pg-field-chip { flex: 1 1 150px; }
+/* The goal labels are full phrases now, not enum names — give the select
+   room to show them instead of truncating mid-sentence. */
+.pg-field-goal { flex: 2 1 260px; }
 .pg-share-btn {
   margin-left: auto;
   align-self: flex-end;
@@ -1992,8 +2025,27 @@ footer {
 .pg-preset-custom { font-style: italic; }
 .pg-preset-custom.active { font-style: normal; }
 
+/* Conversation length — promoted out of Advanced, so it sits in the main bar
+   with a plain-language hint underneath translating tokens into pages. */
+.pg-field-seq { margin-top: 0.9rem; }
+.pg-seq-control { display: flex; align-items: center; gap: 0.5rem; }
+.pg-seq-control input { flex: 0 1 10rem; }
+.pg-seq-unit { font-size: 0.78rem; color: var(--muted); white-space: nowrap; }
+.pg-seq-hint {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
 /* Advanced disclosure */
 .pg-advanced { margin-top: 0.9rem; border-top: 1px solid var(--border); padding-top: 0.75rem; }
+.pg-adv-note {
+  margin: 0.7rem 0 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
 .pg-advanced summary {
   display: flex;
   align-items: baseline;
@@ -2172,6 +2224,17 @@ footer {
 .pg-hero-metric-lbl { color: var(--muted); font-size: 0.9rem; }
 
 .pg-rationale { color: var(--muted); line-height: 1.6; margin-bottom: 0.85rem; }
+/* The raw compression ratio, demoted here from the hero stat row. */
+.pg-rationale-tech {
+  font-size: 0.84rem;
+  color: var(--muted);
+  margin-bottom: 0.85rem;
+}
+.pg-rationale-tech strong {
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
 .pg-ratio { font-weight: 600; color: var(--text); font-family: 'JetBrains Mono', monospace; }
 
 /* Knob chips */
@@ -2476,7 +2539,8 @@ footer {
 #playground .pg-copy:focus-visible,
 #playground .pg-share-btn:focus-visible,
 #playground .pg-tip:focus-visible,
-#playground .pg-advanced summary:focus-visible {
+#playground .pg-advanced summary:focus-visible,
+#playground .pg-primer summary:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -2492,7 +2556,7 @@ footer {
   .pg-token-grid { grid-template-columns: 1fr; }
   .pg-membar-label { flex-basis: 66px; }
   .pg-membar-val { flex-basis: 76px; }
-  .pg-field-chip { flex-basis: 100%; }
+  .pg-field-chip, .pg-field-goal { flex-basis: 100%; }
   .pg-hero-head { justify-content: flex-start; }
   .pg-cta { flex: 1 1 100%; text-align: center; }
 }

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -7,7 +7,7 @@
   <title>Playground — VeloxQuant-MLX</title>
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg?v=2" />
   <link rel="shortcut icon" href="assets/favicon.svg?v=2" />
-  <meta name="description" content="Interactive VeloxQuant-MLX playground: pick your Mac chip, RAM, model size and goal to get a recommended KV-cache compression method, explore how much context fits in your RAM, and browse real measured Metal / RaBitQ / KIVI benchmarks — all computed in your browser." />
+  <meta name="description" content="Pick your Mac and the model you want to run, and see which VeloxQuant-MLX setting to use, how long a conversation fits in your RAM, and the measured benchmarks behind it — all worked out in your browser, nothing sent anywhere." />
   <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
        third-party hop, no render-blocking preconnect. -->
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
@@ -56,20 +56,39 @@
   <!-- ── PLAYGROUND ── -->
   <main id="playground">
     <header class="pg-header">
-      <span class="pg-eyebrow">Interactive · runs in your browser</span>
-      <h1>Feel the power of <span>VeloxQuant-MLX</span></h1>
+      <span class="pg-eyebrow">Free · runs in your browser · nothing is sent anywhere</span>
+      <h1>Run bigger models on the <span>Mac you already have</span></h1>
       <p class="pg-sub">
-        Dial in your Mac, model and goal — see the recommended compression method,
-        how much more context fits in your RAM, and real measured benchmarks.
+        Tell us your Mac and what you want to run. We'll show you which setting
+        to use and how long a conversation will fit in your memory.
       </p>
       <p class="pg-headline" id="pg-headline" aria-live="polite">
         <!-- animated headline metric injected by playground.js -->
       </p>
+
+      <!-- Plain-language primer: the page's central noun, defined once, up
+           front, before any control asks the visitor to care about it. -->
+      <details class="pg-primer">
+        <summary>New here? What this actually does</summary>
+        <p>
+          As a chatbot reads your conversation it keeps notes on every word so
+          far, so it doesn't have to re-read everything to write the next word.
+          Those notes are called the <strong>KV cache</strong>, and they live in
+          your Mac's memory. The longer the conversation, the bigger they get —
+          and on a Mac, memory is the wall you hit first.
+        </p>
+        <p>
+          VeloxQuant-MLX stores those notes in a more compact form. Smaller
+          notes mean longer conversations, or a bigger model, in the same Mac.
+          This page works out which approach suits your machine.
+        </p>
+      </details>
+
       <p class="pg-trust">
-        Every number is computed live from the same heuristic that ships in
-        <code>veloxquant recommend</code> — a direct port of
-        <code>mac_recommender.py</code> — or read from committed benchmark data.
-        <strong>Nothing is faked.</strong>
+        Every number here is worked out live from the same code that ships in the
+        tool itself, or read from real benchmark runs we've committed to the
+        repository. <strong>Nothing is made up</strong>, and where a number is an
+        estimate rather than a measurement, we say so.
       </p>
     </header>
 
@@ -98,39 +117,59 @@
             <option value="128">128 GB</option>
           </select>
         </div>
-        <div class="pg-field pg-field-chip">
-          <label for="pg-goal">Goal</label>
+        <div class="pg-field pg-field-goal">
+          <label for="pg-goal">What matters most</label>
+          <!-- Values are the recommender's own goal enum and must not change:
+               they are the API contract and the ?goal= share-link key. Only
+               the visible labels are consumer-facing. -->
           <select id="pg-goal">
-            <option value="everyday" selected>Everyday (zero-calibration)</option>
-            <option value="max_key_accounting">Max key accounting (~16×)</option>
-            <option value="max_context">Max context (full-KV)</option>
-            <option value="best_quality">Best quality</option>
-            <option value="constant_memory">Constant memory (eviction)</option>
+            <option value="everyday" selected>Just work well by default</option>
+            <option value="max_key_accounting">Squeeze the cache as small as possible</option>
+            <option value="max_context">Fit the longest conversation</option>
+            <option value="best_quality">Keep answers as accurate as possible</option>
+            <option value="constant_memory">Never grow past a fixed memory limit</option>
           </select>
         </div>
         <button type="button" class="pg-share-btn" id="pg-share-btn"
-                title="Copy a link that restores this exact setup">
-          <span aria-hidden="true">🔗</span> Copy my setup
+                title="Copy a link that brings you back to exactly this setup">
+          <span aria-hidden="true">🔗</span> Save my setup
         </button>
       </div>
 
       <!-- Model presets — one click fills the shape fields -->
-      <div class="pg-presets" role="group" aria-label="Start from a model">
-        <span class="pg-presets-label">Start from a model</span>
+      <div class="pg-presets" role="group" aria-label="Pick the model you want to run">
+        <span class="pg-presets-label">Which model do you want to run?</span>
         <div class="pg-preset-row" id="pg-preset-row">
           <!-- chips injected by playground.js -->
         </div>
       </div>
 
+      <!-- Conversation length lives in the main bar, not under Advanced: it is
+           the most intuitive knob on the page and the one a newcomer most wants
+           to move. The id and its ?seq= share-link key are unchanged. -->
+      <div class="pg-field pg-field-seq">
+        <label for="pg-seqlen">How long is your conversation?</label>
+        <div class="pg-seq-control">
+          <input id="pg-seqlen" type="number" min="1" step="256" value="4096"
+                 inputmode="numeric" aria-describedby="pg-seq-hint" />
+          <span class="pg-seq-unit" aria-hidden="true">words-ish</span>
+        </div>
+        <span id="pg-seq-hint" class="pg-seq-hint" aria-live="polite"></span>
+      </div>
+
       <!-- Advanced disclosure — raw architecture fields -->
       <details class="pg-advanced" id="pg-advanced">
         <summary>
-          <span class="pg-adv-label">Advanced — architecture shape</span>
+          <span class="pg-adv-label">Advanced — exact model shape</span>
           <span class="pg-adv-hint" id="pg-adv-hint"></span>
         </summary>
+        <p class="pg-adv-note">
+          Only needed if your model isn't listed above. Picking a model sets
+          these for you.
+        </p>
         <div class="pg-adv-grid">
           <div class="pg-field">
-            <label for="pg-model">Model class</label>
+            <label for="pg-model">Model size</label>
             <select id="pg-model">
               <option value="1B">1B</option>
               <option value="3B">3B</option>
@@ -138,10 +177,6 @@
               <option value="14B">14B</option>
               <option value="32B">32B</option>
             </select>
-          </div>
-          <div class="pg-field">
-            <label for="pg-seqlen">Sequence length</label>
-            <input id="pg-seqlen" type="number" min="1" step="256" value="4096" inputmode="numeric" />
           </div>
           <div class="pg-field">
             <label for="pg-layers">Layers</label>
@@ -152,7 +187,7 @@
             <input id="pg-heads" type="number" min="1" step="1" value="8" inputmode="numeric" />
           </div>
           <div class="pg-field">
-            <label for="pg-headdim">Head dim</label>
+            <label for="pg-headdim">Head dimension</label>
             <input id="pg-headdim" type="number" min="1" step="8" value="128" inputmode="numeric" />
           </div>
         </div>
@@ -164,17 +199,17 @@
       <button class="pg-step active" data-pgtab="rec" role="tab" id="pg-tab-rec"
               aria-selected="true" aria-controls="pg-panel-rec">
         <span class="pg-step-num">1</span>
-        <span class="pg-step-txt"><strong>Recommend</strong><em>a method for your setup</em></span>
+        <span class="pg-step-txt"><strong>What should I use?</strong><em>the right setting for your Mac</em></span>
       </button>
       <button class="pg-step" data-pgtab="lab" role="tab" id="pg-tab-lab"
               aria-selected="false" aria-controls="pg-panel-lab" tabindex="-1">
         <span class="pg-step-num">2</span>
-        <span class="pg-step-txt"><strong>Explore</strong><em>context you can fit</em></span>
+        <span class="pg-step-txt"><strong>How much fits?</strong><em>conversation length in your RAM</em></span>
       </button>
       <button class="pg-step" data-pgtab="bench" role="tab" id="pg-tab-bench"
               aria-selected="false" aria-controls="pg-panel-bench" tabindex="-1">
         <span class="pg-step-num">3</span>
-        <span class="pg-step-txt"><strong>Verify</strong><em>real measured benchmarks</em></span>
+        <span class="pg-step-txt"><strong>Is this real?</strong><em>benchmarks we measured</em></span>
       </button>
     </div>
 
@@ -188,7 +223,7 @@
     <section class="pg-panel" id="pg-panel-lab" role="tabpanel"
              aria-labelledby="pg-tab-lab" tabindex="0">
       <div class="pg-lab-controls">
-        <span class="pg-controls-label" id="pg-method-label">Method</span>
+        <span class="pg-controls-label" id="pg-method-label">Try a different approach</span>
         <!-- Hidden input holds the selected method so URL state, the engine,
              and the recommender CTA can all read/write one source of truth. -->
         <input type="hidden" id="pg-cmethod" value="turboquant_rvq" />
@@ -197,7 +232,7 @@
           <!-- method cards injected by playground.js -->
         </div>
         <div class="pg-field pg-field-budget">
-          <label for="pg-budget-input" id="pg-budget-label">RAM budget for KV</label>
+          <label for="pg-budget-input" id="pg-budget-label">Memory you can spare</label>
           <!-- Hidden input remains the single source of truth for URL state + engine. -->
           <input type="hidden" id="pg-budget" value="" />
           <div class="pg-budget-control">
@@ -206,7 +241,7 @@
             <span class="pg-budget-unit" aria-hidden="true">GB</span>
             <button type="button" id="pg-budget-auto" class="pg-budget-auto"
                     aria-pressed="true"
-                    title="Match the RAM free for KV on your selected Mac">Auto</button>
+                    title="Work this out from the Mac you picked above">Auto</button>
           </div>
           <span id="pg-budget-src" class="pg-budget-src" aria-live="polite"></span>
         </div>
@@ -219,7 +254,7 @@
              aria-labelledby="pg-tab-bench" tabindex="0">
       <div class="pg-lab-controls">
         <div class="pg-field pg-field-bench">
-          <label id="pg-bench-label">Benchmark</label>
+          <label id="pg-bench-label">Which result?</label>
           <!-- Hidden input remains the single source of truth (URL state,
                engine, hero CTA all read/write it); the segmented control
                below is the accessible view over it. -->
@@ -241,12 +276,15 @@
     </section>
 
     <p class="pg-disclaimer">
-      Recommender + compression estimates are transparent heuristics (a direct port of
-      <code>veloxquant_mlx/tools/mac_recommender.py</code>) — they state when resident RAM
-      savings are unlikely. Token counts and the book comparison are linear KV
-      extrapolations, labelled as approximations. Benchmark charts read measured values
-      committed under <code>figures/</code>. For live numbers on your own machine, run
-      <code>python -m veloxquant_mlx benchmark</code>.
+      <strong>Where these numbers come from.</strong> The recommendation and the
+      cache sizes are calculated, not measured — they use the same rules as the
+      <code>veloxquant recommend</code> command
+      (<code>veloxquant_mlx/tools/mac_recommender.py</code>), and they tell you
+      when a method is unlikely to free real memory rather than quietly
+      overstating it. Conversation lengths and the page comparison are estimates
+      that assume memory grows evenly with length. The charts in step 3 are real
+      measurements committed under <code>figures/</code>. To measure your own Mac
+      instead of estimating, run <code>python -m veloxquant_mlx benchmark</code>.
     </p>
   </main>
 

--- a/veloxquant_mlx/tools/mac_recommender.py
+++ b/veloxquant_mlx/tools/mac_recommender.py
@@ -75,19 +75,33 @@ def recommend(req: RecommendRequest) -> RecommendResult:
     # Leave ~4 GB for OS + apps; activations need headroom too
     headroom_gb = req.ram_gb - weight_gb - 4.0
     if headroom_gb < 3.0:
-        warnings.append(
-            f"{req.model_class} 4-bit weights (~{weight_gb} GB) leave little "
-            f"headroom on {req.ram_gb} GB (est. headroom {headroom_gb:.1f} GB). "
-            "Prefer a smaller model, eviction, or full-KV compression."
-        )
+        # Negative headroom means the weights alone overrun the machine, so say
+        # "will not fit" rather than "barely fits" — the softer phrasing would
+        # read as a caution about a setup that is in fact impossible.
+        if headroom_gb < 0:
+            warnings.append(
+                f"A {req.model_class} model will not fit in {req.ram_gb} GB. Its "
+                f"weights alone need ~{weight_gb} GB, which is more than this Mac "
+                f"has once macOS takes its share — you are about "
+                f"{abs(headroom_gb):.1f} GB short of any headroom. Pick a smaller "
+                "model."
+            )
+        else:
+            warnings.append(
+                f"A {req.model_class} model barely fits in {req.ram_gb} GB. Its "
+                f"weights alone take ~{weight_gb} GB, leaving about "
+                f"{headroom_gb:.1f} GB of headroom for everything else. Try a "
+                "smaller model, or pick a goal that caps memory."
+            )
 
     kv_fp16 = estimate_kv_fp16_mb(req.n_layers, req.n_kv_heads, req.head_dim, req.seq_len)
 
     # Tiny-model Metal overhead warning (chip generation does not remove this)
     if req.model_class == "1B":
         warnings.append(
-            "Metal kernel launch overhead can dominate on tiny models; "
-            "prefer RVQ or disable Metal if tok/s drops."
+            "On a model this small the GPU spends more time starting work than "
+            "doing it, so compression can actually slow generation down. If speed "
+            "drops, switch to turboquant_rvq or turn the Metal kernels off."
         )
 
     tight = req.ram_gb <= 16 or headroom_gb < 3.0
@@ -97,13 +111,17 @@ def recommend(req: RecommendRequest) -> RecommendResult:
         ratio = 7.5
         resident = False
         rationale = (
-            "Zero-calibration default. Key accounting ~7.5x at head_dim=128. "
-            "Default path dequantizes into parent fp16 cache."
+            "The safe everyday pick: it works out of the box with no setup step, "
+            "and shrinks the key half of the cache by about 7.5x. It unpacks each "
+            "value back to full precision as it is read, so this is a size "
+            "measurement rather than a drop in live memory use."
         )
         if tight and req.model_class in ("7B", "14B", "32B"):
             warnings.append(
-                "Tight RAM with a mid/large model: consider goal=max_context "
-                "(rabitq) or goal=constant_memory (eviction) for long prompts."
+                "RAM is tight for a model this size. For long prompts you will get "
+                "more out of 'Fit the longest conversation' (rabitq), which "
+                "compresses the whole cache, or 'Never grow past a fixed memory "
+                "limit' (streaming_llm), which caps it outright."
             )
 
     elif req.goal == "max_key_accounting":
@@ -114,48 +132,56 @@ def recommend(req: RecommendRequest) -> RecommendResult:
             "key_sub_dim": 8,
             "value_sub_dim": 8,
             "use_metal_kernels": None,
-            "note": "Requires one-time codebook calibration",
+            "note": "Needs a one-time setup pass over sample data before first use",
         }
         ratio = 16.0
         resident = False
         rationale = (
-            "Product VQ 1-bit path targets ~16x key accounting when "
-            "head_dim is divisible by sub_dim=8. Needs calibration."
+            "The smallest key cache on offer, around 16x. The trade is a one-time "
+            "setup pass over sample data before you can use it, and the same "
+            "unpack-on-read caveat as the everyday option."
         )
         if req.head_dim % 8 != 0:
             warnings.append(
-                f"head_dim={req.head_dim} is not divisible by 8; "
-                "VecInfer sub_dim must divide head_dim."
+                f"This model will not work with vecinfer: it splits each vector "
+                f"into groups of 8, and this model's head dimension "
+                f"({req.head_dim}) does not divide evenly by 8."
             )
 
     elif req.goal == "best_quality":
         method = "spectral"
-        knobs = {"bit_width_inlier": 3, "note": "Requires spectral rotation calibration"}
+        knobs = {
+            "bit_width_inlier": 3,
+            "note": "Needs a one-time setup pass over sample data before first use",
+        }
         ratio = 5.3
         resident = False
         rationale = (
-            "SpectralQuant targets better reconstruction at moderate "
-            "compression via eigenbasis rotation (calibration required)."
+            "Compresses less (about 5.3x) but reconstructs the cache more "
+            "faithfully, so answers stay closest to the uncompressed model. "
+            "Needs a one-time setup pass over sample data."
         )
 
     elif req.goal == "max_context":
         if tight:
             method = "rabitq"
-            knobs = {"note": "1-bit keys + MSE-b4 values; prefer fused Metal path when available"}
+            knobs = {"note": "Compresses the whole cache; turn on the Metal kernels if available"}
             ratio = 6.0
             resident = True
             rationale = (
-                "Full-KV compression is more likely to free resident memory "
-                "than key-only accounting methods on tight RAM."
+                "Compresses both halves of the cache, so it genuinely gives RAM "
+                "back rather than only measuring smaller. That matters most on a "
+                "machine as tight as this one."
             )
         else:
             method = "rabitq"
-            knobs = {"note": "Full KV compression for longer context in fixed RAM"}
+            knobs = {"note": "Compresses the whole cache, for longer chats in the same memory"}
             ratio = 6.0
             resident = True
             rationale = (
-                "RaBitQ compresses keys and values. Better candidate for "
-                "real context capacity gains than key-only RVQ accounting."
+                "Compresses both halves of the cache, not just the keys, so the "
+                "space it frees is real. That makes it the better choice when you "
+                "want the longest possible conversation in the RAM you have."
             )
 
     elif req.goal == "constant_memory":
@@ -164,12 +190,15 @@ def recommend(req: RecommendRequest) -> RecommendResult:
         ratio = 1.0
         resident = True
         rationale = (
-            "Structural eviction keeps a fixed sink + window. Cache token "
-            "count stays bounded regardless of generation length."
+            "Keeps the first few tokens plus a sliding window of recent ones and "
+            "discards the rest, so memory use stops growing no matter how long "
+            "the conversation runs."
         )
         warnings.append(
-            "Eviction drops tokens; quality depends on the task. "
-            "For importance-based eviction try method=h2o instead."
+            "This works by forgetting older tokens, so the model can lose track of "
+            "things said early in a long conversation. How much that hurts depends "
+            "on the task. To drop the least-used tokens instead of simply the "
+            "oldest, try method=h2o."
         )
 
     else:
@@ -178,16 +207,19 @@ def recommend(req: RecommendRequest) -> RecommendResult:
     # Chip note: bandwidth/generation matters less than RAM for method pick
     if req.chip in ("M1", "M2") and req.model_class in ("14B", "32B"):
         warnings.append(
-            f"{req.chip} with {req.model_class}: expect lower tok/s; "
-            "memory fit still depends mainly on unified RAM."
+            f"A {req.model_class} model on an {req.chip} will generate text more "
+            "slowly than on a newer chip. Whether it fits at all, though, comes "
+            "down to how much RAM you have rather than which chip it is."
         )
 
     compressed_mb = kv_fp16 / ratio if ratio > 0 else kv_fp16
     # Resident estimate is only meaningful when resident_savings_likely
     if not resident:
         warnings.append(
-            "Resident RSS savings are unlikely at short context for this "
-            "method's default path (accounting ratio still valid)."
+            "This method measures smaller but may not free much actual RAM on "
+            "short prompts, because its default path unpacks values back to full "
+            "precision as it reads them. The size figure is real; treat it as a "
+            "measure of how well the data compresses, not as RAM you get back."
         )
 
     return RecommendResult(


### PR DESCRIPTION
Closes #154.

Rewrites the playground's language and information order for someone who has never heard of a KV cache. **This is a copy and hierarchy change — no computed value moves.**

Because `landing/assets/playground.js` is a hand-maintained 1:1 port of `veloxquant_mlx/tools/mac_recommender.py`, the warning and rationale strings are rewritten **on both sides together**, so `veloxquant recommend` gets the plainer wording rather than drifting from the web page.

---

## The two judgement calls

**The headline no longer promises something the page walks back.** It read *"Fit up to 7.5× more context on your Mac"* — but three sections later the same number carried *"Accounting-only: resident RAM may not drop by the full factor."* The caveat was correct; the headline should not have needed one. It now leads with the **percentage saved**, which is unconditionally true for every method.

**The negative-headroom warning was wrong, not just jargony.** Rewriting it surfaced that `32B on 8 GB` — which is 14 GB short — produced *"barely fits"*. That is a real (if cosmetic) bug: the softer phrasing reads as a caution about a workable setup rather than an impossible one. Negative headroom now says *"will not fit"* and states the shortfall. No numeric output changed; it is a second branch on the same threshold.

---

## Before → after: user-visible copy

### Controls

| | Before | After |
|---|---|---|
| Goal field | `Goal` | `What matters most` |
| goal=everyday | `Everyday (zero-calibration)` | `Just work well by default` |
| goal=max_key_accounting | `Max key accounting (~16×)` | `Squeeze the cache as small as possible` |
| goal=max_context | `Max context (full-KV)` | `Fit the longest conversation` |
| goal=best_quality | `Best quality` | `Keep answers as accurate as possible` |
| goal=constant_memory | `Constant memory (eviction)` | `Never grow past a fixed memory limit` |
| Presets | `Start from a model` | `Which model do you want to run?` |
| Custom chip | `Custom` | `Something else` |
| Advanced | `Advanced — architecture shape` | `Advanced — exact model shape` (+ note: only needed if your model isn't listed) |
| Seq length | `Sequence length` *(inside Advanced)* | `How long is your conversation?` *(main bar, with a `4,096 words ≈ 9 pages` hint)* |
| Head dim | `Head dim` | `Head dimension` |
| Model class | `Model class` | `Model size` |
| Budget | `RAM budget for KV` | `Memory you can spare` |
| Budget caption | `from 16 GB Mac · auto` / `manual` | `worked out from your 16 GB Mac` / `your own figure` |
| Method group | `Method` | `Try a different approach` |
| Bench group | `Benchmark` | `Which result?` |
| Share button | `Copy my setup` | `Save my setup` |

### Header and steps

| | Before | After |
|---|---|---|
| h1 | Feel the power of VeloxQuant-MLX | Run bigger models on the Mac you already have |
| Eyebrow | Interactive · runs in your browser | Free · runs in your browser · nothing is sent anywhere |
| Headline | **Fit up to 7.5× more context on your Mac.** | **Your chatbot's notes get 87% smaller.** |
| Step 1 | Recommend — *a method for your setup* | What should I use? — *the right setting for your Mac* |
| Step 2 | Explore — *context you can fit* | How much fits? — *conversation length in your RAM* |
| Step 3 | Verify — *real measured benchmarks* | Is this real? — *benchmarks we measured* |

A collapsed **"New here? What this actually does"** primer defines *KV cache* once, up front, before any control asks the visitor to care about it.

### Result cards

| | Before | After |
|---|---|---|
| Hero stat 1 | `Key-accounting ratio` `7.5×` | `Smaller by` `87%` |
| Hero stat 2 | `KV cache saved` `87%` | `Notes take up` `512 MB → 68 MB` |
| Hero stat 3 | `Resident RAM` / Frees RAM / Accounting-only | `Frees actual RAM?` / Yes / Not on short chats |
| Badge | `Recommended` | `Use this` |
| Pill | frees resident RAM / accounting-only | gives memory back / smaller, but not always freed |
| Bands | Recommended method · Memory vs context · Reproduce · Notes & warnings | Why this one · How much space this saves · Run this yourself · Things to know |
| CTAs | Open in Compression Lab → / See the benchmark → | See how much fits → / Show me the proof → |
| Memory bar | `fp16 KV` / `compressed` / `≈87% smaller KV cache` | `normally` / `with VeloxQuant` / `≈87% less memory for the same conversation` |
| Lab stats | `Tokens @ fp16 · 8 GB` | `Words that fit in 8 GB — normally` |
| No warnings | No warnings for this configuration. | Nothing to watch out for — this setup is a comfortable fit. |

The raw `7.5×` ratio is not deleted — it moves into the **Why this one** band, where the technical detail belongs.

### Warnings and rationales (Python + JS together)

| Before | After |
|---|---|
| `7B 4-bit weights (~4.5 GB) leave little headroom on 16 GB (est. headroom -0.5 GB). Prefer a smaller model, eviction, or full-KV compression.` | `A 32B model will not fit in 8 GB. Its weights alone need ~18.0 GB, which is more than this Mac has once macOS takes its share — you are about 14.0 GB short of any headroom. Pick a smaller model.` *(negative case; the ≥0 case keeps "barely fits")* |
| `Metal kernel launch overhead can dominate on tiny models; prefer RVQ or disable Metal if tok/s drops.` | `On a model this small the GPU spends more time starting work than doing it, so compression can actually slow generation down. If speed drops, switch to turboquant_rvq or turn the Metal kernels off.` |
| `Tight RAM with a mid/large model: consider goal=max_context (rabitq) or goal=constant_memory (eviction) for long prompts.` | `RAM is tight for a model this size. For long prompts you will get more out of 'Fit the longest conversation' (rabitq), which compresses the whole cache, or 'Never grow past a fixed memory limit' (streaming_llm), which caps it outright.` |
| `head_dim=100 is not divisible by 8; VecInfer sub_dim must divide head_dim.` | `This model will not work with vecinfer: it splits each vector into groups of 8, and this model's head dimension (100) does not divide evenly by 8.` |
| `Eviction drops tokens; quality depends on the task. For importance-based eviction try method=h2o instead.` | `This works by forgetting older tokens, so the model can lose track of things said early in a long conversation. How much that hurts depends on the task. To drop the least-used tokens instead of simply the oldest, try method=h2o.` |
| `M1 with 32B: expect lower tok/s; memory fit still depends mainly on unified RAM.` | `A 32B model on an M1 will generate text more slowly than on a newer chip. Whether it fits at all, though, comes down to how much RAM you have rather than which chip it is.` |
| `Resident RSS savings are unlikely at short context for this method's default path (accounting ratio still valid).` | `This method measures smaller but may not free much actual RAM on short prompts, because its default path unpacks values back to full precision as it reads them. The size figure is real; treat it as a measure of how well the data compresses, not as RAM you get back.` |
| `Zero-calibration default. Key accounting ~7.5x at head_dim=128. Default path dequantizes into parent fp16 cache.` | `The safe everyday pick: it works out of the box with no setup step, and shrinks the key half of the cache by about 7.5x. It unpacks each value back to full precision as it is read, so this is a size measurement rather than a drop in live memory use.` |
| `Product VQ 1-bit path targets ~16x key accounting when head_dim is divisible by sub_dim=8. Needs calibration.` | `The smallest key cache on offer, around 16x. The trade is a one-time setup pass over sample data before you can use it, and the same unpack-on-read caveat as the everyday option.` |
| `SpectralQuant targets better reconstruction at moderate compression via eigenbasis rotation (calibration required).` | `Compresses less (about 5.3x) but reconstructs the cache more faithfully, so answers stay closest to the uncompressed model. Needs a one-time setup pass over sample data.` |
| `RaBitQ compresses keys and values. Better candidate for real context capacity gains than key-only RVQ accounting.` | `Compresses both halves of the cache, not just the keys, so the space it frees is real. That makes it the better choice when you want the longest possible conversation in the RAM you have.` |
| `Structural eviction keeps a fixed sink + window. Cache token count stays bounded regardless of generation length.` | `Keeps the first few tokens plus a sliding window of recent ones and discards the rest, so memory use stops growing no matter how long the conversation runs.` |
| knob note: `1-bit keys + MSE-b4 values; prefer fused Metal path when available` | `Compresses the whole cache; turn on the Metal kernels if available` |
| knob note: `Requires one-time codebook calibration` | `Needs a one-time setup pass over sample data before first use` |

### Method cards

| Method | Before | After |
|---|---|---|
| TurboQuant-RVQ | Zero-calibration everyday default. | Works out of the box. Start here. |
| VecInfer | Max key accounting; needs calibration. | Smallest of all, but needs a setup step first. |
| RaBitQ | Full-KV compression for long context. | Frees real memory. Best for long chats. |
| SpectralQuant | Best reconstruction quality. | Keeps answers closest to the original. |
| KIVI-2bit | Per-channel keys, throughput-neutral. | Compresses less, but doesn't slow you down. |

`METHODS[].label` stays technical (it is the badge) and `.config` is untouched — it is a real API snippet.

### Benchmark captions

| Before | After |
|---|---|
| `Hand-written Metal quantize kernel vs pure-MLX, by sequence length S (B=1, H=8, D=128).` | `How much faster our hand-written Apple GPU code compresses the cache, compared with doing the same work in plain MLX. Higher is better; S is the conversation length.` |
| `Full-KV memory, Falcon3-7B shape: fp16 vs RaBitQ (~5.95× smaller).` | `Actual memory used by the notes on a Falcon3-7B model, with and without RaBitQ — about 5.95× smaller. Shorter bars are better.` |
| `KIVI on <model> (M3, 16 GB): throughput retention vs key compression.` | `KIVI running <model> on an M3 with 16 GB. Blue shows how much of the original speed is kept; purple shows how much smaller the cache got.` |
| `Measured on real hardware · source figures/…` | `Measured on a real Mac, not estimated · you can check the raw numbers in figures/…` |

---

## Honesty guarantees — reworded, never dropped

- accounting-only vs frees-real-RAM distinction → *"smaller, but not always freed"* + the full explanation in the caveat
- `~450 tokens/page` label → *"rough estimate · counting ~450 words a page"*
- measured-data provenance line → kept, and now says explicitly that it is measured rather than estimated
- every `res.warnings` entry still reaches the screen
- the bottom disclaimer now leads with **"Where these numbers come from"** and states plainly which figures are calculated and which are measured

## Verification

**Parity across all 2400 `chip × RAM × model × goal × shape` combinations** — baseline extracted from `master`, compared three ways:

```
numeric mismatches   : 0     (method, ratio, resident flag, MB, warning count, knobs)
text drift py vs js  : 0     (warnings, rationales, knob notes — word for word)
```

The repo had **no JS↔Python parity check before this**; the file header only asked future editors to "keep parity". The harness is in the PR discussion below for anyone who wants to re-run it.

Also checked:

- `pytest tests/non_metal/test_mac_recommender.py` — **8 passed**. These assert on the substrings `"headroom"` and `"tight"`, both deliberately preserved in the new wording.
- `ruff format --check` and `ruff check` — clean on `mac_recommender.py` and `README.md`.
- `node --check playground.js` — clean.
- All **32** element ids referenced by the JS resolve against the HTML; no dangling `pg-hero-ratio` after removing that stat card.
- Both landing pages parse with balanced tags.
- The five `<option value=…>` goal values still match `ruleset_dict()["goals"]` exactly, so existing `?goal=` share links resolve.
- `URL_KEYS` unchanged — every renamed control kept its query key, including `?seq=` for the promoted conversation-length field.
- CLI output re-run by hand for the tight, impossible, and comfortable cases.

**Not automated:** I could not drive a real browser (no jsdom/Playwright here, and adding one to a deliberately zero-build page seemed the wrong trade). Visual layout and keyboard navigation want a human pass on the Netlify deploy preview — particularly the wider goal `<select>` at the 560px breakpoint.

## Notes for review

- `landing/index.html` is untouched; its links to the playground read generically ("Try the playground") and are still accurate.
- The `README.md` CLI transcript is regenerated from a real run. It had drifted independently of this work — it was **missing one of the two warnings** the command actually prints.
- New CSS is scoped to genuinely new markup (`.pg-primer`, `.pg-field-seq`, `.pg-adv-note`, `.pg-rationale-tech`) plus one width rule for the now-much-longer goal labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
