### PR TITLE
docs(landing): rewrite the method picker for a non-expert audience

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -277,40 +277,40 @@
       <p class="section-label">Which method</p>
       <h2 class="section-title">41 methods, one decision</h2>
       <p class="section-desc">
-        Most people need one of six. Pick by what you're optimising for —
-        the full catalogue lives in the docs.
+        You only need one. Find the row that sounds like your situation —
+        that's your answer. The other 35 are in the docs when you want them.
       </p>
     </div>
 
     <div class="picker-list fade-in">
       <div class="picker-row is-default">
-        <p class="picker-goal">Balanced, nothing to calibrate
-          <small>The default. Works on any model, no setup pass.</small></p>
-        <p class="picker-pick"><a href="#quickstart" class="picker-tab-link" data-tab="rvq"><code class="inline plain">turboquant_rvq</code></a><small>7.5× keys</small></p>
+        <p class="picker-goal">I just want it to work
+          <small>Start here. No setup step, works on any model.</small></p>
+        <p class="picker-pick"><a href="#quickstart" class="picker-tab-link" data-tab="rvq"><code class="inline plain">turboquant_rvq</code></a><small>7.5× on half the cache</small></p>
       </div>
       <div class="picker-row is-max">
-        <p class="picker-goal">Maximum compression, quality secondary
-          <small>Needs a one-time codebook calibration.</small></p>
-        <p class="picker-pick"><a href="#quickstart" class="picker-tab-link" data-tab="vecinfer"><code class="inline plain">vecinfer</code></a><small>16× keys</small></p>
+        <p class="picker-goal">I want it as small as possible
+          <small>The most compression on offer, if you can spare a one-time setup pass.</small></p>
+        <p class="picker-pick"><a href="#quickstart" class="picker-tab-link" data-tab="vecinfer"><code class="inline plain">vecinfer</code></a><small>16× on half the cache</small></p>
       </div>
       <div class="picker-row">
-        <p class="picker-goal">Longest context in fixed RAM
-          <small>Compresses keys <em>and</em> values — real resident savings.</small></p>
-        <p class="picker-pick"><code class="inline plain">rabitq</code><small>6× full KV</small></p>
+        <p class="picker-goal">I want the longest possible conversation
+          <small>The only picks here that hand real RAM back, not just smaller numbers.</small></p>
+        <p class="picker-pick"><code class="inline plain">rabitq</code><small>6× on the whole cache</small></p>
       </div>
       <div class="picker-row">
-        <p class="picker-goal">Quality-critical work
-          <small>Per-channel keys, per-token values, fp16 residual window.</small></p>
-        <p class="picker-pick"><code class="inline plain">kivi</code><small>~4× full KV</small></p>
+        <p class="picker-goal">I need the answers to stay accurate
+          <small>Compresses least, stays closest to the original model.</small></p>
+        <p class="picker-pick"><code class="inline plain">kivi</code><small>~4× on the whole cache</small></p>
       </div>
       <div class="picker-row">
-        <p class="picker-goal">Bounded memory regardless of length
-          <small>Drops stale tokens. Quality depends on the task.</small></p>
-        <p class="picker-pick"><code class="inline plain">streaming_llm</code> / <code class="inline plain">h2o</code><small>eviction</small></p>
+        <p class="picker-goal">I never want it to run out of memory
+          <small>Forgets older messages to hold memory flat. Fine for chat, risky for long documents.</small></p>
+        <p class="picker-pick"><code class="inline plain">streaming_llm</code> / <code class="inline plain">h2o</code><small>fixed size</small></p>
       </div>
       <div class="picker-row">
-        <p class="picker-goal">Everything else
-          <small>35 more, including cross-layer merging and spectral rotation.</small></p>
+        <p class="picker-goal">None of these are my problem
+          <small>35 more methods, each from a published paper.</small></p>
         <p class="picker-pick"><a href="/docs/algorithms/overview" class="t-accent">algorithm reference →</a></p>
       </div>
     </div>


### PR DESCRIPTION
Follows #155, which rewrote the playground but stopped at `playground.html`. The method picker on the home page still read like internal docs.

Closes #158

## Copy

| Before | After |
|---|---|
| Balanced, nothing to calibrate | **I just want it to work** |
| Maximum compression, quality secondary | **I want it as small as possible** |
| Longest context in fixed RAM | **I want the longest possible conversation** |
| Quality-critical work | **I need the answers to stay accurate** |
| Bounded memory regardless of length | **I never want it to run out of memory** |
| Everything else | **None of these are my problem** |

Sub-lines followed:

| Before | After |
|---|---|
| Per-channel keys, per-token values, fp16 residual window. | Compresses least, stays closest to the original model. |
| Drops stale tokens. Quality depends on the task. | Forgets older messages to hold memory flat. Fine for chat, risky for long documents. |
| Compresses keys *and* values — real resident savings. | The only picks here that hand real RAM back, not just smaller numbers. |
| Needs a one-time codebook calibration. | The most compression on offer, if you can spare a one-time setup pass. |
| 35 more, including cross-layer merging and spectral rotation. | 35 more methods, each from a published paper. |

The rows are first-person situations now, so a reader matches their own case instead of decoding a term. Wording reuses the goal vocabulary #155 settled on in the playground, so the two pages agree.

## The comparison fix

The old figures read `7.5× keys` against `6× full KV`. Those are not comparable — the first covers half the cache, the second the whole thing — so scanning the column made `turboquant_rvq` look like the better deal when `rabitq` actually frees more memory.

Now: **"7.5× on half the cache"** vs **"6× on the whole cache"**. Same numbers, apples to apples.

## Preserved

- Method identifiers (`turboquant_rvq`, `vecinfer`, `rabitq`, `kivi`, `streaming_llm`, `h2o`) — real `KVCacheConfig` values, translating them would break the link to the code
- Both `picker-tab-link` anchors and all six `data-tab` hooks
- Every ratio, verified against `mac_recommender.py` (7.5 / 16.0 / 6.0)

## Verification

- Copy only — 19 insertions, 19 deletions, all in place
- `index.html` parses with balanced tags (void-element-aware checker)
- No JS or CSS touched

## Not automated

Visual check of the picker rows on the deploy preview — the sub-lines are longer now and could wrap differently at narrow widths.