### PR TITLE
test: fix two release-workflow failures on master

### DIFF
--- a/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
+++ b/veloxquant_mlx/tests/cache/test_issue_83_state_writethrough.py
@@ -16,21 +16,26 @@ Config per method mirrors each method's own dedicated test file's ``_make``
 helper, kept minimal here since only the base-class bookkeeping contract is
 under test — not each method's compression/eviction quality.
 
-H2O is a documented, deliberate EXCEPTION to the ``offset == shape[2]``
-assertion the other 16 methods satisfy (see ``_OFFSET_EQUALS_SHAPE_METHODS``
-below). Investigation (see docs-site/docs/algorithms/h2o.md and
-cache/h2o_cache.py's module docstring) found that this equality is exactly
-what caused a real, confirmed-on-real-models generation-corruption bug:
-``mlx_lm``'s attention module rotates the query and next incoming key using
+H2O and CurDKV are documented, deliberate EXCEPTIONS to the
+``offset == shape[2]`` assertion the other 15 methods satisfy (see
+``_OFFSET_EQUALS_SHAPE_METHODS`` below). Investigation (see
+docs-site/docs/algorithms/h2o.md and cache/h2o_cache.py's module docstring)
+found that this equality is exactly what caused a real,
+confirmed-on-real-models generation-corruption bug: ``mlx_lm``'s attention
+module rotates the query and next incoming key using
 ``self.rope(x, offset=cache.offset)`` *before* ``update_and_fetch`` is ever
 called, so once eviction makes ``shape[2] < true elapsed steps``, resetting
-``offset`` to ``shape[2]`` (what the other 16 methods do) silently rotates
-future queries/keys at the wrong absolute position. H2OKVCache fixes this by
+``offset`` to ``shape[2]`` (what the other 15 methods do) silently rotates
+future queries/keys at the wrong absolute position. H2OKVCache fixed this by
 keeping ``offset`` equal to the true step count instead, which necessarily
-makes ``offset != shape[2]`` once eviction has occurred — the *other* 16
-eviction methods are NOT yet known to be free of this same bug; they were not
-in scope for this fix and are tracked separately (see the linked follow-up
-issue in this repo's issue tracker) rather than silently assumed safe.
+makes ``offset != shape[2]`` once eviction has occurred; CurDKVKVCache was
+given the same fix afterwards (commit fdc8e8e, "fix(curdkv): track true
+absolute position for RoPE, not kept-row count") for the same
+confirmed-on-Llama-3.2-1B corruption, and so moved into the same exception
+group. The *other* 15 eviction methods are NOT yet known to be free of this
+same bug; they were not in scope for those fixes and are tracked separately
+(see the linked follow-up issue in this repo's issue tracker) rather than
+silently assumed safe.
 """
 
 from __future__ import annotations
@@ -70,11 +75,12 @@ _CASE_C_METHODS = ["palu", "kvtc"]
 ALL_METHODS = list(_CONFIGS)
 
 # Methods whose cache.offset must equal shape[2] (stored row count) at all
-# times. H2O is the sole documented exception: offset tracks the TRUE
+# times. H2O and CurDKV are the documented exceptions: offset tracks the TRUE
 # absolute step count instead, so mlx_lm's rope(x, offset=cache.offset) call
 # on the query/next key rotates correctly even after eviction has made
 # shape[2] < true step count — see module docstring above.
-_OFFSET_EQUALS_SHAPE_METHODS = [m for m in ALL_METHODS if m != "h2o"]
+_TRUE_STEP_COUNT_OFFSET_METHODS = ["h2o", "curdkv"]
+_OFFSET_EQUALS_SHAPE_METHODS = [m for m in ALL_METHODS if m not in _TRUE_STEP_COUNT_OFFSET_METHODS]
 
 
 def _make(method: str, head_dim: int = 8, **extra):
@@ -116,8 +122,9 @@ def test_state_shape_matches_offset(method: str) -> None:
     """cache.state's seq-length dim must equal cache.offset, mirroring the
     base KVCache contract mlx_lm relies on elsewhere (e.g. make_mask).
 
-    H2O is excluded — see module docstring for why offset intentionally
-    tracks true elapsed steps instead of shape[2] for that method.
+    H2O and CurDKV are excluded — see module docstring for why offset
+    intentionally tracks true elapsed steps instead of shape[2] for those
+    methods, and test_state_shape_at_or_below_offset for their counterpart.
     """
     cache = _make(method)
     k, v = _rand_kv(S=6)
@@ -129,13 +136,14 @@ def test_state_shape_matches_offset(method: str) -> None:
     assert v_state.shape[2] == cache.offset
 
 
-def test_h2o_state_shape_at_or_below_offset() -> None:
-    """H2O's counterpart to test_state_shape_matches_offset: shape[2] (rows
-    actually stored) must never EXCEED offset (true elapsed steps) — the
+@pytest.mark.parametrize("method", _TRUE_STEP_COUNT_OFFSET_METHODS)
+def test_state_shape_at_or_below_offset(method: str) -> None:
+    """H2O/CurDKV's counterpart to test_state_shape_matches_offset: shape[2]
+    (rows actually stored) must never EXCEED offset (true elapsed steps) — the
     reverse inequality would mean more rows are stored than steps have
     occurred, which is impossible — but may be strictly less once eviction
     has dropped rows. See module docstring."""
-    cache = _make("h2o")
+    cache = _make(method)
     k, v = _rand_kv(S=6)
     cache.update_and_fetch(k, v)
 
@@ -156,7 +164,8 @@ def test_state_accessible_across_chunked_prefill(method: str) -> None:
     per prefill_step_size chunk), each followed by a .state access (mirrors
     generate.py's `mx.eval([c.state for c in cache])` after every chunk).
 
-    H2O is excluded — see module docstring / test_h2o_state_shape_at_or_below_offset.
+    H2O and CurDKV are excluded — see module docstring /
+    test_state_shape_at_or_below_offset.
     """
     cache = _make(method)
     for seed in range(3):
@@ -167,10 +176,11 @@ def test_state_accessible_across_chunked_prefill(method: str) -> None:
         assert k_state.shape[2] == cache.offset
 
 
-def test_h2o_state_accessible_across_chunked_prefill() -> None:
-    """H2O counterpart: .state must stay accessible and shape[2] <= offset
-    throughout chunked prefill (mirrors the scenario above)."""
-    cache = _make("h2o")
+@pytest.mark.parametrize("method", _TRUE_STEP_COUNT_OFFSET_METHODS)
+def test_true_step_offset_state_accessible_across_chunked_prefill(method: str) -> None:
+    """H2O/CurDKV counterpart: .state must stay accessible and shape[2] <=
+    offset throughout chunked prefill (mirrors the scenario above)."""
+    cache = _make(method)
     for seed in range(3):
         k, v = _rand_kv(S=5, seed=seed)
         cache.update_and_fetch(k, v)
@@ -184,7 +194,8 @@ def test_state_accessible_after_decode_steps(method: str) -> None:
     """Prefill followed by several S==1 decode steps; .state must stay
     accessible and consistent with offset throughout.
 
-    H2O is excluded — see module docstring / test_h2o_state_shape_at_or_below_offset.
+    H2O and CurDKV are excluded — see module docstring /
+    test_state_shape_at_or_below_offset.
     """
     cache = _make(method)
     k, v = _rand_kv(S=5)
@@ -198,11 +209,13 @@ def test_state_accessible_after_decode_steps(method: str) -> None:
         assert k_state.shape[2] == cache.offset
 
 
-def test_h2o_state_accessible_after_decode_steps() -> None:
-    """H2O counterpart: .state stays accessible and shape[2] <= offset
-    throughout decode, and offset keeps climbing even once eviction caps
-    shape[2] — the whole point of the fix."""
-    cache = _make("h2o")
+@pytest.mark.parametrize("method", _TRUE_STEP_COUNT_OFFSET_METHODS)
+def test_true_step_offset_state_accessible_after_decode_steps(method: str) -> None:
+    """H2O/CurDKV counterpart: .state stays accessible and shape[2] <= offset
+    throughout decode, and offset keeps climbing by exactly one per decode
+    step even once eviction caps shape[2] — the whole point of the fix, since
+    mlx_lm rotates the next query/key at rope(x, offset=cache.offset)."""
+    cache = _make(method)
     k, v = _rand_kv(S=5)
     cache.update_and_fetch(k, v)
 

--- a/veloxquant_mlx/tests/cache/test_panel.py
+++ b/veloxquant_mlx/tests/cache/test_panel.py
@@ -18,10 +18,30 @@ from veloxquant_mlx.ui import config as ui_config
 from veloxquant_mlx.ui.server import PanelHandler
 from veloxquant_mlx.ui.supervisor import LOG_CAPACITY, ServerSupervisor
 
+# Generous enough that a slow/loaded CI runner never turns latency into a
+# spurious failure; the panel fixture already warms the one genuinely slow
+# call, so a request hitting this ceiling means something is really stuck.
+_TIMEOUT = 60
+
 
 @pytest.fixture()
 def panel():
-    """A control plane on an ephemeral port, torn down after the test."""
+    """A control plane on an ephemeral port, torn down after the test.
+
+    ``/api/methods`` resolves the method registry lazily *inside* the request
+    handler thread (deliberate: it keeps panel startup fast). The first
+    ``list_methods()`` call is the expensive one — it imports all 40 method
+    modules behind ``get_method``'s cache, ~5s here and slower on a cold CI
+    runner — while every later call is ~0.04s. That one-off cost landed on
+    whichever request came first, pushing it past the client timeout so the
+    test failed with a socket TimeoutError rather than any real panel bug.
+    Warm the cache here so it is paid during setup, not inside a timed
+    request.
+    """
+    from veloxquant_mlx.cache.registry import list_methods
+
+    list_methods()
+
     supervisor = ServerSupervisor()
     handler = type("T", (PanelHandler,), {"supervisor": supervisor})
     httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
@@ -38,7 +58,7 @@ def panel():
 
 
 def _get(base, path):
-    with urllib.request.urlopen(base + path, timeout=10) as resp:
+    with urllib.request.urlopen(base + path, timeout=_TIMEOUT) as resp:
         return resp.status, json.loads(resp.read())
 
 
@@ -50,7 +70,7 @@ def _post(base, path, payload):
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
             return resp.status, json.loads(resp.read())
     except urllib.error.HTTPError as exc:
         return exc.code, json.loads(exc.read())
@@ -203,7 +223,7 @@ def test_api_start_rejects_bad_input(panel):
 
 def test_api_serves_the_panel(panel):
     base, _ = panel
-    with urllib.request.urlopen(base + "/", timeout=10) as resp:
+    with urllib.request.urlopen(base + "/", timeout=_TIMEOUT) as resp:
         html = resp.read().decode()
     assert "VeloxQuant-MLX" in html
     assert 'id="primary-btn"' in html
@@ -212,7 +232,7 @@ def test_api_serves_the_panel(panel):
 def test_api_refuses_path_traversal(panel):
     base, _ = panel
     with pytest.raises(urllib.error.HTTPError) as exc:
-        urllib.request.urlopen(base + "/../config.py", timeout=10)
+        urllib.request.urlopen(base + "/../config.py", timeout=_TIMEOUT)
     assert exc.value.code == 404
 
 


### PR DESCRIPTION
Fixes the two failures in the release workflow on `master`. Both are test-side; neither indicated a production bug, and no production code is touched.

## 1. `test_state_accessible_across_chunked_prefill[curdkv]` — stale test

Commit `fdc8e8e` ("fix(curdkv): track true absolute position for RoPE, not kept-row count") deliberately changed `CurDKVKVCache.offset` to track the true absolute step count instead of the kept-row count. That fixed confirmed generation corruption on Llama-3.2-1B: `mlx_lm` rotates the query and next key via `self.rope(x, offset=cache.offset)` *before* `update_and_fetch` runs, so once eviction drops rows, `offset == shape[2]` rotates at the wrong absolute position.

H2O got the same fix earlier (`470ab0f`) and was moved into this file's documented exception list. CurDKV's fix never updated the test file, leaving `curdkv` in `_OFFSET_EQUALS_SHAPE_METHODS` — asserting exactly the property the fix intentionally removed.

It only trips once enough eviction accumulates for `offset` to diverge — the third prefill chunk (`assert 8 == 10`) — which is why the single-prefill cases still passed and this slipped through.

**Fix:** move `curdkv` into a shared `_TRUE_STEP_COUNT_OFFSET_METHODS` group alongside `h2o`, and parametrize the three former H2O-only counterpart tests over both. CurDKV is now genuinely covered rather than merely exempted — including `offset == prev_offset + 1` per decode step, the property the fix exists to guarantee. This file goes 117 → 118 tests.

`curdkv` correctly stays in `_CASE_A_METHODS` (verified `is_trimmable() is False`).

## 2. `test_api_methods_matches_registry` — slow call inside a timed request

`/api/methods` resolves the registry lazily inside the request handler thread. My first read blamed the module import, but profiling corrected that:

| | cost |
|---|---|
| `veloxquant_mlx.cache.registry` import | ~0.9s |
| **first** `list_methods()` call | **~5.1s** (imports all 40 method modules behind `get_method`'s cache) |
| every later `list_methods()` call | ~0.04s |

That one-off 5.1s landed on whichever request arrived first and crossed the client's 10s timeout on a cold CI runner — surfacing as a socket `TimeoutError`, not any panel defect. Locally the cache was usually already warm, so it passed.

**Fix:** warm `list_methods()` in the `panel` fixture so the cost is paid during setup, and raise the client timeout to 60s for margin. Measured against a cold registry: **5.16s in setup, request latency 0.13s** — a ~40x margin.

## Verification

- Full suite: **2153 passed**, 1 warning (the pre-existing unrelated `adakv` `UserWarning`, also present on the failing CI run)
- `ruff format --check` and `ruff check`: clean

## Note, out of scope

The ~5.1s first-`list_methods()` cost is real for actual panel users too — the first `/api/methods` request from a browser pays it. Not addressed here since the lazy import in `veloxquant_mlx/ui/server.py` is deliberate for panel startup, but worth knowing if the panel ever appears to hang on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)