### PR TITLE
ci(release): collapse merge bursts into one release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,60 @@ on:
   push:
     branches: [master]
 
+# `cancel-in-progress: false` is deliberate and must stay that way: this job
+# pushes a tag, publishes a GitHub Release, and uploads to PyPI. Cancelling it
+# midway could leave a tag pushed with nothing published, or a PyPI upload with
+# no matching tag. A queued run is always safer than a half-finished release.
+#
+# The cost of queueing is that a burst of merges (Dependabot lands several PRs
+# in a row) queues one macos-14 release run each, all starting within seconds.
+# On 2026-08-17 that burst hit a codeload.github.com 429 and two release runs
+# died downloading actions/checkout before any step ran, which is why 0.50.0
+# was tagged but never reached PyPI. `debounce` below collapses such a burst
+# into a single release instead of widening this window.
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  release:
-    # Guard against the bump commit re-triggering this workflow, and against
-    # running on commits authored by the release bot itself.
+  # Cheap ubuntu gate that runs before the macos-14 release job. Its only
+  # purpose is to let a burst of merges collapse into one release: it waits
+  # briefly, then drops out if a newer commit has already landed on master,
+  # so only the last push in the burst proceeds to actually release. Whatever
+  # that final run releases includes every commit in the burst -- semantic
+  # release reads all commits since the last tag, so nothing is skipped.
+  #
+  # This uses no actions at all (no checkout, no setup-python) precisely
+  # because the failure it mitigates was an action *download* being rate
+  # limited before any step could run.
+  debounce:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Wait out any in-flight burst of merges
+        run: sleep 60
+
+      - name: Release only if this is still the newest commit on master
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/master" --jq '.sha')
+          if [ "$head_sha" = "${GITHUB_SHA}" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "This is master HEAD -- proceeding to release."
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Superseded by ${head_sha} -- that run will release this commit too."
+          fi
+
+  release:
+    needs: debounce
+    if: needs.debounce.outputs.proceed == 'true'
     runs-on: macos-14
     permissions:
       contents: write


### PR DESCRIPTION
## What broke

Three Dependabot PRs merged back to back (#202, #203, #204). With `concurrency.cancel-in-progress: false`, each push queued its **own** `macos-14` release run, all starting seconds apart. That burst hit a `codeload.github.com` **429 Too Many Requests**, and two release runs died while *downloading* `actions/checkout@v4` — before a single step executed.

That is how **0.50.0 was tagged, committed and version-bumped but never reached PyPI**. PyPI sat on 0.49.4 until the failed run was manually re-run, which then published 0.50.1.

## The fix

A `debounce` gate ahead of the release job. It waits 60s, then compares its own SHA against master HEAD and drops out if a newer commit has landed. In a burst, only the last push proceeds to an actual release.

**Nothing is skipped by dropping out.** python-semantic-release reads every commit since the last tag, so the one run that proceeds releases the whole burst.

Two deliberate choices:

- **The gate uses no actions at all** — no `checkout`, no `setup-python`. The failure it mitigates is an action *download* being rate limited before any step runs, so a step-level retry would not have helped. Only `gh` (preinstalled on runners) and shell.
- **It runs on `ubuntu-latest`, not `macos-14`** — the common case now costs a cheap minute rather than an expensive one, and the macOS runner is only spun up for a release that will actually happen.

## What I did NOT change

`cancel-in-progress: false` stays exactly as it was, and now carries a comment explaining why. The release job pushes a tag, publishes a GitHub Release, and uploads to PyPI — cancelling it midway risks a pushed tag with nothing published, or a PyPI upload with no matching tag. **Reducing how many runs start is the safe lever; cancelling in-flight releases is not.**

Flipping that flag would have been the one-line "fix" and it would have made the failure mode worse.

## Verification

- YAML parses; job graph is `debounce → release → publish-testpypi → publish-pypi`.
- `[skip ci]` guard preserved (moved to `debounce`; `release` inherits it — a skipped gate produces no `proceed`).
- Publish jobs remain gated on `needs.release.outputs.next_version != ''`, so a skipped release cannot trigger a publish.
- `gh api repos/{owner}/{repo}/commits/master --jq '.sha'` confirmed to return the SHA in the expected form.
- `contents: read` added explicitly to the gate rather than relying on default token scope.

Note this cannot be fully exercised until it is on master — the debounce only engages on pushes to `master`. The logic is simple and fails safe: if the API call errors the step fails, and `release` does not run, which is the same outcome as today's failure but without a half-finished release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
