### PR TITLE
docs(knorm): measure real-model perplexity for L2Norm after RoPE fix (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,28 @@ needs real Apple Silicon and remains open.
 
 ### Documentation
 
+**Measured real-model perplexity for L2Norm after the RoPE offset fix**
+([#190](https://github.com/rajveer43/VeloxQuant-MLX/issues/190),
+validating [#174](https://github.com/rajveer43/VeloxQuant-MLX/issues/174))
+— #174 generalized the #171 offset fix to `L2NormKVCache` and re-enabled
+L2Norm as an arm in the Q-Filters generation-perplexity benchmark, but was
+authored in a sandbox without MLX, so the fix shipped with unit-test
+coverage and **no end-to-end numbers**. Ran
+`benchmark_scripts/qfilters_real_model_perplexity.py` on
+Llama-3.2-1B-Instruct-4bit (1024 tokens, budgets 128/256) on Apple
+Silicon: against an fp16 baseline of ppl 4.050, L2Norm scores 20.469 at
+budget 128 and 9.529 at budget 256, landing between calibrated Q-Filters
+(16.307 / 8.476) and the key-SVD fallback (23.645 / 13.358) at both
+points. The budget-responsive curve confirms the offset fix end-to-end —
+pre-#174 position drift grows without bound with sequence length and would
+flatten every arm regardless of budget. Documented in
+`docs-site/docs/algorithms/knorm.md`, replacing its "no model-level
+benchmark has been run" note. **Scope**: one model, two budgets — larger
+models and a wider sweep remain open under
+[#181](https://github.com/rajveer43/VeloxQuant-MLX/issues/181) /
+[#180](https://github.com/rajveer43/VeloxQuant-MLX/issues/180); L2Norm
+TTFT/throughput is still unmeasured. Docs only, no code changes.
+
 **Reviewed StreamingLLM-adapted's RoPE position semantics against the paper**
 ([#189](https://github.com/rajveer43/VeloxQuant-MLX/issues/189)) — the
 implementation already preserved original absolute token positions after

--- a/docs-site/docs/algorithms/knorm.md
+++ b/docs-site/docs/algorithms/knorm.md
@@ -176,10 +176,42 @@ random eviction, H2O-adapted — under two data regimes:
   — 0.3–1.2 ms per prefill block vs H2O-adapted's 37–275 ms on the same
   inputs (M-series, offline harness).
 
-**No model-level benchmark has been run.** These are offline-synthetic,
-output-perturbation and byte-accounting numbers — not perplexity or
-throughput on a real model, and they validate the machinery, not the
-paper's correlation claim.
+The numbers above are offline-synthetic, output-perturbation and
+byte-accounting measurements — they validate the machinery, not the paper's
+correlation claim. For real-model perplexity, see the next section.
+
+#### Real-model perplexity after the RoPE fix (#174, #190)
+
+The #174 fix was authored without access to Apple Silicon, so no end-to-end
+numbers existed for it. Measured on **Llama-3.2-1B-Instruct-4bit**, 1024
+tokens, generation mode (tokens fed one at a time, eviction running as the
+cache fills — `benchmark_scripts/qfilters_real_model_perplexity.py`), fp16
+full-cache baseline **ppl 4.050**:
+
+| Budget | Compression | Q-Filters calibrated | Q-Filters fallback | **L2Norm** |
+|--------|-------------|----------------------|--------------------|------------|
+| 128 (`recent=32`) | ~8× | 16.307 (+302.7%) | 23.645 (+483.9%) | **20.469 (+405.4%)** |
+| 256 (`recent=64`) | ~4× | 8.476 (+109.3%) | 13.358 (+229.8%) | **9.529 (+135.3%)** |
+
+Two things this establishes:
+
+- **The offset fix works end-to-end.** L2Norm's perplexity now responds to
+  the cache budget (20.5 → 9.5 as the budget doubles). Position drift under
+  the pre-#174 bug grows without bound with sequence length, which swamps
+  eviction quality and pins every arm at a garbage number regardless of
+  budget; an ordered, budget-responsive curve is what a correct offset looks
+  like.
+- **L2Norm is a genuine baseline, not a strawman.** It lands between the two
+  Q-Filters arms at both budgets — well ahead of the key-SVD fallback,
+  behind calibrated query-SVD. The gap to calibrated Q-Filters widens as
+  compression gets more aggressive (9.53 vs 8.48 at budget 256; 20.47 vs
+  16.31 at budget 128), which is where filter quality matters most.
+
+**Scope of this measurement:** one model (1B) and two budgets. Larger models
+(Llama-3.2-3B, Qwen2.5-7B) and a wider budget sweep remain open — see
+[#181](https://github.com/rajveer43/VeloxQuant-MLX/issues/181) and
+[#180](https://github.com/rajveer43/VeloxQuant-MLX/issues/180). Throughput
+and TTFT for L2Norm are still unmeasured.
 
 ## When to use it
 


### PR DESCRIPTION
## What this is

**#190 is a duplicate of #174, which is already fixed and merged** (commit `0241a5d`). The one part of #190's acceptance criteria that #174 left open was validation — that fix was authored in a sandbox without MLX (`libmlx.so` unavailable), so it shipped with unit-test coverage and no end-to-end numbers. This PR supplies them.

Docs only. No code changes.

## Results

`benchmark_scripts/qfilters_real_model_perplexity.py` on **Llama-3.2-1B-Instruct-4bit**, 1024 tokens, generation mode. fp16 full-cache baseline **ppl 4.050**:

| Budget | Compression | Q-Filters calibrated | Q-Filters fallback | **L2Norm** |
|--------|-------------|----------------------|--------------------|------------|
| 128 (`recent=32`) | ~8x | 16.307 (+302.7%) | 23.645 (+483.9%) | **20.469 (+405.4%)** |
| 256 (`recent=64`) | ~4x | 8.476 (+109.3%) | 13.358 (+229.8%) | **9.529 (+135.3%)** |

Two conclusions:

- **The offset fix works end-to-end.** L2Norm's perplexity now responds to the cache budget (20.5 -> 9.5 as the budget doubles). Position drift under the pre-#174 bug grows without bound with sequence length, which swamps eviction quality and pins every arm at a garbage number regardless of budget. A budget-responsive curve is what a correct offset looks like.
- **L2Norm is a genuine baseline, not a strawman.** It lands between the two Q-Filters arms at both budgets. This matters for #180: it shows calibrated Q-Filters beating a correctly-implemented competitor, not just a broken one. The gap widens under more aggressive compression, which is where filter quality matters most.

## Scope / what is NOT covered

- **One model, two budgets.** Llama-3.2-3B and Qwen2.5-7B are not run; the existing Q-Filters results cover 3B, so #190's "same models as Q-Filters" criterion is only partly met. Tracked by #181 / #180.
- **No TTFT or throughput for L2Norm** — perplexity only.
- The `figures/knorm/results.json` offline-synthetic numbers are untouched; this adds a separate real-model section alongside them.

## Verification

- `test_knorm_cache.py` (17) + `test_knorm.py` (10) — 27 passed.
- Benchmark run on Apple Silicon, `Device(gpu, 0)`.

## Suggested follow-up

Close #190 as a duplicate of #174, with this PR as the missing validation evidence.

Worth noting the duplicate pattern is not isolated — #183/#184 and #185/#186 are also near-duplicate pairs, and #191 (H2O/TOVA RoPE) may already be covered by commit `6cef57b` ("generalize RoPE offset fix to TOVA cache; audit H2O (#175)"). Worth checking before starting #191 as fresh work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)