### PR TITLE
test(rotation): pin bare-m Hadamard behaviour to the installed MLX version

### DIFF
--- a/veloxquant_mlx/math/rotation.py
+++ b/veloxquant_mlx/math/rotation.py
@@ -13,11 +13,19 @@ def is_hadamard_compatible(d: int) -> bool:
 
     MLX requires d = m * 2^k where m in {1, 12, 20, 28} and k >= 0 -- except
     for the bare non-trivial m values (d == 12, 20, 28 exactly, i.e. k=0),
-    which crash mx.hadamard_transform during Metal shader compilation on the
-    installed MLX version (0.32.0) rather than raising a catchable, sensible
-    error (#67). k=0 with m=1 (d=1) is unaffected and works fine, since it's
-    just the identity transform. All powers of 2 work (m=1, k>=0). Examples
-    that do NOT work: 576=9*64, 192=3*64.
+    which this gate rejects. On MLX <= 0.32.0 they crash
+    mx.hadamard_transform during Metal shader compilation rather than raising
+    a catchable error (#67). MLX 0.32.1 fixed that kernel and returns a
+    correct orthonormal Hadamard for those sizes, but this package supports
+    mlx>=0.18, so the gate stays conservative: green-lighting a d that crashes
+    on a supported older MLX is worse than declining a rotation that would
+    have worked on a newer one. If the floor is ever raised to >=0.32.1 this
+    can accept bare m -- see test_bare_m_transform_is_orthonormal_when_supported,
+    which checks the correctness precondition for doing so.
+
+    k=0 with m=1 (d=1) is unaffected and works fine, since it's just the
+    identity transform. All powers of 2 work (m=1, k>=0). Examples that do NOT
+    work: 576=9*64, 192=3*64.
     """
     if d < 1:
         return False

--- a/veloxquant_mlx/tests/math/test_rotation.py
+++ b/veloxquant_mlx/tests/math/test_rotation.py
@@ -2,10 +2,31 @@
 
 from __future__ import annotations
 
+import functools
+
 import numpy as np
 import pytest
 
 from veloxquant_mlx.math.rotation import is_hadamard_compatible
+
+
+@functools.lru_cache(maxsize=1)
+def _mlx_supports_bare_m() -> bool:
+    """Does the installed MLX handle d == m for non-trivial m (no doublings)?
+
+    Probed rather than version-compared: the fix landed in mlx 0.32.1, but the
+    behaviour is what these tests care about, and probing also covers backports
+    and any future regression. d=12 stands in for the whole {12, 20, 28} set --
+    they are one kernel path and move together.
+    """
+    import mlx.core as mx
+
+    try:
+        y = mx.hadamard_transform(mx.array(np.zeros(12, dtype=np.float32)))
+        mx.eval(y)
+    except RuntimeError:
+        return False
+    return True
 
 
 class TestBareMValuesAreRejected:
@@ -18,18 +39,55 @@ class TestBareMValuesAreRejected:
         assert not is_hadamard_compatible(d)
 
     @pytest.mark.parametrize("d", [12, 20, 28])
-    def test_bare_m_actually_crashes_mlx(self, d: int) -> None:
-        """Confirms the premise: mx.hadamard_transform really does fail for
-        these inputs on the installed MLX version, so the gate must reject
-        them. If this test starts failing (transform succeeds), the MLX
-        version's kernel constraints have changed and the gate can be
-        relaxed accordingly."""
+    def test_bare_m_behaviour_matches_installed_mlx(self, d: int) -> None:
+        """Pins what the installed MLX actually does with bare m, in both
+        directions.
+
+        Through MLX 0.32.0 these inputs crash mx.hadamard_transform during
+        Metal shader compilation (#67), which is why the gate rejects them.
+        MLX 0.32.1 fixed the kernel and they now return a correct orthonormal
+        Hadamard. The project still supports mlx>=0.18, so the gate stays
+        conservative and rejects them on every version -- a user on 0.31 must
+        not be handed a d that crashes their MLX. This test therefore asserts
+        whichever behaviour the installed version has, so it keeps working as
+        a regression guard instead of encoding one version's bug as a
+        permanent fact.
+
+        If the floor is ever raised to >=0.32.1, is_hadamard_compatible can be
+        relaxed to accept bare m and this test can drop the older branch.
+        """
         import mlx.core as mx
 
         x = mx.array(np.random.randn(d).astype(np.float32))
-        with pytest.raises(RuntimeError):
+        if _mlx_supports_bare_m():
             y = mx.hadamard_transform(x)
             mx.eval(y)
+            assert np.isfinite(np.array(y)).all()
+        else:
+            with pytest.raises(RuntimeError):
+                y = mx.hadamard_transform(x)
+                mx.eval(y)
+
+    @pytest.mark.parametrize("d", [12, 20, 28])
+    def test_bare_m_transform_is_orthonormal_when_supported(self, d: int) -> None:
+        """Where MLX does support bare m, what it returns is a real Hadamard.
+
+        Guards the claim behind the note above: relaxing the gate on a newer
+        MLX would be safe on correctness grounds. Applying the transform to
+        the identity recovers the matrix itself; it must be orthonormal with
+        entries +-1/sqrt(d). Note it is NOT symmetric for d=20 and d=28 (the
+        Paley construction), so H(H(x)) == x does not hold there and is not a
+        valid check.
+        """
+        import mlx.core as mx
+
+        if not _mlx_supports_bare_m():
+            pytest.skip(f"installed MLX {mx.__version__} does not support bare m={d}")
+
+        matrix = np.array(mx.hadamard_transform(mx.array(np.eye(d, dtype=np.float32))))
+        gram = matrix @ matrix.T
+        np.testing.assert_allclose(gram, np.eye(d), atol=1e-5)
+        np.testing.assert_allclose(np.abs(matrix) * np.sqrt(d), np.ones((d, d)), atol=1e-4)
 
 
 class TestDoubledMValuesAreAccepted:


### PR DESCRIPTION
Fixes the three failures currently red on `master`:

```
FAILED test_rotation.py::TestBareMValuesAreRejected::test_bare_m_actually_crashes_mlx[12]
FAILED test_rotation.py::TestBareMValuesAreRejected::test_bare_m_actually_crashes_mlx[20]
FAILED test_rotation.py::TestBareMValuesAreRejected::test_bare_m_actually_crashes_mlx[28]
- Failed: DID NOT RAISE RuntimeError
```

## Cause

Not a regression in this package. **mlx 0.32.1 fixed the Metal kernel behind #67.** `mx.hadamard_transform` now succeeds for `d` in {12, 20, 28} instead of crashing during shader compilation.

`pyproject.toml` pins only `mlx>=0.18`, so CI resolved the new release and a test asserting *"this must crash"* stopped holding. The test's own docstring called this shot:

> If this test starts failing (transform succeeds), the MLX version's kernel constraints have changed and the gate can be relaxed accordingly.

Reproduced locally by installing 0.32.1 into a venv: same 3 failures. On 0.32.0 (my machine) the transform still raises, so the behaviour is genuinely version-dependent.

## What I did *not* do

**The gate is deliberately left conservative.** `is_hadamard_compatible` still rejects 12/20/28.

This package supports `mlx>=0.18`. If the gate returned `True` for `d=12`, a user on 0.31 gets the #67 crash back — the gate would be actively green-lighting the thing it exists to prevent. Declining a rotation that a newer MLX *could* have done is the cheaper failure of the two. Library behaviour is therefore unchanged on every supported MLX version, and all 8 production callers of the gate are unaffected.

Relaxing it is a reasonable future change, but it belongs with a floor raise to `mlx>=0.32.1`, which is a separate decision about dropping support for older MLX.

## What changed

The premise test now asserts whichever behaviour the installed MLX actually has — raises on `<=0.32.0`, succeeds on `>=0.32.1` — so it stays a live regression guard instead of encoding one version's bug as permanent fact. Support is **probed, not version-compared**, which also covers backports and any future regression.

A second test verifies that where MLX does support bare m, the result is a genuine orthonormal Hadamard (`MMᵀ = I`, entries `±1/√d`). That is the correctness precondition for relaxing the gate later, so the note in the docstring is backed by a check rather than an assumption.

One trap worth recording: **`H(H(x)) == x` is not a valid check here.** The d=20 and d=28 matrices come from the Paley construction and are not symmetric, so the round-trip fails (rel err ~1.7) even though the matrix is perfectly orthonormal. Orthogonality is the right criterion.

## Verification

| MLX | Result |
|---|---|
| 0.32.1 (CI) | **38 passed** — orthonormality tests run |
| 0.32.0 (local) | **35 passed, 3 skipped** — correctly skipped |

Full suite on 0.32.1: **2237 passed, 2 skipped, 0 failed**.

`ruff format` clean. The one `ruff check` error in `rotation.py` (`F401: math imported but unused`) is **pre-existing on `master`** and untouched by this diff — I left it rather than fold an unrelated fix in here.

The tests badge is not updated in this PR: `scripts/sync_release_badges.py` recomputes the count at release time from `pytest --collect-only`, so it will self-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)