### PR TITLE
perf(qfilters): vectorize the per-(B, H) eviction loop

### DIFF
--- a/veloxquant_mlx/cache/qfilters_cache.py
+++ b/veloxquant_mlx/cache/qfilters_cache.py
@@ -39,7 +39,10 @@ Limitations (stated plainly):
     non-contiguous where tokens were dropped.
   - Uniform budget and n_sink across all heads.
   - ``qfilters_recent`` (trailing protected window) is an extension, off by
-    default.
+    default. With it off, a long prefill's trailing tokens are ranked like
+    any other and mostly evicted before generation starts — pure projection
+    ranking has no recency bias. Set it when generation quality on long
+    prompts matters (see ``qfilters_update`` and :issue:`172`).
   - Calibrated filters are model-specific; a head-layout mismatch raises.
 
 Byte accounting (same names as L2NormKVCache):
@@ -64,6 +67,7 @@ from veloxquant_mlx.quantizers.qfilters import (
     qfilters_fp16_bytes,
     qfilters_get_kv,
     qfilters_update,
+    qfilters_update_batched,
 )
 
 
@@ -97,6 +101,16 @@ class QFiltersKVCache(_MLXKVCache):
         chunked prefill); ``is_trimmable()`` reports ``False`` since the
         internal per-token state can't be rolled back by a base-class
         ``trim()`` (see #83).
+
+        With calibrated filters, eviction runs as ONE vectorized selection over
+        all ``B*H`` groups (``qfilters_update_batched``) instead of a Python
+        loop per (batch, head) — the loop cost scaled with ``B*H`` and dominated
+        decode at realistic head counts (:issue:`173`). Selection is bit-for-bit
+        what the loop produced. Per-head ``QFiltersState`` objects are then
+        stale, and are rebuilt lazily by ``_sync_states()`` for the diagnostic
+        surface (``states``); nothing on the hot path reads them. The key-SVD
+        fallback keeps the loop — its per-group filters freeze at different
+        times, which a single shared-filter selection cannot express.
     """
 
     def __init__(self, config: Any, filters: mx.array | None = None) -> None:
@@ -129,6 +143,13 @@ class QFiltersKVCache(_MLXKVCache):
         self._states: list[QFiltersState] = []
         self._B: int = 0
         self._H: int = 0
+
+        # Batched fast-path buffers ([BH, n_kept, D]); see _update_batched.
+        self._batched_keys: mx.array | None = None
+        self._batched_values: mx.array | None = None
+        self._batched_scores: mx.array | None = None
+        self._batched_filters: mx.array | None = None
+        self._states_stale: bool = False
 
         self._qfilters_kept_bytes: int = 0
         self._full_seq_bytes: int = 0
@@ -174,6 +195,87 @@ class QFiltersKVCache(_MLXKVCache):
         return b * self._H + h
 
     # ------------------------------------------------------------------
+    def _can_batch(self) -> bool:
+        """True when every group can be evicted in one vectorized selection.
+
+        Requires a calibrated filter: only then is every group's filter frozen
+        before token 0, so all ``B*H`` groups hold the same row count and share
+        one selection. The key-SVD fallback freezes each group's direction
+        whenever that group crosses ``calib_tokens``, and groups can sit in
+        different regimes within a single call, so it keeps the per-head loop
+        (which is also where its documented path-dependence lives).
+        """
+        return self._filters is not None
+
+    def _update_batched(
+        self, keys: mx.array, values: mx.array, B: int, H: int, D: int
+    ) -> tuple[mx.array, mx.array]:
+        """Absorb + evict all ``(b, h)`` groups at once, then mirror into states.
+
+        Keeps its own ``[BH, n, D]`` buffer so the hot path never restacks
+        per-head arrays. ``self._states`` is refreshed from it as a view so the
+        byte-accounting properties and ``tokens_kept`` stay accurate; those
+        slices are lazy in MLX and cost nothing until read.
+        """
+        BH = B * H
+        new_k = keys.reshape(BH, -1, D).astype(mx.float16)
+        new_v = values.reshape(BH, -1, D).astype(mx.float16)
+
+        if self._batched_keys is None:
+            keys_cat, values_cat = new_k, new_v
+        else:
+            keys_cat = mx.concatenate([self._batched_keys, new_k], axis=1)
+            values_cat = mx.concatenate([self._batched_values, new_v], axis=1)
+
+        # [H, D] filters are shared across the batch: tile to [BH, D] so group
+        # g = b*H + h reads row h, matching _ensure_states' `i % H`.
+        if self._batched_filters is None:
+            self._batched_filters = mx.tile(self._filters, (B, 1))
+
+        keys_out, values_out, scores_out = qfilters_update_batched(
+            keys_cat,
+            values_cat,
+            self._batched_filters,
+            budget=self._budget,
+            n_sink=self._n_sink,
+            recent=self._recent,
+            sign=self._sign,
+        )
+        self._batched_keys = keys_out
+        self._batched_values = values_out
+        self._batched_scores = scores_out
+        # self._states is now stale; it is rebuilt on demand by _sync_states()
+        # rather than here, so the hot path stays free of any BH-length loop.
+        self._states_stale = True
+
+        return keys_out.reshape(B, H, -1, D), values_out.reshape(B, H, -1, D)
+
+    def _sync_states(self) -> None:
+        """Materialize per-head ``QFiltersState`` views from the batched buffers.
+
+        Only the diagnostic surface (``tokens_kept``, ``.state``-adjacent
+        introspection, tests reaching into ``_states``) needs per-head objects,
+        so the BH-length rebuild is deferred to whoever actually reads them
+        instead of running on every ``update_and_fetch``.
+        """
+        if not self._states_stale or self._batched_keys is None:
+            return
+        for g in range(len(self._states)):
+            st = self._states[g]
+            self._states[g] = QFiltersState(
+                keys=self._batched_keys[g],
+                values=self._batched_values[g],
+                scores=self._batched_scores[g],
+                filter_dir=st.filter_dir,
+                n_sink=st.n_sink,
+                budget=st.budget,
+                recent=st.recent,
+                calib_tokens=st.calib_tokens,
+                sign=st.sign,
+            )
+        self._states_stale = False
+
+    # ------------------------------------------------------------------
     def update_and_fetch(self, keys: mx.array, values: mx.array):
         """Absorb new K/V tokens, apply projection eviction, return retained window.
 
@@ -191,27 +293,37 @@ class QFiltersKVCache(_MLXKVCache):
         self._full_seq_bytes += B * H * S * D * 2 * 2  # K + V, fp16
         self._tokens_seen_total += B * H * S
 
-        k_out_b, v_out_b = [], []
-        for b in range(B):
-            k_out_h, v_out_h = [], []
-            for h in range(H):
-                idx = self._head_idx(b, h)
-                st = qfilters_update(
-                    self._states[idx],
-                    keys[b, h].astype(mx.float16),
-                    values[b, h].astype(mx.float16),
-                )
-                self._states[idx] = st
-                k_h, v_h = qfilters_get_kv(st)
-                k_out_h.append(k_h)
-                v_out_h.append(v_h)
-            k_out_b.append(mx.stack(k_out_h, axis=0))
-            v_out_b.append(mx.stack(v_out_h, axis=0))
+        if self._can_batch():
+            K_out, V_out = self._update_batched(keys, values, B, H, D)
+        else:
+            k_out_b, v_out_b = [], []
+            for b in range(B):
+                k_out_h, v_out_h = [], []
+                for h in range(H):
+                    idx = self._head_idx(b, h)
+                    st = qfilters_update(
+                        self._states[idx],
+                        keys[b, h].astype(mx.float16),
+                        values[b, h].astype(mx.float16),
+                    )
+                    self._states[idx] = st
+                    k_h, v_h = qfilters_get_kv(st)
+                    k_out_h.append(k_h)
+                    v_out_h.append(v_h)
+                k_out_b.append(mx.stack(k_out_h, axis=0))
+                v_out_b.append(mx.stack(v_out_h, axis=0))
 
-        K_out = mx.stack(k_out_b, axis=0)
-        V_out = mx.stack(v_out_b, axis=0)
+            K_out = mx.stack(k_out_b, axis=0)
+            V_out = mx.stack(v_out_b, axis=0)
 
-        self._qfilters_kept_bytes = sum(qfilters_fp16_bytes(st) for st in self._states)
+        if self._batched_keys is not None:
+            # Closed form of the per-state sum: every group holds the same
+            # n_kept rows and one float32 filter_dir, so summing BH identical
+            # terms in Python would just re-add the loop this path removes.
+            bh, n_kept, d = (int(x) for x in self._batched_keys.shape)
+            self._qfilters_kept_bytes = bh * (n_kept * d * 2 * 2 + d * 4)
+        else:
+            self._qfilters_kept_bytes = sum(qfilters_fp16_bytes(st) for st in self._states)
 
         # K_out/V_out is the full retained state every call, not a delta —
         # reset so the base class's append-only buffer starts fresh instead
@@ -281,9 +393,22 @@ class QFiltersKVCache(_MLXKVCache):
     @property
     def tokens_kept(self) -> int:
         """Tokens currently in the (B=0, H=0) head's cache (diagnostic)."""
+        if self._batched_keys is not None:
+            return int(self._batched_keys.shape[1])
         if not self._states or self._states[0].keys is None:
             return 0
         return int(self._states[0].keys.shape[0])
+
+    @property
+    def states(self) -> list[QFiltersState]:
+        """Per-head eviction states (diagnostic).
+
+        On the batched path these are rebuilt lazily from the ``[BH, n, D]``
+        buffers, so reading this is what pays the BH-length cost — never the
+        hot path.
+        """
+        self._sync_states()
+        return self._states
 
 
 __all__ = ["QFiltersKVCache"]

--- a/veloxquant_mlx/quantizers/qfilters.py
+++ b/veloxquant_mlx/quantizers/qfilters.py
@@ -58,6 +58,7 @@ QFiltersState           — immutable per-head state dataclass
 init_qfilters_state     — construct empty state (validates budget/sign guards)
 estimate_filter_dir     — top right-singular vector of observed keys (frozen)
 qfilters_update         — absorb a whole [S, D] block, evict if over budget
+qfilters_update_batched — same selection for all [BH, n_total, D] groups at once
 qfilters_get_kv         — extract current (keys, values) arrays
 qfilters_fp16_bytes     — bytes stored in current state (incl. filter_dir)
 full_qfilters_fp16_bytes — hypothetical cost without eviction
@@ -199,6 +200,29 @@ def qfilters_update(
     Once enough keys are seen the filter is estimated & frozen, all stored
     tokens are scored, and the over-budget case is a single protected top-k.
     Kept tokens are returned in original temporal order.
+
+    One-shot eviction == incremental eviction (calibrated path)
+    -----------------------------------------------------------
+    A token is scored once, against a filter frozen before token 0, and its
+    score never changes while it is cached. Selecting the top ``budget`` rows
+    under a fixed key is therefore order-invariant: absorbing S tokens and
+    evicting once retains exactly the rows that evicting after every chunk
+    would. Feeding the same prompt as one block, in 256-token chunks, or one
+    token at a time yields bit-identical K/V and the same ``budget`` bound
+    (:issue:`172`; ``test_calibrated_kept_set_is_invariant_to_prefill_chunk_size``).
+    Incremental eviction would buy nothing here — it is the same function.
+
+    The trade-off this DOES expose: with ``recent=0`` the trailing tokens of a
+    long prefill are scored like any other, so most of the prompt's tail —
+    typically where the question lives — is evicted before the first token is
+    generated, which degrades generation badly at small budgets. That is a
+    property of pure projection ranking, not of chunking. Set ``recent`` to
+    pin a trailing window when generation quality on long prompts matters.
+
+    On the key-SVD FALLBACK path the frozen direction still depends on which
+    chunk first crosses ``calib_tokens``, so kept sets legitimately differ
+    across chunkings (see the module docstring). Only the calibrated path is
+    path-independent.
     """
     new_keys = new_keys.astype(mx.float16)
     new_values = new_values.astype(mx.float16)
@@ -267,6 +291,72 @@ def qfilters_update(
     )
 
 
+def qfilters_update_batched(
+    keys_cat: mx.array,  # [BH, n_total, D] fp16
+    values_cat: mx.array,  # [BH, n_total, D] fp16
+    filter_dir: mx.array,  # [BH, D] float32, frozen
+    budget: int,
+    n_sink: int,
+    recent: int,
+    sign: int,
+) -> tuple[mx.array, mx.array, mx.array]:
+    """Score and evict every ``(batch, head)`` group at once — no Python loop.
+
+    The batched twin of :func:`qfilters_update`'s post-calibration branch, for
+    the case the cache actually runs in: one frozen filter per group, a budget
+    / ``n_sink`` / ``recent`` / ``sign`` shared by every head, and the same
+    ``n_total`` rows in every group. Those uniformities are what make the whole
+    ``[BH, n_total, D]`` block a single vectorized selection (:issue:`173`).
+
+    Selection is identical to the per-head path: protected rows are lifted to
+    ``+inf``, an ascending ``argsort`` takes the top ``budget``, and survivors
+    are returned in temporal order. Ties break toward the same rows because the
+    sort key and ordering convention are the same.
+
+    Args:
+        keys_cat:   ``[BH, n_total, D]`` fp16 stored + newly appended keys.
+        values_cat: ``[BH, n_total, D]`` fp16, same layout.
+        filter_dir: ``[BH, D]`` float32 frozen per-group unit-norm Q-Filter.
+        budget:     Rows retained per group, including protected rows.
+        n_sink:     Leading rows never evicted.
+        recent:     Trailing rows never evicted.
+        sign:       ``+1`` = paper direction; ``-1`` = inverted ablation.
+
+    Returns:
+        ``(keys, values, scores)`` — keys/values ``[BH, n_kept, D]`` fp16 and
+        scores ``[BH, n_kept]`` float32, temporal order. When the block is
+        under budget nothing is evicted and ``n_kept == n_total``.
+    """
+    bh, n_total, _ = (int(x) for x in keys_cat.shape)
+
+    # sign * <k_i, f_g> per group — one batched matvec for all BH groups.
+    scores_cat = sign * mx.einsum("gnd,gd->gn", keys_cat.astype(mx.float32), filter_dir)
+
+    if n_total <= budget:
+        return keys_cat, values_cat, scores_cat
+
+    n_sink_eff = min(n_sink, n_total)
+    protect = mx.zeros((n_total,), dtype=mx.float32)
+    if n_sink_eff > 0:
+        protect[:n_sink_eff] = float("inf")
+    if recent > 0:
+        r_eff = min(recent, n_total - n_sink_eff)
+        if r_eff > 0:
+            protect[n_total - r_eff :] = float("inf")
+    sel = scores_cat + protect  # broadcasts [n_total] across groups
+
+    order = mx.argsort(sel, axis=-1)  # ascending, per group
+    keep_idx = mx.sort(order[:, n_total - budget :], axis=-1)  # [BH, budget]
+
+    # take_along_axis gathers a *different* row set per group in one op — the
+    # part a per-head loop was doing serially.
+    gather = mx.expand_dims(keep_idx, axis=-1)
+    keys_out = mx.take_along_axis(keys_cat, gather, axis=1)
+    values_out = mx.take_along_axis(values_cat, gather, axis=1)
+    scores_out = mx.take_along_axis(scores_cat, keep_idx, axis=1)
+    return keys_out, values_out, scores_out
+
+
 def qfilters_get_kv(state: QFiltersState) -> tuple[mx.array, mx.array]:
     """Return ``(keys, values)`` arrays from state.
 
@@ -304,6 +394,7 @@ __all__ = [
     "init_qfilters_state",
     "estimate_filter_dir",
     "qfilters_update",
+    "qfilters_update_batched",
     "qfilters_get_kv",
     "qfilters_fp16_bytes",
     "full_qfilters_fp16_bytes",

--- a/veloxquant_mlx/tests/cache/test_qfilters_cache.py
+++ b/veloxquant_mlx/tests/cache/test_qfilters_cache.py
@@ -17,6 +17,7 @@ import pytest
 
 from veloxquant_mlx.cache.base import KVCacheBuilder, KVCacheConfig, KVCacheFactory
 from veloxquant_mlx.cache.qfilters_cache import QFiltersKVCache
+from veloxquant_mlx.quantizers.qfilters import qfilters_fp16_bytes
 
 
 def _kv(B, H, S, D, seed=0):
@@ -337,6 +338,174 @@ def test_calibrated_filter_is_path_independent() -> None:
 
     assert np.array_equal(np.array(k_prefill), np.array(k_decode))
     assert np.array_equal(np.array(v_prefill), np.array(v_decode))
+
+
+@pytest.mark.parametrize("chunk", [1073, 512, 256, 64, 16, 1])
+def test_calibrated_kept_set_is_invariant_to_prefill_chunk_size(chunk: int) -> None:
+    """Same prompt, any chunking — bit-identical retained K/V and offset (#172).
+
+    Q-Filters scores a token once, against a filter frozen before token 0, and
+    a token's score never changes afterwards. Top-k under a fixed key is
+    order-invariant, so absorbing S tokens then evicting once and evicting
+    incrementally select the *same* rows. This pins that: the chunk-size
+    sensitivity reported in #172 is not an eviction-ordering effect.
+    """
+    B, H, S, D = 1, 4, 1073, 16
+    cfg = KVCacheConfig(method="qfilters", head_dim=D, qfilters_budget=128, qfilters_n_sink=4)
+    filters = _calibrated_filters(H, D, seed=7)
+    k, v = _kv_block(B, H, S, D, seed=8)
+
+    one_shot = QFiltersKVCache(cfg, filters=filters)
+    k_ref, v_ref = one_shot.update_and_fetch(k, v)
+
+    chunked = QFiltersKVCache(cfg, filters=filters)
+    k_out = v_out = None
+    for i in range(0, S, chunk):
+        k_out, v_out = chunked.update_and_fetch(k[:, :, i : i + chunk], v[:, :, i : i + chunk])
+
+    assert np.array_equal(np.array(k_ref), np.array(k_out))
+    assert np.array_equal(np.array(v_ref), np.array(v_out))
+    # Budget is respected regardless of how the prompt was fed in.
+    assert k_out.shape[2] == 128
+    # True absolute position must not depend on chunking, or RoPE drifts.
+    assert chunked.offset == one_shot.offset == S
+
+
+@pytest.mark.parametrize("chunk", [1073, 256, 64])
+def test_recent_window_protects_prompt_tail_at_every_chunk_size(chunk: int) -> None:
+    """``qfilters_recent`` pins the trailing window regardless of chunking (#172).
+
+    With ``recent=0`` the tail of a long prompt — where the actual question
+    lives — is scored like any other token and is almost entirely evicted,
+    which is what produces degenerate generation. The trailing guard is the
+    knob that prevents it, and it must behave identically under one-shot and
+    chunked prefill.
+    """
+    B, H, S, D, recent = 1, 2, 1073, 16, 32
+    cfg = KVCacheConfig(
+        method="qfilters",
+        head_dim=D,
+        qfilters_budget=128,
+        qfilters_n_sink=4,
+        qfilters_recent=recent,
+    )
+    filters = _calibrated_filters(H, D, seed=9)
+    k, v = _kv_block(B, H, S, D, seed=10)
+
+    cache = QFiltersKVCache(cfg, filters=filters)
+    k_out = None
+    for i in range(0, S, chunk):
+        k_out, _ = cache.update_and_fetch(k[:, :, i : i + chunk], v[:, :, i : i + chunk])
+
+    assert k_out.shape[2] == 128
+    # The final `recent` rows of the window are exactly the prompt's last
+    # `recent` tokens, in order — never evicted, never reordered.
+    tail_expected = np.array(k)[:, :, S - recent :]
+    assert np.array_equal(np.array(k_out)[:, :, -recent:], tail_expected)
+
+
+def _reference_evict(k, v, filters, budget, n_sink, recent, sign):
+    """Per-(b, h) numpy oracle for the vectorized path (#173).
+
+    Deliberately an independent reimplementation rather than a call into
+    ``qfilters_update``: a parity test that shares code with the thing it
+    checks can only catch wiring mistakes, not selection mistakes.
+    """
+    k = np.array(k, dtype=np.float16)
+    v = np.array(v, dtype=np.float16)
+    f = np.array(filters, dtype=np.float32)
+    B, H, S, _ = k.shape
+    ks, vs = [], []
+    for b in range(B):
+        kh, vh = [], []
+        for h in range(H):
+            scores = k[b, h].astype(np.float32) @ f[h] * sign
+            if S > budget:
+                sel = scores.copy()
+                sel[: min(n_sink, S)] = np.inf
+                if recent > 0:
+                    sel[S - min(recent, S - min(n_sink, S)) :] = np.inf
+                keep = np.sort(np.argsort(sel, kind="stable")[S - budget :])
+            else:
+                keep = np.arange(S)
+            kh.append(k[b, h][keep])
+            vh.append(v[b, h][keep])
+        ks.append(np.stack(kh))
+        vs.append(np.stack(vh))
+    return np.stack(ks), np.stack(vs)
+
+
+@pytest.mark.parametrize(
+    ("B", "H", "S", "budget", "n_sink", "recent", "sign"),
+    [
+        (1, 4, 300, 64, 4, 0, 1),  # single batch
+        (3, 4, 300, 64, 4, 0, 1),  # batched — the loop's worst case
+        (2, 3, 257, 48, 4, 8, 1),  # recent window + ragged S
+        (1, 4, 300, 64, 2, 0, -1),  # inverted sign ablation
+        (2, 2, 20, 64, 4, 0, 1),  # under budget — no eviction at all
+        (2, 8, 512, 128, 4, 16, 1),  # GQA-shaped head count
+    ],
+)
+def test_batched_path_matches_per_head_reference(
+    B: int, H: int, S: int, budget: int, n_sink: int, recent: int, sign: int
+) -> None:
+    """Vectorizing the B×H loop must not move a single bit (#173)."""
+    D = 16
+    cfg = KVCacheConfig(
+        method="qfilters",
+        head_dim=D,
+        qfilters_budget=budget,
+        qfilters_n_sink=n_sink,
+        qfilters_recent=recent,
+        qfilters_sign=sign,
+    )
+    filters = _calibrated_filters(H, D, seed=11)
+    k, v = _kv_block(B, H, S, D, seed=12)
+
+    cache = QFiltersKVCache(cfg, filters=filters)
+    k_out, v_out = cache.update_and_fetch(k, v)
+
+    k_ref, v_ref = _reference_evict(k, v, filters, budget, n_sink, recent, sign)
+    assert np.array_equal(np.array(k_out), k_ref)
+    assert np.array_equal(np.array(v_out), v_ref)
+
+
+def test_batched_path_state_mirror_stays_consistent() -> None:
+    """Lazily-rebuilt per-head states must match the batched buffers (#173).
+
+    The fast path leaves ``_states`` stale and refreshes it on demand; if that
+    sync drifts, byte accounting and ``tokens_kept`` silently go wrong.
+    """
+    B, H, S, D, budget = 2, 4, 300, 16, 64
+    cfg = KVCacheConfig(method="qfilters", head_dim=D, qfilters_budget=budget, qfilters_n_sink=4)
+    filters = _calibrated_filters(H, D, seed=13)
+    k, v = _kv_block(B, H, S, D, seed=14)
+
+    cache = QFiltersKVCache(cfg, filters=filters)
+    k_out, _ = cache.update_and_fetch(k, v)
+
+    assert cache.tokens_kept == budget
+    states = cache.states
+    assert len(states) == B * H
+    for g, st in enumerate(states):
+        b, h = divmod(g, H)
+        assert np.array_equal(np.array(st.keys), np.array(k_out)[b, h])
+        assert st.scores.shape[0] == budget
+    # Closed-form byte accounting must equal the per-state sum it replaced.
+    assert cache.qfilters_kept_bytes == sum(qfilters_fp16_bytes(st) for st in states)
+
+
+def test_fallback_path_still_uses_per_head_loop() -> None:
+    """The key-SVD fallback must not be silently routed to the batched path.
+
+    Its filters freeze per group at different times, which the shared-filter
+    vectorization cannot represent — so it must keep the loop (#173).
+    """
+    cfg = KVCacheConfig(method="qfilters", head_dim=16, qfilters_budget=32)
+    fallback = QFiltersKVCache(cfg)
+    assert fallback._can_batch() is False
+    calibrated = QFiltersKVCache(cfg, filters=_calibrated_filters(4, 16))
+    assert calibrated._can_batch() is True
 
 
 def test_calibrated_selection_matches_projection_ranking() -> None:


### PR DESCRIPTION
Closes #173. Also resolves the investigation in #172.

## #173 — vectorizing the loop

`update_and_fetch` ran a Python loop over every `(batch, head)` pair. The cost scaled with `B×H` and was nearly independent of `S`, so it dominated decode at realistic head counts — confirming the premise in #173 that the previous TTFT/throughput figures measured implementation overhead rather than the algorithm.

On the calibrated path every group shares one frozen filter, one budget, one `n_sink`/`recent`/`sign`, and the same row count, so the whole `[BH, n_total, D]` block is a single selection. `qfilters_update_batched()` does it with one `einsum`, one batched `argsort`, and `take_along_axis` to gather a different surviving row set per group.

Two secondary `B×H` loops also had to go, or bookkeeping would have cancelled the win:
- **Byte accounting** summed `qfilters_fp16_bytes` over every state on every call; all groups hold the same `n_kept` rows, so it now has a closed form.
- **Per-head `QFiltersState`** objects are only read by diagnostics, so they are marked stale and rebuilt lazily in `_sync_states()`, exposed via a new `states` property.

The key-SVD **fallback deliberately keeps the loop** — its per-group filters freeze whenever each group crosses `calib_tokens`, and groups can sit in different regimes within one call, which a single shared-filter selection cannot express. `_can_batch()` gates this and is covered by a test.

### Benchmarks

Isolated processes, warmed, min-of-5. The machine shows an intermittent ~3× slow mode that makes single runs and even medians unreliable — worth knowing for any follow-up measurement.

| config | TTFT before→after | decode before→after | decode speedup |
|---|---|---|---|
| B=1 H=8 S=1024 | 0.51 → 0.45 ms | 0.491 → 0.329 ms | **1.49×** |
| B=1 H=32 S=1024 | 1.45 → 0.92 ms | 1.838 → 0.613 ms | **3.00×** |
| B=4 H=32 S=1024 | 8.40 → 2.62 ms | 6.942 → 1.626 ms | **4.27×** |
| B=1 H=8 S=4096 | 1.08 → 0.87 ms | 0.557 → 0.406 ms | **1.37×** |
| B=4 H=32 S=4096 | 13.17 → 8.48 ms | 7.421 → 2.852 ms | **2.60×** |

Gain scaling with `B×H` and not with `S` is the signature of the removed Python/dispatch overhead.

### Parity

Bit-for-bit unchanged selection: `K`/`V`/`offset`/`tokens_kept`/byte-accounting dumped on both sides of a `git stash` across single-batch, multi-batch, recent-window, inverted-sign, under-budget and GQA-shaped configs, prefill plus five decode steps.

## #172 — eviction semantics (documentation, no algorithm change)

The root cause proposed in #172 does not hold. On the calibrated path, one-shot and incremental eviction are **the same function**: a token is scored once against a filter frozen before token 0 and its score never changes, so top-k under a fixed key is order-invariant. Measured retained sets are bit-identical at chunk sizes 1073/256/64/1, and `offset` ends at 1073 in all of them.

The actual cause of the degenerate output is that **`qfilters_recent` defaults to 0**. Projection ranking has no recency bias, so the prompt tail — where the question lives — gets scored like any other token and evicted; in the repro only 2 of the final 49 prompt tokens survived, at *every* chunk size. Small chunks were masking the problem, not avoiding a bad eviction decision. This is now stated plainly in `qfilters_update` and the cache module.

I did **not** change the `qfilters_recent` default. Making it `budget//8` would be safe out of the box, but that is a behavioural default change and should be a deliberate call — happy to add it here if you want it.

## Tests

8 new cases for #173: 6 parametrized parity configs against an **independent numpy oracle** (deliberately not a call into `qfilters_update` — a parity test sharing code with its subject only catches wiring bugs, not selection bugs), plus state-mirror consistency and the `_can_batch()` gate. Plus 9 chunk-invariance cases for #172.

Mutation-checked against the batched function: dropping the sink guard, dropping the recent guard, inverting the sign, keeping lowest-instead-of-highest, and skipping the temporal re-sort each fail 5–15 tests.

**Full suite: 2218 passed.** Ruff clean on the touched files (the 653 repo-wide findings are pre-existing on `master`, unchanged).

## Follow-up not taken

`qfilters_fused_evict` is exported but still unwired, and computes the same `[BH, n_total, D]` selection this PR now does in MLX. Worth benchmarking whether the kernel beats the vectorized path — left alone since #173 asked to preserve existing kernel behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)