### PR TITLE
feat(landing): add GoatCounter privacy-friendly analytics

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -968,5 +968,11 @@ pip install -e ".[dev]"</span></pre>
 
   <script src="assets/calc.js" defer></script>
   <script src="assets/main.js" defer></script>
+
+  <!-- GoatCounter: privacy-friendly, cookieless page counts. Client-side, so
+       it records browsers rather than crawlers — expect it to read lower than
+       server-side request counts. -->
+  <script data-goatcounter="https://veloxquant.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -304,5 +304,11 @@
   <script src="assets/calc.js" defer></script>
   <script src="assets/main.js" defer></script>
   <script src="assets/playground.js" defer></script>
+
+  <!-- GoatCounter: privacy-friendly, cookieless page counts. Client-side, so
+       it records browsers rather than crawlers — expect it to read lower than
+       server-side request counts. -->
+  <script data-goatcounter="https://veloxquant.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds a cookieless [GoatCounter](https://www.goatcounter.com/) beacon to both landing pages, so we can see which countries, referrers, and pages the traffic actually comes from.

## Why not Netlify Analytics

Netlify's built-in analytics is **\$9/month per site with no free tier**. It is also server-side, which means it counts crawlers, scanners, and AI bots as traffic — the opposite of what we want, given the open question is *how much of the ~26k requests are human*.

GoatCounter is client-side JS, so it under-counts bots rather than over-counting them. The numbers will read lower than Cloudflare's request counts, but they will be much closer to real people. It is free for non-commercial use.

Cloudflare Web Analytics was the other free candidate, but it needs a zone you control, and `veloxquant-mlx.netlify.app` is a Netlify-owned subdomain. If we ever buy a custom domain, that option opens up.

## The change

Six lines per page, appended after the existing script tags:

```html
<script data-goatcounter="https://veloxquant.goatcounter.com/count"
        async src="//gc.zgo.at/count.js"></script>
```

- `landing/index.html`
- `landing/playground.html`

## Verification

- **No CSP on this site.** Grepped for `Content-Security-Policy`, `script-src`, and `connect-src` across HTML, `netlify.toml`, `_headers`, and JSON — no hits, and no `_headers` file exists outside `node_modules`. The beacon needs no header changes to load.
- **Both pages still parse** with balanced tags (void-element-aware checker).
- **Diff is 12 insertions, 0 deletions.** Nothing else touched.
- The script is `async` and sits after the existing `defer` bundles, so it cannot affect page rendering or the playground's behaviour.

## Before this is useful

The account at `veloxquant.goatcounter.com` **must exist** or the beacon will 404 silently. If it is not registered yet, sign up first — the dashboard URL in the script is the account name, not the site domain.

## Not automated

Confirming a hit actually lands in the dashboard needs a real page load against the deploy preview.

Closes #157