### PR TITLE
Review SnapKV RoPE position semantics vs. paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,28 @@ anyway). **Not measured**: whether the paper's renumbering scheme would
 produce different generation quality — that needs real model inference
 and remains open, same as [#187](https://github.com/rajveer43/VeloxQuant-MLX/issues/187).
 
+**Reviewed SnapKV-adapted's RoPE position semantics against the paper**
+([#188](https://github.com/rajveer43/VeloxQuant-MLX/issues/188)) — unlike
+StreamingLLM, the SnapKV paper doesn't define a position-renumbering scheme
+at all (it compresses the cache once, at the end of prefill, before
+generation starts); common HF-`DynamicCache`-based reference
+implementations instead fall back to the retained-row-count convention this
+repo's `#171` fix moved away from. Reviewed why absolute-position
+preservation isn't a stylistic choice here but the behavior mathematically
+required by how the eviction mechanism works: SnapKV selects from K rows
+the model already rotated with RoPE during its own prefill forward pass, so
+survivors' rotations are permanently baked in before eviction happens —
+reporting anything but their true position would break RoPE's
+relative-distance identity. Unlike StreamingLLM (continuous per-step
+eviction), a hypothetical renumbering scheme here would only cost a
+one-time `O(budget)` re-rotation right after prefill compression — still not
+worth implementing, since exact positions already require none. Test
+coverage already existed
+(`test_offset_tracks_true_position_not_retained_rows` plus the
+chunked-prefill offset assertions) — no code or test changes needed, this
+was purely a documentation review. Added to
+`docs-site/docs/algorithms/snapkv.md`.
+
 ### Fixed
 
 **RoPE positions after eviction in TOVA-adapted**

--- a/docs-site/docs/algorithms/snapkv.md
+++ b/docs-site/docs/algorithms/snapkv.md
@@ -81,6 +81,74 @@ stream), but the proxy is still an approximation.
 The paper's max-pool smoothing step (`kernel_size > 1`) is not implemented. Documented
 as "SnapKV-adapted (key-as-query proxy)" throughout — never claimed as a faithful port.
 
+## RoPE position semantics vs. the paper (#188)
+
+Requested by [#188](https://github.com/rajveer43/VeloxQuant-MLX/issues/188): a
+review of whether preserving original absolute positions after eviction is
+the correct behavior for this implementation.
+
+**What the paper specifies.** Unlike StreamingLLM's paper — which explicitly
+describes reassigning RoPE position IDs by slot in a continuously-sliding
+window — the SnapKV paper does not define a position-renumbering scheme at
+all. SnapKV compresses the cache **exactly once**, at the end of prefill,
+before generation starts; the paper's contribution is which tokens to keep,
+not how position IDs should be assigned to the compressed result afterward.
+That said, common eviction reference implementations built on HF's
+`DynamicCache` typically derive "current position" from
+`past_key_values.get_seq_length()` — i.e., the **retained row count** — since
+that is the cache's built-in length semantics once rows are physically
+dropped. That convention is exactly what this repo's [#171](https://github.com/rajveer43/VeloxQuant-MLX/issues/171)
+fix moved away from.
+
+**Why absolute-position preservation isn't just a style choice here.** SnapKV
+eviction is a *post-hoc selection* over K rows that the model already rotated
+with RoPE during its own prefill forward pass — the cache wrapper never sees
+unrotated keys, and it has no access to the rotary embedding layer to
+re-rotate them (`update_and_fetch` only receives K/V tensors). Every
+surviving key's true-position rotation is therefore permanently baked in
+before eviction ever happens. Given that, reporting the retained row count as
+the position for subsequent tokens isn't a faithful-to-paper convention — it
+puts new queries/keys on a different absolute axis than the frozen survivors,
+which breaks the RoPE relative-distance identity
+(`⟨rope(q,i), rope(k,j)⟩` depends only on `i-j`) and silently corrupts
+attention. That is precisely the bug #171 found and fixed via `_true_offset`
+and the `offset` property split (see the code comments in
+`snapkv_cache.py` for the full mechanics — the base class needs the retained
+row count for its own cursor/slice arithmetic while everything outside it,
+including mlx_lm's RoPE, needs the true position; `_in_base` switches which
+one `self.offset` reads).
+
+**Contrast with StreamingLLM ([#189](https://github.com/rajveer43/VeloxQuant-MLX/issues/189)).**
+StreamingLLM evicts continuously, every decode step once its window is full,
+so faithfully renumbering positions there would mean re-rotating survivors on
+every step. SnapKV only evicts at prefill (`_process_prefill` /
+`_process_prefill_chunk`); decode tokens (`S == 1`) are always appended,
+never evicted. If renumbering-to-contiguous were ever implemented here, its
+re-rotation cost would be a **one-time** `O(budget)` operation right after
+prefill compression completes — not a per-decode-step cost. This implementation
+still doesn't do it, because absolute-position preservation is already exact
+and requires no re-rotation at all; the one-time cost would buy nothing but
+parity with the naive HF-`DynamicCache` convention.
+
+**What is NOT validated here.** Whether generation quality, perplexity, or
+retrieval behavior would differ under a renumbering scheme has **not been
+measured** — that needs a real model forward pass, which this development
+environment cannot run. See [#187](https://github.com/rajveer43/VeloxQuant-MLX/issues/187)
+and [#198](https://github.com/rajveer43/VeloxQuant-MLX/issues/198) for the
+general GPU-blocked-measurement pattern this repo follows.
+
+**Decision:** keep absolute-position preservation. It is the behavior
+mathematically required by how SnapKV's eviction mechanism actually works
+(post-hoc selection from already-rotated keys, no re-rotation performed), it
+is consistent with every other eviction cache in this library, and unlike
+StreamingLLM there isn't even a re-rotation-cost tradeoff to weigh — the
+alternative buys nothing. Regression coverage already exists in
+`test_snapkv_cache.py` (`test_offset_tracks_true_position_not_retained_rows`,
+plus the chunked-prefill offset assertions in
+`test_chunked_prefill_budget_stays_capped` and
+`test_chunked_prefill_then_decode_appends`); no code change was needed for
+this review.
+
 ## Evidence
 
 All claims trace to passing tests in
@@ -98,6 +166,10 @@ All claims trace to passing tests in
 - `keep_rate` in `(0, 1]` after realistic-budget prefill
 - Decode accumulation: seq dim grows by 1 per single-token call
 - Determinism; `for_model` config propagation (`_budget`, `_obs_window`, `_n_sink`)
+- `cache.offset` tracks the true absolute token position (not the retained
+  row count) after single-chunk eviction, across multi-chunk prefill
+  re-enforcement, and through a subsequent decode run (#171, reviewed
+  against the paper for #188 — see the RoPE section above)
 
 The offline harness in `benchmark_scripts/benchmark_snapkv.py` measures attention
 coverage (fraction of total obs-window attention mass in the kept set) vs a


### PR DESCRIPTION
## Summary

`SnapKVKVCache` already preserves original absolute token positions after eviction (the `_true_offset` / `offset`-property-split fix from #171), with existing regression coverage in `test_snapkv_cache.py`. This divergence had never been reviewed against the paper explicitly — this PR does that, as requested by #188.

Key finding: unlike StreamingLLM (#189, reviewed and merged in #199), the SnapKV paper doesn't actually define a position-renumbering scheme at all — SnapKV compresses the cache exactly once, at the end of prefill, before generation starts. The new `## RoPE position semantics vs. the paper (#188)` section in `docs-site/docs/algorithms/snapkv.md` covers:

- What the paper (and common HF-`DynamicCache`-based reference implementations) actually do for position bookkeeping after eviction.
- Why absolute-position preservation isn't a stylistic choice here but the behavior **mathematically required** by how the eviction mechanism works: SnapKV selects from K rows the model already rotated with RoPE during its own prefill forward pass, so survivors' rotations are permanently baked in *before* the cache wrapper ever sees them — reporting anything but their true position would break RoPE's relative-distance identity (`⟨rope(q,i), rope(k,j)⟩` depends only on `i-j`).
- Contrast with StreamingLLM: a hypothetical renumbering scheme here would only cost a **one-time** `O(budget)` re-rotation right after prefill compression, not StreamingLLM's implied per-decode-step cost — still not worth implementing, since exact positions already require no re-rotation at all.
- What's explicitly **not** validated: whether generation quality would differ under a renumbering scheme — needs real model inference, tracked as open per #187/#198.

No functional code or test changes — regression coverage already existed (`test_offset_tracks_true_position_not_retained_rows`, plus the chunked-prefill offset assertions in `test_chunked_prefill_budget_stays_capped` / `test_chunked_prefill_then_decode_appends`). This is a pure documentation review.

## Related issue

Closes #188

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon — **not applicable**: no test code changed. This development environment has no `mlx`/Metal runtime available (`import mlx.core` fails), so pytest cannot be executed here regardless.
- [x] New or updated unit tests cover the change — N/A, no code change; existing coverage already validated the reviewed behavior (cited above).
- [x] Docs updated if user-facing behavior changed — no behavior changed; docs updated to document/review the existing (already-correct) behavior.

## Number claims (if any)

None. Documentation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDM98QuGqYVT9zfxdxxkUV)_