### PR TITLE
fix(qfilters): derive head_dim for Qwen, validate Q-Filters at 7B across budgets 256/512/1024

### DIFF
--- a/benchmark_scripts/qfilters_real_model_attention_corr.py
+++ b/benchmark_scripts/qfilters_real_model_attention_corr.py
@@ -23,7 +23,9 @@ mid = sys.argv[1]
 m, tok = mlx_lm.load(mid)
 inner = getattr(m, "model", m)
 args = m.args
-H, KV, D = args.num_attention_heads, args.num_key_value_heads, args.head_dim
+H, KV = args.num_attention_heads, args.num_key_value_heads
+# Qwen2's ModelArgs omits head_dim; Llama's carries it. Derive when absent.
+D = getattr(args, "head_dim", None) or args.hidden_size // H
 
 calib = [
     "The capital of France is Paris, a city of art and history. " * 40,

--- a/benchmark_scripts/qfilters_real_model_perplexity.py
+++ b/benchmark_scripts/qfilters_real_model_perplexity.py
@@ -106,7 +106,69 @@ EVAL = (
     "reproducing an argument collapsed, and that arguments which would once have "
     "died in a single monastery library could now be answered, and answered "
     "again, by people who had never met. "
+    "Longitude at sea resisted solution for far longer than latitude, which any "
+    "navigator could fix by measuring the sun at noon or the pole star at night. "
+    "Longitude required knowing the time at a reference meridian at the same "
+    "instant as local time, and no pendulum clock could keep that reference "
+    "aboard a rolling ship through changes of temperature and humidity. The "
+    "astronomical alternative, the method of lunar distances, demanded tables of "
+    "the moon's position accurate to a degree no observatory had yet reached, and "
+    "a set of calculations that took a trained officer four hours to complete. "
+    "John Harrison spent decades building sea clocks against this problem, moving "
+    "from large machines with interlocking grasshopper escapements to a watch "
+    "barely five inches across, and the board charged with judging his work kept "
+    "raising what would count as proof. The eventual solution in practice was "
+    "neither one method nor the other but both together, chronometers checked "
+    "against lunars when the sky allowed, until the price of a reliable timepiece "
+    "fell far enough that every merchant vessel could carry one. "
+    "Bird migration was for centuries explained by theories that now read as "
+    "fantasy, including the belief that swallows spent the winter in the mud at "
+    "the bottom of ponds, an idea repeated by serious naturalists into the "
+    "eighteenth century. The evidence that settled the question arrived piecemeal: "
+    "a stork shot in Germany carrying a central African spear through its neck, "
+    "then systematic ringing programmes that recovered numbered bands from birds "
+    "thousands of miles from where they were fitted. What the recoveries revealed "
+    "was more surprising than mere distance. Individual birds return not just to "
+    "the same country but often to the same hedgerow, navigating by a combination "
+    "of the sun's arc, the pattern of polarised light at dusk, star rotation "
+    "around the celestial pole, and a magnetic sense whose receptor is still "
+    "argued over. Young birds of some species make the first journey alone, "
+    "without any adult to follow, which means the route is inherited rather than "
+    "taught, while in others the knowledge is cultural and a population that "
+    "loses its experienced birds loses the route with them. "
+    "The problem of measuring the speed of light was thought hopeless by "
+    "observers who assumed propagation was instantaneous. Galileo proposed "
+    "stationing two people on hilltops with shuttered lanterns and found, "
+    "unsurprisingly, only the delay of human reaction. The first real value came "
+    "not from a terrestrial experiment but from watching the moons of Jupiter, "
+    "whose eclipses ran early when Earth approached and late when it receded, a "
+    "discrepancy Ole Romer interpreted as the time light took to cross the "
+    "diameter of Earth's orbit. His figure was low, because the size of that "
+    "orbit was itself poorly known, but the method was sound and the principle "
+    "established. Later terrestrial measurements using toothed wheels and "
+    "rotating mirrors closed the gap, and the constant eventually became so well "
+    "determined that the metre was redefined in terms of it, inverting the "
+    "original relationship: the speed of light is now exact by definition and it "
+    "is the length of the metre that follows from it. "
+    "Cartographic projection forces an unavoidable compromise, since no flat "
+    "sheet can represent a sphere without distorting area, angle, or distance "
+    "somewhere. The Mercator projection preserves angles, which is exactly what a "
+    "navigator wants because a straight line drawn on the chart is a course of "
+    "constant compass bearing, but it inflates land near the poles without limit "
+    "and has been criticised for the political impression that inflation leaves. "
+    "Equal-area projections correct the sizes and pay for it by shearing shapes "
+    "into forms that look wrong to eyes trained on the familiar arrangement. "
+    "There is no projection that is best in general, only projections that are "
+    "appropriate for a purpose, and the long history of the subject is largely a "
+    "history of people rediscovering that fact and proposing a new compromise "
+    "they believe resolves it. "
 ) * 3
+
+# The corpus above yields ~3.5k tokens under the Llama/Qwen tokenizers, so this
+# cap is a ceiling rather than a target; budgets 256/512/1024 then run at
+# roughly 13.6x/6.8x/3.4x compression. Any budget >= the token count would
+# never fill the cache, and every arm would return the fp16 baseline exactly.
+EVAL_TOKENS = 4096
 
 
 def perplexity(model, ids, caches, label: str) -> float:
@@ -131,12 +193,18 @@ def main() -> None:
     inner = getattr(model, "model", model)
     n_layers = len(inner.layers)
     kv_heads = model.args.num_key_value_heads
-    head_dim = model.args.head_dim
+    # Qwen2's ModelArgs omits head_dim; Llama's carries it. Derive when absent.
+    head_dim = (
+        getattr(model.args, "head_dim", None)
+        or model.args.hidden_size // model.args.num_attention_heads
+    )
 
     acts = collect_query_activations(model, tok, CALIB, max_length=512, max_samples_per_head=3000)
     filters = [average_gqa_filters(compute_qfilters(a), kv_heads) for a in acts]
 
-    ids = tok.encode(EVAL)[:1024]
+    # Must exceed the largest budget or the cache never fills and no eviction
+    # runs: at budget == len(ids) every arm returns the fp16 baseline exactly.
+    ids = tok.encode(EVAL)[:EVAL_TOKENS]
     print(f"\n=== {model_id} | {len(ids)} tokens, generation mode ===")
     base = perplexity(
         model, ids, [KVCache() for _ in range(n_layers)], "fp16 full cache (no eviction)"

--- a/benchmark_scripts/qfilters_ttft_throughput_niah.py
+++ b/benchmark_scripts/qfilters_ttft_throughput_niah.py
@@ -280,7 +280,11 @@ def main() -> None:
         inner = getattr(model, "model", model)
         n_layers = len(inner.layers)
         kv_heads = model.args.num_key_value_heads
-        head_dim = model.args.head_dim
+        # Qwen2's ModelArgs omits head_dim; Llama's carries it. Derive when absent.
+        head_dim = (
+            getattr(model.args, "head_dim", None)
+            or model.args.hidden_size // model.args.num_attention_heads
+        )
 
         print("calibrating query-SVD filters ...", flush=True)
         acts = collect_query_activations(

--- a/docs-site/docs/algorithms/qfilters.md
+++ b/docs-site/docs/algorithms/qfilters.md
@@ -327,18 +327,20 @@ Observation 3.1 holds in **every head measured** — that universal positivity i
 `κʰ > 0`, the property the sign correctness rests on. Observation 3.2 holds
 too: the leading component's mean projection is ~50× the rest, which have
 near-zero mean, matching Figure 2c. Qwen2.5 is the paper's §5 limitation case
-(QKV bias), yet the anisotropy is present there as well.
+(QKV bias), yet the anisotropy is present there as well. Anisotropy alone does
+not guarantee an end-to-end win, though: see the Qwen budget sweep below, where
+the advantage disappears at mild compression.
 
 ### The calibrated filter predicts real attention (Figure 4)
 
 Spearman correlation against **true** mean attention `Sʰₜ` from real attention
 maps on held-out text:
 
-| Scorer | Llama-3.2-1B (128 KV heads) | Llama-3.2-3B (224 KV heads) |
-|---|---|---|
-| **Q-Filters, calibrated (query-SVD)** | **+0.783** (100% sign-correct) | **+0.863** (100% sign-correct) |
-| K-norm ([L2Norm](../algorithms/knorm)) | +0.460 (94.5%) | +0.410 (94.6%) |
-| Q-Filters, key-SVD fallback | **−0.032** (46.1%) | **−0.008** (49.1%) |
+| Scorer | Llama-3.2-1B (128 KV heads) | Llama-3.2-3B (224 KV heads) | Qwen2.5-7B (112 KV heads) |
+|---|---|---|---|
+| **Q-Filters, calibrated (query-SVD)** | **+0.783** (100% sign-correct) | **+0.863** (100% sign-correct) | **+0.850** (100% sign-correct) |
+| K-norm ([L2Norm](../algorithms/knorm)) | +0.460 (94.5%) | +0.410 (94.6%) | +0.402 (86.6%) |
+| Q-Filters, key-SVD fallback | **−0.032** (46.1%) | **−0.008** (49.1%) | **−0.039** (48.2%) |
 
 The calibrated filter tracks true attention strongly and beats K-norm,
 reproducing the paper's Figure 4 ordering. The key-SVD fallback is
@@ -373,6 +375,45 @@ attention-correlation ordering. But note the absolute numbers: perplexity is
 still well above fp16. This is a **policy comparison, not a reproduction of
 Figure 5** — no RoPE renumbering, uniform per-head budgets, and a much smaller
 calibration set than the paper's §4.2.
+
+#### Qwen2.5-7B and a wider budget sweep (#176)
+
+The rows above use a 1024-token eval, which caps the usable budget: at
+budget 1024 the cache never fills, no eviction runs, and every arm returns the
+fp16 baseline. The sweep below therefore uses a longer **~3485-token** corpus,
+so budgets 256/512/1024 sit at roughly 13.6×/6.8×/3.4× compression.
+**These numbers are not comparable to the 1024-token tables above.**
+Llama-3.2-1B was re-run on the same corpus to keep the comparison matched.
+
+**Qwen2.5-7B** (fp16 baseline **2.325**):
+
+| Budget | Calibrated | Fallback | L2Norm | Gap to fp16 closed |
+|---|---|---|---|---|
+| 256 (~13.6×) | **10.478** | 11.660 | 11.297 | 13% |
+| 512 (~6.8×) | **7.000** | 8.416 | 7.751 | 23% |
+| 1024 (~3.4×) | 4.015 | 4.010 | **3.560** | −0% |
+
+**Llama-3.2-1B** (fp16 baseline **3.445**):
+
+| Budget | Calibrated | Fallback | L2Norm | Gap to fp16 closed |
+|---|---|---|---|---|
+| 256 (~13.6×) | **27.671** | 34.631 | 30.836 | 22% |
+| 512 (~6.8×) | **15.975** | 24.126 | 16.855 | 39% |
+| 1024 (~3.4×) | 6.818 | 9.237 | **6.518** | 42% |
+
+Two findings, one positive and one not:
+
+The query-SVD advantage **does** survive at 7B scale. Qwen's Spearman
+correlation (+0.850) is close to Llama-3.2-3B's, and the calibrated filter beats
+the fallback at budgets 256 and 512.
+
+It does **not** hold uniformly across compression ratios. At budget 1024 on Qwen
+the calibrated and fallback arms are tied (4.015 vs 4.010) and plain L2Norm beats
+both. The advantage is also consistently smaller on Qwen than on Llama-3.2-1B at
+matched compression — 13% vs 22% at budget 256, 23% vs 39% at budget 512. That is
+consistent with the paper's §5, which lists Qwen-2.5 as a limitation case because
+of its QKV projection bias. If you are running Q-Filters on Qwen at mild
+compression, measure against L2Norm before assuming the calibrated filter helps.
 
 #### `qfilters_recent` is effectively required for generation
 

--- a/figures/qfilters/real_model_results.json
+++ b/figures/qfilters/real_model_results.json
@@ -40,15 +40,57 @@
     "held_out_tokens": 512,
     "mlx-community/Llama-3.2-1B-Instruct-4bit": {
       "kv_heads": 128,
-      "query_svd_calibrated": {"median": 0.783, "mean": 0.737, "frac_positive": 1.0},
-      "key_svd_fallback": {"median": -0.032, "mean": -0.022, "frac_positive": 0.461},
-      "k_norm": {"median": 0.460, "mean": 0.415, "frac_positive": 0.945}
+      "query_svd_calibrated": {
+        "median": 0.783,
+        "mean": 0.737,
+        "frac_positive": 1.0
+      },
+      "key_svd_fallback": {
+        "median": -0.032,
+        "mean": -0.022,
+        "frac_positive": 0.461
+      },
+      "k_norm": {
+        "median": 0.46,
+        "mean": 0.415,
+        "frac_positive": 0.945
+      }
     },
     "mlx-community/Llama-3.2-3B-Instruct-4bit": {
       "kv_heads": 224,
-      "query_svd_calibrated": {"median": 0.863, "mean": 0.829, "frac_positive": 1.0},
-      "key_svd_fallback": {"median": -0.008, "mean": 0.003, "frac_positive": 0.491},
-      "k_norm": {"median": 0.410, "mean": 0.381, "frac_positive": 0.946}
+      "query_svd_calibrated": {
+        "median": 0.863,
+        "mean": 0.829,
+        "frac_positive": 1.0
+      },
+      "key_svd_fallback": {
+        "median": -0.008,
+        "mean": 0.003,
+        "frac_positive": 0.491
+      },
+      "k_norm": {
+        "median": 0.41,
+        "mean": 0.381,
+        "frac_positive": 0.946
+      }
+    },
+    "mlx-community/Qwen2.5-7B-Instruct-4bit": {
+      "kv_heads": 112,
+      "query_svd_calibrated": {
+        "median": 0.85,
+        "mean": 0.827,
+        "frac_positive": 1.0
+      },
+      "key_svd_fallback": {
+        "median": -0.039,
+        "mean": -0.004,
+        "frac_positive": 0.482
+      },
+      "k_norm": {
+        "median": 0.402,
+        "mean": 0.347,
+        "frac_positive": 0.866
+      }
     }
   },
   "rope_offset_fix": {
@@ -64,20 +106,101 @@
     "eval_text": "continuous non-repetitive prose (a repeated short paragraph drives fp16 ppl to ~1.3 and makes all policies look equally bad)",
     "recency_window_finding": {
       "_comment": "The single largest factor in generation. Pure projection ranking is a long-range-importance signal and will evict the immediately-preceding tokens, which next-token prediction depends on most. The paper evaluates retrieval/NIAH tasks where this matters far less.",
-      "llama_3_2_1b_budget_128_calibrated": {"recent_0": 263.15, "recent_32": 16.31, "recent_64": 20.32, "recent_96": 24.86}
+      "llama_3_2_1b_budget_128_calibrated": {
+        "recent_0": 263.15,
+        "recent_32": 16.31,
+        "recent_64": 20.32,
+        "recent_96": 24.86
+      }
     },
     "mlx-community/Llama-3.2-1B-Instruct-4bit": {
-      "fp16_baseline": 4.050,
-      "budget_256_recent_64": {"calibrated": 8.476, "fallback": 13.358, "gap_closed_pct": 52},
-      "budget_128_recent_32": {"calibrated": 16.307, "fallback": 23.645, "gap_closed_pct": 37},
-      "budget_64_recent_16": {"calibrated": 25.933, "fallback": 31.274, "gap_closed_pct": 20}
+      "fp16_baseline": 4.05,
+      "budget_256_recent_64": {
+        "calibrated": 8.476,
+        "fallback": 13.358,
+        "gap_closed_pct": 52
+      },
+      "budget_128_recent_32": {
+        "calibrated": 16.307,
+        "fallback": 23.645,
+        "gap_closed_pct": 37
+      },
+      "budget_64_recent_16": {
+        "calibrated": 25.933,
+        "fallback": 31.274,
+        "gap_closed_pct": 20
+      }
     },
     "mlx-community/Llama-3.2-3B-Instruct-4bit": {
       "fp16_baseline": 3.305,
-      "budget_256_recent_64": {"calibrated": 5.076, "fallback": 7.264, "gap_closed_pct": 55},
-      "budget_128_recent_32": {"calibrated": 10.046, "fallback": 14.909, "gap_closed_pct": 42}
+      "budget_256_recent_64": {
+        "calibrated": 5.076,
+        "fallback": 7.264,
+        "gap_closed_pct": 55
+      },
+      "budget_128_recent_32": {
+        "calibrated": 10.046,
+        "fallback": 14.909,
+        "gap_closed_pct": 42
+      }
     },
     "conclusion": "The calibrated query-SVD filter beats the key-SVD fallback at every budget on both models, consistent with the attention-correlation ordering. Perplexity is still well above fp16 at these ratios: this is single-sequence eviction with no RoPE renumbering, uniform per-head budgets, and a much smaller calibration set than the paper's; the numbers are a policy comparison, NOT a reproduction of the paper's Figure 5.",
     "not_measured": "TTFT / throughput (paper Fig. 10), Ruler, NIAH, and any comparison against SnapKV / Expected Attention / StreamingLLM. L2Norm was excluded because it carries the same un-fixed RoPE offset defect and would compare unfairly."
+  },
+  "end_to_end_generation_perplexity_3485tok": {
+    "_comment": "Issue #176: Qwen2.5-7B validation plus a budget sweep at 256/512/1024. SEPARATE from end_to_end_generation_perplexity above because the eval corpus was lengthened from 1024 to ~3485 tokens; at the old length budget 1024 never fills the cache, no eviction runs, and every arm returns the fp16 baseline identically. Numbers here are NOT comparable to the 1024-token block above. Llama-3.2-1B was re-run on the same corpus so the cross-model comparison is matched. Script: benchmark_scripts/qfilters_real_model_perplexity.py.",
+    "date": "2026-08-18",
+    "eval_tokens": 3485,
+    "recent_window": "budget // 4, as set by the script",
+    "mlx-community/Qwen2.5-7B-Instruct-4bit": {
+      "fp16_baseline": 2.325,
+      "budget_256_recent_64": {
+        "compression_x": 14,
+        "calibrated": 10.478,
+        "fallback": 11.66,
+        "l2norm": 11.297,
+        "gap_closed_pct": 13.0
+      },
+      "budget_512_recent_128": {
+        "compression_x": 7,
+        "calibrated": 7.0,
+        "fallback": 8.416,
+        "l2norm": 7.751,
+        "gap_closed_pct": 23.0
+      },
+      "budget_1024_recent_256": {
+        "compression_x": 3,
+        "calibrated": 4.015,
+        "fallback": 4.01,
+        "l2norm": 3.56,
+        "gap_closed_pct": -0.0
+      }
+    },
+    "mlx-community/Llama-3.2-1B-Instruct-4bit": {
+      "fp16_baseline": 3.445,
+      "budget_256_recent_64": {
+        "compression_x": 14,
+        "calibrated": 27.671,
+        "fallback": 34.631,
+        "l2norm": 30.836,
+        "gap_closed_pct": 22.0
+      },
+      "budget_512_recent_128": {
+        "compression_x": 7,
+        "calibrated": 15.975,
+        "fallback": 24.126,
+        "l2norm": 16.855,
+        "gap_closed_pct": 39.0
+      },
+      "budget_1024_recent_256": {
+        "compression_x": 3,
+        "calibrated": 6.818,
+        "fallback": 9.237,
+        "l2norm": 6.518,
+        "gap_closed_pct": 42.0
+      }
+    },
+    "finding": "The calibrated query-SVD filter beats the key-SVD fallback on Qwen2.5-7B at budgets 256 and 512 (13% and 23% of the fallback's gap closed), so the attention-correlation advantage does carry to 7B. It does NOT hold uniformly across compression ratios: at budget 1024 (~3.4x) the two are tied on Qwen (4.015 calibrated vs 4.010 fallback, -0% gap closed) and L2Norm beats both (3.560). The advantage is also smaller on Qwen than on Llama-3.2-1B at matched compression (13% vs 22% at budget 256; 23% vs 39% at budget 512), consistent with the paper's section 5 listing Qwen-2.5 as a limitation case (QKV projection bias).",
+    "not_measured": "Llama-3.2-3B on the 3485-token corpus; TTFT/throughput; Ruler; NIAH; comparison against SnapKV / Expected Attention / StreamingLLM."
   }
 }


### PR DESCRIPTION
Closes #176.

## Summary

Runs the Q-Filters evaluation on Qwen2.5-7B and sweeps budgets 256/512/1024, as the issue asks. The headline: **the query-SVD advantage carries to 7B on the attention-correlation metric, but it does not hold uniformly across compression ratios.** Details below, including the negative result.

Two blockers had to be cleared first.

### 1. `head_dim` was unresolvable on Qwen

All three Q-Filters real-model scripts read `model.args.head_dim`. Qwen2's `ModelArgs` does not define it; Llama's does, which is why the existing 1B/3B runs never hit this. The Qwen run failed immediately:

```
AttributeError: 'ModelArgs' object has no attribute 'head_dim'
```

They now fall back to `hidden_size // num_attention_heads` (Qwen derives 128, Llama keeps reading its declared 64, so existing results stay reproducible).

### 2. Budget 1024 could not evict anything

The perplexity harness truncated the eval to 1024 tokens. At budget 1024 the cache never fills, eviction never runs, and all three arms return the fp16 baseline *identically* — the row the issue asked for would have carried no signal at all.

The `EVAL` corpus is extended to ~3485 tokens, putting budgets 256/512/1024 at roughly 13.6x/6.8x/3.4x compression. **This makes the new numbers incomparable to the stored 1024-token rows**, so they live under a separate key in the results JSON rather than being merged into the existing block, and Llama-3.2-1B was re-run on the same corpus so the cross-model comparison is matched.

## Results

**Spearman vs true attention** — Qwen2.5-7B, 112 KV heads (new):

| Scorer | median | sign-correct |
|---|---|---|
| query-SVD (calibrated) | **+0.850** | 100% |
| K-norm | +0.402 | 86.6% |
| key-SVD (fallback) | **−0.039** | 48.2% |

Matches the 1B/3B ordering. The fallback remains indistinguishable from noise.

**Generation perplexity**, ~3485-token corpus:

Qwen2.5-7B (fp16 **2.325**):

| Budget | Calibrated | Fallback | L2Norm | Gap closed |
|---|---|---|---|---|
| 256 (~13.6x) | **10.478** | 11.660 | 11.297 | 13% |
| 512 (~6.8x) | **7.000** | 8.416 | 7.751 | 23% |
| 1024 (~3.4x) | 4.015 | 4.010 | **3.560** | −0% |

Llama-3.2-1B (fp16 **3.445**), same corpus:

| Budget | Calibrated | Fallback | L2Norm | Gap closed |
|---|---|---|---|---|
| 256 (~13.6x) | **27.671** | 34.631 | 30.836 | 22% |
| 512 (~6.8x) | **15.975** | 24.126 | 16.855 | 39% |
| 1024 (~3.4x) | 6.818 | 9.237 | **6.518** | 42% |

## What this says about the issue's question

The issue asked whether the improvements remain consistent at 7B scale and across compression ratios. Reported straight:

- **At 7B, yes on correlation.** Qwen's +0.850 is close to Llama-3.2-3B's +0.863.
- **Across ratios, no.** At budget 1024 on Qwen the calibrated and fallback arms are tied (4.015 vs 4.010) and plain L2Norm beats both (3.560). The advantage is also consistently smaller on Qwen than on Llama-3.2-1B at matched compression — 13% vs 22% at budget 256, 23% vs 39% at budget 512.

This is consistent with the paper's §5, which lists Qwen-2.5 as a limitation case because of its QKV projection bias. The docs now tell readers to measure against L2Norm before assuming the calibrated filter helps on Qwen at mild compression.

## Acceptance criteria

- [x] Qwen2.5-7B calibration validation
- [x] Query anisotropy and sign correctness across heads — was already present in the results file (100% of 784 heads, 47.9x Obs-3.2 ratio); unchanged
- [x] Spearman correlation against true attention
- [x] End-to-end perplexity evaluation
- [x] Budgets 256/512/1024
- [x] Calibrated vs key-SVD fallback
- [x] Raw results in the existing reproducible format (`figures/qfilters/real_model_results.json`)
- [x] Documented whether improvements hold at 7B and across ratios

## Not done

Llama-3.2-3B was not re-run on the longer corpus (1B was, which is enough for a matched comparison). TTFT/throughput, Ruler, NIAH, and comparisons against SnapKV / Expected Attention / StreamingLLM remain unmeasured, as before.

## Verification

79 Q-Filters tests pass; `ruff format` clean; no new `ruff check` errors (the 5 E402s in `qfilters_ttft_throughput_niah.py` are pre-existing on `master`). The `head_dim` fallback was checked against both Qwen (derives 128) and Llama (reads 64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)