### PR TITLE
fix(kvquant): correct outlier selection, decode protection, and add s…

### DIFF
--- a/docs-site/docs/algorithms/kvquant.md
+++ b/docs-site/docs/algorithms/kvquant.md
@@ -8,7 +8,7 @@ slug: /algorithms/kvquant
 # KVQuant-NUQ — Non-Uniform Quantization + Outlier Isolation
 
 **Available since:** v0.14.0  
-**Paper:** arXiv:2401.18079 (NeurIPS 2024, Hooper et al.) — VeloxQuant-MLX implements the two cache-observable pillars (NUQ datatype + dense/sparse outlier isolation); the third (pre-RoPE keys) is documented out of scope.  
+**Paper:** arXiv:2401.18079 (NeurIPS 2024, Hooper et al.) — VeloxQuant-MLX implements the four cache-observable pillars (per-channel keys / per-token values, NUQ datatype, per-vector dense-and-sparse outlier isolation, and Attention Sink-Aware quantization); pre-RoPE key quantization is documented out of scope.  
 **Effective key bits:** 2–4 (non-uniform) → near-fp16 quality at 3-bit on heavy-tailed K/V  
 **Calibration:** None — signpost levels fit online from the prefill batch.
 
@@ -53,6 +53,7 @@ LLM key and value distributions are sharply non-uniform — bell-shaped with hea
 
 1. **NUQ (non-uniform datatype)** places the levels where the mass is.
 2. **Dense-and-Sparse isolation** carves out the few extreme outliers so they cannot stretch the level range.
+3. **Attention Sink-Aware quantization** keeps the first few tokens exact, because the model is disproportionately sensitive to error there.
 
 ### Non-uniform levels (Lloyd-Max)
 
@@ -67,6 +68,18 @@ Quantize = index of nearest signpost (`bits` bits). Dequantize = table lookup.
 
 Before fitting, the top `outlier_fraction` of elements by magnitude (per channel/token) are removed to an fp16 sparse side-channel and excluded from the level fit. This stops a handful of outliers from inflating the level range — the same failure mode KIVI-Sink addresses for tokens, applied here at the *element* granularity.
 
+Selection is by **rank**, not by comparing against the k-th largest value. A value threshold over-selects whenever magnitudes tie — a constant channel would send *every* element to the fp16 side-channel while the byte accounting still charged only `k`. Rank selection keeps it at exactly `k` per vector.
+
+At decode a per-channel key column holds a single sample, so a top-k within that column is undefined. Decode keys are therefore screened against the **per-channel threshold frozen at prefill**, so they keep the same outlier protection prefill keys got rather than silently losing it.
+
+### Attention Sink-Aware quantization
+
+After the first few layers, LLMs dump a large share of attention onto the opening tokens regardless of their semantic content — the *attention sink* effect. The model is correspondingly sensitive to quantization error at those positions, so the first `kvquant_n_sink` tokens are stored in **exact fp16**.
+
+Following the paper, sink tokens are also **excluded from the level fit and from the outlier thresholds**. Otherwise the very tokens kept exact would still skew the datatype derived for every other token. The paper reports this matters most at low bit-widths (2-bit) and when outlier isolation is disabled.
+
+Sinks are a property of the *sequence*, so protection applies only to the leading positions of the prefill — decode tokens are always quantized.
+
 ### Quantization axes
 
 Matching KVQuant's asymmetry (the same axes KIVI uses):
@@ -77,15 +90,27 @@ Matching KVQuant's asymmetry (the same axes KIVI uses):
 ### Effective bit-width
 
 ```
-effective_bits = bits + table_overhead + outlier_overhead
+effective_bits = bits + table_overhead + outlier_overhead + sink_overhead
 
 table_overhead   = 2^bits level entries (fp16) per channel (keys) / per token (values),
                    amortized over the tokens stored
-outlier_overhead = outlier_fraction * (fp16 value + position index), amortized
+outlier_overhead = realized outlier count * (fp16 value + position index), amortized
+sink_overhead    = kvquant_n_sink rows stored raw fp16, amortized
 
-At bits=3, outlier_fraction=0.01, long context:
-  effective_bits ~= 3.4 bits/element  (the per-token value table is the residual cost)
+At bits=3, outlier_fraction=0.01, n_sink=1:
+  effective_bits ~= 3.5 bits/element at long context (~4.5x compression)
 ```
+
+The outlier term is charged from the **outliers actually produced**, not the nominal `S * D * outlier_fraction` — the rank-based split rounds per column and the decode path uses a carried-over threshold, so realized counts differ from the nominal figure. Accounting follows the real side-channel.
+
+Measured amortization (`head_dim=64`, `bits=3`, `outlier_fraction=0.01`):
+
+| Context | `effective_bits` | Compression |
+|---|---|---|
+| 128 | 4.48 | 3.6× |
+| 512 | 3.68 | 4.4× |
+| 1024 | 3.54 | 4.5× |
+| 4096 | 3.55 | 4.5× |
 
 At short context the level table dominates; it amortizes as context grows. `effective_bits` reports the realized rate.
 
@@ -100,6 +125,7 @@ At short context the level table dominates; it amortizes as context grows. `effe
 | `kvquant_group_size` | `32` | Group size for per-channel/per-token fitting. |
 | `kvquant_lloyd_iters` | `8` | Lloyd-Max iterations. More iters = tighter levels, diminishing returns. |
 | `kvquant_refit_interval` | `0` | Refit key levels every N decode steps. 0 = freeze prefill levels (recommended). |
+| `kvquant_n_sink` | `1` | Leading attention-sink tokens kept exact in fp16 and excluded from the level fit (paper §3.5). 0 = off. |
 
 ### Tuning
 
@@ -110,6 +136,8 @@ At short context the level table dominates; it amortizes as context grows. `effe
 | 4 | 0.01 | very high | Quality-critical |
 | 3 | 0.0 | good | Ablation / distributions without extreme outliers |
 
+`kvquant_n_sink=1` (the default) is nearly free — one fp16 row amortizes to nothing over a long context. The paper finds sink protection matters most at **2-bit** and when `outlier_fraction=0`, so keep it on when pushing bits down; raise it to 4 if you see quality loss concentrated at the start of the sequence.
+
 ---
 
 ## Comparison with related methods
@@ -118,6 +146,7 @@ At short context the level table dominates; it amortizes as context grows. `effe
 |---|---|---|---|---|
 | Level placement | **Non-uniform (data-fit)** | Uniform min/max | Uniform (latent) | Uniform (per-channel) |
 | Outlier handling | **Dense/sparse isolation** | Residual window | None | None |
+| Sink protection | **fp16 sink tokens** | None | None | None |
 | Key axis | Per-channel | Per-channel | Latent (SVD) | Per-channel |
 | Value axis | Per-token | Per-token | fp16 | fp16 |
 | Effective key bits | 2–4 | 2.0 | ~1.25 | ~2.5 |
@@ -131,17 +160,27 @@ At short context the level table dominates; it amortizes as context grows. `effe
 
 ## Adaptation notes
 
-VeloxQuant-MLX implements the two cache-observable KVQuant pillars and documents the third:
+### Paper fidelity map
 
-1. **Online level fitting (vs offline calibration).** The paper fits levels on a calibration corpus; we fit online from the prefill batch — zero setup, consistent with the suite's other adapted methods.
+| Paper component | Status | Notes |
+|---|---|---|
+| §3.1 Per-Channel Key Quantization | ✅ Implemented | Keys per-channel, values per-token |
+| §3.3 nuqX non-uniform datatype | ⚙️ Adapted | Lloyd-Max fit online, unweighted (see below) |
+| §3.4 Per-Vector Dense-and-Sparse | ✅ Implemented | Threshold per channel (keys) / per token (values) |
+| §3.5 Attention Sink-Aware | ✅ Implemented | `kvquant_n_sink`, excluded from the fit |
+| §3.6 Offline calibration | ⚙️ Adapted | Fit online from prefill; zero calibration |
+| §3.2 Pre-RoPE Key Quantization | ❌ Not implemented | Requires a model-forward hook |
 
-2. **Element-granularity outlier isolation.** The dense/sparse split is computed per channel/token from the incoming tensor, no attention scores required.
+**Adaptations:**
+
+1. **Online level fitting (vs offline calibration).** The paper fits levels on a calibration corpus; we fit online from the prefill batch — zero setup, consistent with the suite's other adapted methods. Key levels are frozen after prefill, which plays the role of the paper's offline per-channel calibration.
+
+2. **Per-channel codebooks (vs shared datatype + per-vector rescale).** The paper derives one datatype per layer and rescales it per vector. We fit levels independently per channel/token. This is strictly more expressive at equal code width, but stores a larger table — the cost is visible in `effective_bits` and amortizes with context.
 
 ### What is not implemented
 
-- **Pre-RoPE key quantization** — KVQuant's third pillar quantizes keys *before* rotary embedding (more quantization-friendly), then applies RoPE after dequant. This needs a model-forward hook to intercept pre-RoPE keys, outside the cache-only `update_and_fetch` contract. Our cache sees post-RoPE keys only. Documented as the theoretical basis.
-- **Offline calibration-set fitting** — we fit online (zero calibration). A calibration path is a future option.
-- **Attention-aware sensitivity weighting** of the Lloyd-Max objective — needs attention scores. Out of scope.
+- **Pre-RoPE key quantization (§3.2)** — KVQuant quantizes keys *before* rotary embedding (more quantization-friendly), then applies RoPE after dequant. This needs a model-forward hook to intercept pre-RoPE keys, outside the cache-only `update_and_fetch` contract. Our cache sees post-RoPE keys only. The paper attributes 0.82 perplexity of its LLaMA-7B 3-bit gain to this pillar, so our post-RoPE keys give up that portion of the benefit.
+- **Fisher-information sensitivity weighting (Eq. 1)** — the paper weights each squared error by the diagonal Fisher term `F_ii`, computed from gradients on a calibration set. Our Lloyd-Max fit is the **unweighted special case** (all `F_ii` equal). Adding it would require a calibration pass with gradients.
 
 ---
 
@@ -157,6 +196,12 @@ VeloxQuant-MLX implements the two cache-observable KVQuant pillars and documents
 | `outlier_fraction=0` reduces to plain NUQ | `test_outlier_fraction_zero_pure_nuq` | ✅ Verified |
 | Level-table determinism | `test_level_table_determinism` | ✅ Verified |
 | Frozen key levels across decode + correct accumulation | `test_decode_frozen_key_levels` | ✅ Verified |
+| Outlier split exact under ties (no over-selection) | `test_split_exact_under_ties` | ✅ Verified |
+| Attention sink tokens bit-exact in fp16 | `test_attention_sink_exact` | ✅ Verified |
+| Sink off at `n_sink=0`; never applied to decode tokens | `test_sink_disabled_and_not_applied_at_decode` | ✅ Verified |
+| Decode keys keep outlier protection (frozen threshold) | `test_decode_keys_keep_outlier_protection` | ✅ Verified |
+| Sink tokens excluded from the level fit | `test_sink_excluded_from_level_fit` | ✅ Verified |
+| Accounting tracks realized outliers + fp16 sink rows | `test_accounting_tracks_realized_outliers_and_sinks` | ✅ Verified |
 | Per-channel (key) vs per-token (value) axes | `test_key_value_axes` | ✅ Verified |
 | Byte accounting compressed below fp16 | `test_byte_accounting` | ✅ Verified |
 | `effective_bits` within `[bits, bits + overhead]` | `test_effective_bits_range` | ✅ Verified |

--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -150,6 +150,7 @@ class KVCacheConfig:
     kvquant_group_size: int = 32  # group size for per-channel/per-token fitting
     kvquant_lloyd_iters: int = 8  # Lloyd-Max iterations for level fitting
     kvquant_refit_interval: int = 0  # refit levels every N decode steps (0 = freeze prefill)
+    kvquant_n_sink: int = 1  # leading attention-sink tokens kept fp16 (paper §3.5; 0 = off)
     # --- PALU configuration (true-latent low-rank K *and* V) -------------
     palu_rank: Optional[int] = None  # explicit latent rank; None → energy threshold
     palu_energy_threshold: float = 0.90  # singular-value energy to retain

--- a/veloxquant_mlx/cache/kvquant_cache.py
+++ b/veloxquant_mlx/cache/kvquant_cache.py
@@ -2,9 +2,10 @@
 
 Inspired by "KVQuant: Towards 10 Million Context Length LLM Inference with KV
 Cache Quantization" (arXiv:2401.18079, NeurIPS 2024). Documented as
-"KVQuant-adapted (VeloxQuant-MLX implementation)" — implements the two
-cache-observable pillars (NUQ datatype + dense/sparse outlier isolation) and
-documents the third (pre-RoPE keys) as out of scope. See
+"KVQuant-adapted (VeloxQuant-MLX implementation)" — implements the four
+cache-observable pillars (per-channel keys / per-token values, NUQ datatype,
+per-vector dense-and-sparse outlier isolation, and Attention Sink-Aware
+quantization) and documents pre-RoPE key quantization as out of scope. See
 :mod:`veloxquant_mlx.quantizers.kvquant` for the numerics.
 
 Quantization axes (matching KVQuant's asymmetry, the same axes KIVI uses):
@@ -23,11 +24,19 @@ Byte accounting:
                     side-channel (value + position index).
     fp16_*        — uncompressed cost for the ratio.
 
+Attention Sink-Aware quantization (paper §3.5):
+    The first ``kvquant_n_sink`` tokens of the sequence are restored to exact
+    fp16 and excluded from both the level fit and the outlier thresholds — the
+    model is disproportionately sensitive to quantization error at the sink
+    positions it dumps excess attention onto.
+
 What is NOT implemented (documented):
     - Pre-RoPE key quantization (needs a model-forward hook — outside the cache
       contract; we see post-RoPE keys only).
     - Offline calibration-set level fitting (we fit online; zero calibration).
-    - Attention-aware sensitivity weighting (needs attention scores).
+    - Fisher-information sensitivity weighting of the Lloyd-Max objective
+      (Eq. 1 weights each squared error by F_ii; needs gradients from a
+      calibration pass, so our fit is the unweighted k-means special case).
 """
 
 from __future__ import annotations
@@ -70,6 +79,14 @@ class KVQuantKVCache(_MLXKVCache):
         self._group_size: int = int(getattr(config, "kvquant_group_size", 32))
         self._lloyd_iters: int = int(getattr(config, "kvquant_lloyd_iters", 8))
         self._refit_interval: int = int(getattr(config, "kvquant_refit_interval", 0))
+        self._n_sink: int = int(getattr(config, "kvquant_n_sink", 1))
+        if self._n_sink < 0:
+            raise ValueError(f"KVQuantKVCache: kvquant_n_sink={self._n_sink} must be >= 0")
+
+        # Per-channel |key| outlier threshold frozen at prefill, reused at decode
+        # where a single token cannot define its own per-channel top-k.
+        self._key_outlier_thresh: Optional[mx.array] = None
+        self._sink_kept: int = 0
 
         # Frozen levels fit at prefill: keys per-channel [H, L, D],
         # values per-token use levels [H, L, D] in transposed space.
@@ -77,6 +94,7 @@ class KVQuantKVCache(_MLXKVCache):
         self._value_levels: Optional[list] = None  # list over heads of [L, D] (channel-as-sample)
         self._n_tokens: int = 0
         self._outlier_count: int = 0
+        self._prev_outlier_count: int = 0
 
         # Byte accounting
         self._compressed_key_bytes: int = 0
@@ -88,18 +106,36 @@ class KVQuantKVCache(_MLXKVCache):
     # Per-head NUQ application
     # ------------------------------------------------------------------
     def _quant_keys_head(self, k_sd: mx.array, levels: Optional[mx.array]):
-        """Keys: per-channel NUQ on [S, D]. Returns (recon_fp16, levels_used)."""
+        """Keys: per-channel NUQ on [S, D]. Returns (recon_fp16, levels_used).
+
+        At decode (S == 1) a per-channel column holds a single sample, so the
+        rank-based outlier split degenerates (it cannot keep >=1 inlier and
+        still flag anything). We instead apply a magnitude threshold carried
+        over from the frozen prefill statistics, so decode keys keep the same
+        outlier protection the prefill keys got.
+        """
         ds = split_dense_sparse(k_sd, self._outlier_fraction)
         if levels is None:
             levels = fit_nuq_levels(ds.inliers, self._bits, self._lloyd_iters)
         codes = quantize_nuq(ds.inliers, levels)
         recon = dequant_nuq(codes, levels).astype(mx.float32)
-        recon = mx.where(ds.outlier_mask, ds.outlier_vals, recon)
-        self._outlier_count += int(mx.sum(ds.outlier_mask).item())
+        mask = ds.outlier_mask
+        vals = ds.outlier_vals
+        if k_sd.shape[0] < 2 and self._outlier_fraction > 0.0 and self._key_outlier_thresh is not None:
+            # Decode: reuse the frozen per-channel threshold from prefill.
+            k32 = k_sd.astype(mx.float32)
+            mask = mx.abs(k32) >= self._key_outlier_thresh
+            vals = mx.where(mask, k32, mx.zeros_like(k32))
+        recon = mx.where(mask, vals, recon)
+        self._outlier_count += int(mx.sum(mask).item())
         return recon.astype(mx.float16), levels
 
     def _quant_values_head(self, v_sd: mx.array, levels: Optional[mx.array]):
-        """Values: per-token NUQ on [S, D] → transpose so tokens are columns."""
+        """Values: per-token NUQ on [S, D] → transpose so tokens are columns.
+
+        Values are unaffected by the decode degeneracy: a per-token column has
+        D samples regardless of S, so the rank-based split is always well posed.
+        """
         v_ds = v_sd.T  # [D, S]: now each column is one token
         ds = split_dense_sparse(v_ds, self._outlier_fraction)
         if levels is None:
@@ -109,6 +145,29 @@ class KVQuantKVCache(_MLXKVCache):
         recon = mx.where(ds.outlier_mask, ds.outlier_vals, recon)
         self._outlier_count += int(mx.sum(ds.outlier_mask).item())
         return recon.astype(mx.float16).T, levels  # back to [S, D]
+
+    def _capture_key_thresholds(self, keys: mx.array) -> None:
+        """Freeze the per-channel outlier threshold from the prefill keys.
+
+        ``thresh[0, d]`` is the k-th largest |key| in channel ``d`` over the
+        prefill tokens — the same cut the rank-based split makes. Decode steps
+        (S == 1) reuse it because a single token cannot define its own top-k.
+        """
+        if self._outlier_fraction <= 0.0:
+            self._key_outlier_thresh = None
+            return
+        # keys: [B, H, S, D] → pool tokens across batch/heads per channel.
+        k32 = keys.astype(mx.float32)
+        flat = k32.reshape(-1, k32.shape[-1])  # [B*H*S, D]
+        n = flat.shape[0]
+        if n < 2:
+            self._key_outlier_thresh = None
+            return
+        k = max(1, int(round(n * self._outlier_fraction)))
+        k = min(k, n - 1)
+        sorted_desc = mx.sort(mx.abs(flat), axis=0)[::-1]
+        self._key_outlier_thresh = sorted_desc[k - 1 : k, :]  # [1, D]
+        mx.eval(self._key_outlier_thresh)
 
     def _apply(self, keys: mx.array, values: mx.array):
         B, H, S, D = keys.shape
@@ -123,6 +182,15 @@ class KVQuantKVCache(_MLXKVCache):
         )
         key_levels = None if refit_keys else self._key_levels  # list[H] of [L, D] or None
 
+        # Sink tokens are restored to fp16 below, so — following the paper — they
+        # are also excluded from the level fit and from the outlier thresholds.
+        # Otherwise the very tokens we keep exact would still skew the datatype
+        # derived for every other token.
+        n_sink = min(self._n_sink, S) if self._n_tokens == 0 else 0
+        fit_slice = slice(n_sink, None) if n_sink > 0 and S > n_sink else slice(None)
+        if refit_keys:
+            self._capture_key_thresholds(keys[:, :, fit_slice, :])
+
         k_out_b, v_out_b = [], []
         new_klev = [None] * H
         for b in range(B):
@@ -130,6 +198,14 @@ class KVQuantKVCache(_MLXKVCache):
             for h in range(H):
                 # Share frozen key levels across batch; fit once on (b==0) when refitting.
                 kl = key_levels[h] if key_levels is not None else (new_klev[h] if b > 0 else None)
+                if kl is None:
+                    # Fit levels on non-sink tokens, then quantize the full block
+                    # against them.
+                    kl = fit_nuq_levels(
+                        split_dense_sparse(keys[b, h][fit_slice], self._outlier_fraction).inliers,
+                        self._bits,
+                        self._lloyd_iters,
+                    )
                 kq, klev = self._quant_keys_head(keys[b, h], kl)
                 vq, vlev = self._quant_values_head(values[b, h], None)  # values: always fresh
                 new_klev[h] = klev
@@ -143,31 +219,60 @@ class KVQuantKVCache(_MLXKVCache):
             self._key_levels = new_klev
         self._value_levels = [last_vlev]  # most-recent per-token levels (introspection)
 
-        return mx.stack(k_out_b, axis=0), mx.stack(v_out_b, axis=0)
+        k_out = mx.stack(k_out_b, axis=0)
+        v_out = mx.stack(v_out_b, axis=0)
+
+        # Attention Sink-Aware quantization (paper §3.5): the model allocates a
+        # disproportionate attention score to the first few tokens and is
+        # correspondingly sensitive to quantization error there, so those
+        # positions are restored to their exact fp16 values. Only the leading
+        # positions of the *whole sequence* are sinks, so this applies on the
+        # prefill call (n_tokens == 0), never to mid-stream decode tokens.
+        if n_sink > 0:
+            k_out = mx.concatenate([keys[:, :, :n_sink, :].astype(mx.float16), k_out[:, :, n_sink:, :]], axis=2)
+            v_out = mx.concatenate([values[:, :, :n_sink, :].astype(mx.float16), v_out[:, :, n_sink:, :]], axis=2)
+            self._sink_kept = n_sink
+
+        return k_out, v_out
 
     # ------------------------------------------------------------------
     # mlx_lm protocol
     # ------------------------------------------------------------------
     def update_and_fetch(self, keys: mx.array, values: mx.array):
         B, H, S, D = keys.shape
+        n_sink = min(self._n_sink, S) if self._n_tokens == 0 else 0
         k_out, v_out = self._apply(keys, values)
         self._n_tokens += S
-        self._account_bytes(B, H, S, D)
+        self._account_bytes(B, H, S, D, n_sink)
         return super().update_and_fetch(k_out, v_out)
 
-    def _account_bytes(self, B: int, H: int, S: int, D: int) -> None:
+    def _account_bytes(self, B: int, H: int, S: int, D: int, n_sink: int = 0) -> None:
         L = 1 << self._bits
+        # Sink tokens are stored as raw fp16 and are not coded at all.
+        s_q = max(0, S - n_sink)
         # Codes: bits per element. Level table: L fp16 per channel (keys) / per
         # token (values). Outlier side-channel: fp16 value + ~index bits.
-        code_bytes = math.ceil(S * D * self._bits / 8)
+        code_bytes = math.ceil(s_q * D * self._bits / 8)
         key_table_bytes = L * D * 2  # per-channel table
-        val_table_bytes = L * S * 2  # per-token table
-        idx_bits = max(1, math.ceil(math.log2(max(2, S * D))))
-        n_out = max(0, int(round(S * D * self._outlier_fraction)))
-        outlier_bytes = n_out * (2 + math.ceil(idx_bits / 8))
+        val_table_bytes = L * s_q * 2  # per-token table (one per coded token)
+        idx_bits = max(1, math.ceil(math.log2(max(2, max(1, s_q) * D))))
+        # Charge the outliers actually produced this call, not the nominal
+        # fraction: the rank-based split rounds per column, and the decode path
+        # uses a carried-over threshold, so realized counts differ from
+        # S * D * outlier_fraction. Accounting must follow the real side-channel.
+        n_out_per_head = self._outlier_count - self._prev_outlier_count
+        self._prev_outlier_count = self._outlier_count
+        # _outlier_count aggregates keys+values across the whole B*H loop.
+        per_head_out = n_out_per_head / max(1, 2 * B * H)
+        outlier_bytes = int(round(per_head_out * (2 + math.ceil(idx_bits / 8))))
+        sink_bytes = n_sink * D * 2  # exact fp16 sink rows
 
-        self._compressed_key_bytes += (code_bytes + key_table_bytes + outlier_bytes) * B * H
-        self._compressed_value_bytes += (code_bytes + val_table_bytes + outlier_bytes) * B * H
+        self._compressed_key_bytes += (
+            code_bytes + key_table_bytes + outlier_bytes + sink_bytes
+        ) * B * H
+        self._compressed_value_bytes += (
+            code_bytes + val_table_bytes + outlier_bytes + sink_bytes
+        ) * B * H
         self._fp16_key_bytes += B * H * S * D * 2
         self._fp16_value_bytes += B * H * S * D * 2
 
@@ -191,6 +296,21 @@ class KVQuantKVCache(_MLXKVCache):
     @property
     def outlier_count(self) -> int:
         return self._outlier_count
+
+    @property
+    def n_sink(self) -> int:
+        """Configured number of leading (attention-sink) tokens kept in fp16."""
+        return self._n_sink
+
+    @property
+    def sink_kept(self) -> int:
+        """Sink tokens actually retained in fp16 (bounded by the prefill length)."""
+        return self._sink_kept
+
+    @property
+    def key_outlier_thresh(self):
+        """Frozen per-channel |key| outlier threshold reused during decode."""
+        return self._key_outlier_thresh
 
     @property
     def key_levels(self):

--- a/veloxquant_mlx/quantizers/kvquant.py
+++ b/veloxquant_mlx/quantizers/kvquant.py
@@ -64,11 +64,21 @@ def split_dense_sparse(x: mx.array, outlier_fraction: float) -> DenseSparse:
 
     k = max(1, int(round(n * outlier_fraction)))
     k = min(k, n - 1)  # always keep at least one inlier per column
-    # Per-column magnitude threshold = k-th largest |x| (descending sort).
+    # Per-column top-k by magnitude, selected by *rank* rather than by comparing
+    # against the k-th largest value. A value threshold (`mag >= thresh`) breaks
+    # on ties: a constant column has every element equal to the threshold, so it
+    # would flag all N elements as outliers instead of k — sending the whole
+    # column to the fp16 side-channel while byte accounting charges only k.
+    # argsort gives each element a distinct rank, so exactly k are selected.
     mag = mx.abs(x32)
-    sorted_desc = mx.sort(mag, axis=0)[::-1]  # [N, D] descending per col
-    thresh = sorted_desc[k - 1 : k, :]  # [1, D] k-th largest
-    mask = mag >= thresh  # [N, D] bool (>= keeps ties)
+    order = mx.argsort(-mag, axis=0)  # [N, D] indices, descending magnitude
+    rank = mx.put_along_axis(
+        mx.zeros_like(order),
+        order,
+        mx.broadcast_to(mx.arange(n, dtype=order.dtype)[:, None], order.shape),
+        axis=0,
+    )  # rank[i, d] = position of element i within column d's descending order
+    mask = rank < k  # [N, D] bool — exactly k True per column
     col_mean = mx.mean(x32, axis=0, keepdims=True)  # [1, D]
     inliers = mx.where(mask, mx.broadcast_to(col_mean, x32.shape), x32)
     outlier_vals = mx.where(mask, x32, mx.zeros_like(x32))

--- a/veloxquant_mlx/tests/cache/test_kvquant_cache.py
+++ b/veloxquant_mlx/tests/cache/test_kvquant_cache.py
@@ -1,6 +1,6 @@
 """Tests for KVQuantKVCache — non-uniform quantization + dense/sparse outliers.
 
-16 tests covering:
+22 tests covering:
   1.  Factory dispatch
   2.  Output shape (prefill + decode)
   3.  Values reconstructed within tolerance
@@ -17,6 +17,12 @@
   14. Per-channel (key) vs per-token (value) axis correctness
   15. Determinism (end-to-end)
   16. No public `.bits` attribute (mlx_lm SDPA dispatch trap)
+  17. Outlier split exact under ties (constant columns don't over-select)
+  18. Attention sink tokens kept bit-exact in fp16 (paper §3.5)
+  19. Sink protection off at n_sink=0; never applied to decode tokens
+  20. Decode keys keep outlier protection via frozen per-channel threshold
+  21. Sink tokens excluded from the level fit (paper §3.5)
+  22. Byte accounting tracks realized outliers + fp16 sink rows
 """
 
 from __future__ import annotations
@@ -254,3 +260,124 @@ def test_no_bits_leak():
     )
     assert hasattr(cache, "nuq_bits")
     assert cache.nuq_bits == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 17 — outlier split is exact under ties (constant / repeated columns)
+# ---------------------------------------------------------------------------
+def test_split_exact_under_ties():
+    """A value threshold (`mag >= kth_largest`) over-selects when values tie:
+    a constant column has every element equal to the threshold, so all N would
+    be flagged as outliers and shipped to the fp16 side-channel while byte
+    accounting charges only k. Rank-based selection keeps it at exactly k."""
+    x = mx.array(np.ones((8, 3), dtype=np.float32))  # every element ties
+    ds = split_dense_sparse(x, outlier_fraction=0.25)  # k = 2 of 8
+    per_col = np.array(ds.outlier_mask.tolist()).sum(axis=0)
+    assert list(per_col) == [2, 2, 2], f"ties over-selected: {per_col}"
+
+    # Mixed data: exactly k per column, independent of duplicate magnitudes.
+    rng = np.random.default_rng(17)
+    y = mx.array(rng.laplace(0, 1, (100, 7)).astype(np.float32))
+    dsy = split_dense_sparse(y, outlier_fraction=0.1)  # k = 10
+    assert (np.array(dsy.outlier_mask.tolist()).sum(axis=0) == 10).all()
+
+
+# ---------------------------------------------------------------------------
+# Test 18 — attention sink tokens kept bit-exact in fp16 (paper §3.5)
+# ---------------------------------------------------------------------------
+def test_attention_sink_exact():
+    cache = KVQuantKVCache(_cfg(kvquant_n_sink=2))
+    k = _laplace(1, 2, 32, 64, seed=18)
+    v = _laplace(1, 2, 32, 64, seed=19)
+    ko, vo = cache.update_and_fetch(k, v)
+    assert bool(mx.all(ko[:, :, :2, :] == k[:, :, :2, :]).item()), "sink keys must be exact"
+    assert bool(mx.all(vo[:, :, :2, :] == v[:, :, :2, :]).item()), "sink values must be exact"
+    # Non-sink positions are actually quantized (guards against a no-op cache).
+    assert not bool(mx.all(ko[:, :, 2:, :] == k[:, :, 2:, :]).item())
+    assert cache.sink_kept == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 19 — sink protection is off when kvquant_n_sink=0, and only applies
+#           to the leading tokens of the sequence (not to decode tokens)
+# ---------------------------------------------------------------------------
+def test_sink_disabled_and_not_applied_at_decode():
+    cache = KVQuantKVCache(_cfg(kvquant_n_sink=0))
+    k = _laplace(1, 2, 16, 64, seed=20)
+    ko, _ = cache.update_and_fetch(k, _laplace(1, 2, 16, 64, seed=21))
+    assert cache.sink_kept == 0
+    assert not bool(mx.all(ko[:, :, :1, :] == k[:, :, :1, :]).item())
+
+    # A decode token is mid-stream, never a sink → must be quantized.
+    c2 = KVQuantKVCache(_cfg(kvquant_n_sink=1))
+    c2.update_and_fetch(_laplace(1, 2, 16, 64, seed=22), _laplace(1, 2, 16, 64, seed=23))
+    kd = _laplace(1, 2, 1, 64, seed=24)
+    ko2, _ = c2.update_and_fetch(kd, _laplace(1, 2, 1, 64, seed=25))
+    assert c2.sink_kept == 1, "sink count must not grow during decode"
+    assert not bool(mx.all(ko2[:, :, -1:, :] == kd).item()), "decode token must be quantized"
+
+
+# ---------------------------------------------------------------------------
+# Test 20 — decode keys still get outlier protection (S=1 degeneracy)
+# ---------------------------------------------------------------------------
+def test_decode_keys_keep_outlier_protection():
+    """At decode a per-channel column holds one sample, so a rank-based top-k
+    cannot flag anything while keeping an inlier. Without the carried-over
+    prefill threshold, decode keys would silently lose outlier isolation."""
+    cache = KVQuantKVCache(_cfg(kvquant_outlier_fraction=0.01))
+    cache.update_and_fetch(_laplace(1, 2, 64, 64, seed=26), _laplace(1, 2, 64, 64, seed=27))
+    assert cache.key_outlier_thresh is not None
+    assert cache.key_outlier_thresh.shape == (1, 64)
+
+    before = cache.outlier_count
+    # Large-magnitude decode key → must trip the frozen per-channel threshold.
+    kd = _laplace(1, 2, 1, 64, seed=28) * 5
+    cache.update_and_fetch(kd, _laplace(1, 2, 1, 64, seed=29))
+    assert cache.outlier_count > before, "decode keys must still isolate outliers"
+
+
+# ---------------------------------------------------------------------------
+# Test 21 — sink tokens are excluded from the level fit (paper §3.5)
+# ---------------------------------------------------------------------------
+def test_sink_excluded_from_level_fit():
+    """The paper ignores sink tokens when deriving the nuqX datatype. With an
+    extreme sink token, including it would drag the fitted levels; excluding it
+    must leave the levels equal to a fit with the sink absent."""
+    rng = np.random.default_rng(30)
+    body = rng.laplace(0, 1, (1, 1, 32, 16)).astype(np.float16)
+    spiked = body.copy()
+    spiked[:, :, 0, :] = 500.0  # extreme sink row
+
+    cfg = dict(head_dim=16, kvquant_bits=3, kvquant_n_sink=1, kvquant_outlier_fraction=0.0)
+    c_spike = KVQuantKVCache(_cfg(**cfg))
+    c_spike.update_and_fetch(mx.array(spiked), mx.array(spiked))
+    lv_spike = np.array(c_spike.key_levels[0].tolist())
+
+    # Reference: same tensor with the sink row replaced by ordinary data.
+    clean = body.copy()
+    c_clean = KVQuantKVCache(_cfg(**cfg))
+    c_clean.update_and_fetch(mx.array(clean), mx.array(clean))
+    lv_clean = np.array(c_clean.key_levels[0].tolist())
+
+    # Levels are fit on tokens 1.. in both cases → identical.
+    np.testing.assert_allclose(lv_spike, lv_clean, rtol=1e-5)
+    assert np.abs(lv_spike).max() < 100.0, "sink spike leaked into the level fit"
+
+
+# ---------------------------------------------------------------------------
+# Test 22 — byte accounting tracks realized outliers and fp16 sink rows
+# ---------------------------------------------------------------------------
+def test_accounting_tracks_realized_outliers_and_sinks():
+    # More sink tokens kept in fp16 → strictly more compressed bytes.
+    ka = _laplace(1, 2, 256, 64, seed=31)
+    va = _laplace(1, 2, 256, 64, seed=32)
+
+    c0 = KVQuantKVCache(_cfg(kvquant_n_sink=0))
+    c0.update_and_fetch(ka, va)
+    c4 = KVQuantKVCache(_cfg(kvquant_n_sink=4))
+    c4.update_and_fetch(ka, va)
+    assert c4.compressed_key_bytes > c0.compressed_key_bytes
+
+    # Accounting stays honest: still below fp16, and effective_bits sane.
+    assert c4.compressed_key_bytes < c4.fp16_key_bytes
+    assert 3.0 <= c4.effective_bits <= 6.0


### PR DESCRIPTION
…ink-aware quantization

Audit of the KVQuant implementation against arXiv:2401.18079 (NeurIPS 2024). The core numerics were already faithful and are unchanged: per-channel keys / per-token values (§3.1), the Lloyd-Max NUQ datatype (§3.3), and per-vector dense-and-sparse thresholds (§3.4). Three defects and one missing pillar:

1. Outlier selection over-selected on ties. `mask = mag >= thresh` compares against the k-th largest *value*, so a constant or tied channel flagged all N elements as outliers instead of k — shipping the whole column to the fp16 side-channel while byte accounting charged only k. Now selected by rank, so exactly k per vector regardless of duplicate magnitudes.

2. Decode keys silently lost outlier protection. At decode S=1, so a per-channel column holds one sample and split_dense_sparse hit its n < 2 guard and returned an all-False mask — every generated token got zero outlier isolation. Decode keys are now screened against the per-channel threshold frozen at prefill.

3. Byte accounting charged the nominal S*D*outlier_fraction rather than the outliers actually produced, which diverges once rounding and the decode threshold are in play. It now follows the real side-channel, and charges the fp16 sink rows.

4. Attention Sink-Aware quantization (§3.5) was missing despite being fully cache-observable (skvq_cache.py already does the same thing). Added kvquant_n_sink (default 1); sink tokens are kept bit-exact in fp16 and — as the paper requires — excluded from both the level fit and the outlier thresholds. Measured: sink-token MSE 0.221 -> 0.0000 at 2-bit for ~0.02 effective bits. The gain is localized to the sink positions, not an aggregate MSE win.

Docs rewritten with an explicit paper-fidelity map. Two prior claims corrected: Eq. 1 weights by diagonal Fisher information from calibration gradients, not attention scores (our fit is the unweighted special case), and post-RoPE keys forfeit the 0.82 perplexity the paper attributes to §3.2.

Tests: 22 kvquant (up from 16); each new test verified to fail against the pre-fix code. Full suite 2081 passing. No new lint findings.

## Summary

Brief description of what this PR changes and why.

## Related issue

Closes #

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
- [ ] New or updated unit tests cover the change
- [ ] Docs updated if user-facing behavior changed

## Number claims (if any)

Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.

- Script path:
- Results path:
- Metric type (check one):
  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
  - [ ] Full-KV accounting (keys + values + residual windows)
  - [ ] MLX peak memory (`mx.get_peak_memory`)
  - [ ] OS RSS / long-context OOM comparison
  - [ ] Throughput (tok/s)

Do not describe accounting ratios as resident RAM savings unless resident memory was measured.
