### PR TITLE
feat(bench): RULER task categories beyond NIAH for Q-Filters (#177)

### DIFF
--- a/benchmark_scripts/qfilters_ruler_beyond_niah.py
+++ b/benchmark_scripts/qfilters_ruler_beyond_niah.py
@@ -629,6 +629,7 @@ def main() -> None:
 
         mrec: dict = {}
         samples: dict = {}
+        prompt_lens: dict = {}
 
         for task in TASKS:
             print(f"\n--- {task} ---", flush=True)
@@ -654,6 +655,15 @@ def main() -> None:
                             # samples of the same model.
                             seed = ctx * 100 + s + TASK_SEED_OFFSET[task]
                             prompt, expected, pool = BUILDERS[task](tok, ctx, seed)
+                            # CTX_LENS sizes the *filler*; the instruction,
+                            # task spans and question add ~100-250 tokens on
+                            # top. Record what was actually prefilled so the
+                            # compression ratio a budget implies is checkable
+                            # rather than inferred from the label. This is why
+                            # budget 1024 still evicts at ctx 1024.
+                            prompt_lens.setdefault(task, {}).setdefault(
+                                str(ctx), len(tok.encode(prompt))
+                            )
                             caches = make_caches(method, n_layers, head_dim, nb, filters)
                             sc, text = run_case(model, tok, caches, prompt, expected, pool)
                             cell.append(sc)
@@ -696,7 +706,11 @@ def main() -> None:
                     flush=True,
                 )
 
-        results["models"][model_id] = {"tasks": mrec, "samples": samples}
+        results["models"][model_id] = {
+            "tasks": mrec,
+            "prompt_tokens": prompt_lens,
+            "samples": samples,
+        }
         # Write after each model: a 7B run is long enough that losing it to a
         # crash on the next model would be a real cost.
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmark_scripts/qfilters_ruler_beyond_niah.py
+++ b/benchmark_scripts/qfilters_ruler_beyond_niah.py
@@ -1,0 +1,713 @@
+"""RULER task categories beyond NIAH, for Q-Filters vs SnapKV / StreamingLLM / L2Norm.
+
+Closes the gap the NIAH harness explicitly left open (see the "WHAT THIS IS
+NOT" block in ``qfilters_ttft_throughput_niah.py``, and "Still not measured"
+in the Q-Filters docs): the retrieval arm there is the needle family only, so
+nothing established whether Q-Filters generalises past single-span lookup.
+
+WHAT IS COVERED
+---------------
+Four task categories, generated synthetically in-process following the
+constructions in RULER (Hsieh et al., "RULER: What's the Real Context Size of
+Your Long-Context Language Models?", arXiv:2404.06654):
+
+* **VT** — variable tracking. A chain of assignments (``VAR X1 = 12345``,
+  ``VAR X2 = X1`` ...) is scattered through filler; the model must name every
+  variable bound to a given value. Tests multi-hop traversal, not lookup:
+  the answer spans positions that are individually unremarkable.
+* **CWE** — common-word extraction. A word list mixes a few words repeated
+  many times with many words repeated twice; the model must report the
+  common ones. Tests aggregation over the whole context.
+* **FWE** — frequent-word extraction. Word frequencies follow a Zeta
+  distribution as in the paper, so the top-3 are separated by frequency
+  alone rather than by a hard threshold.
+* **QA** — multi-hop question answering over distractor paragraphs.
+
+WHAT THIS IS NOT
+----------------
+* **Not the full RULER suite, and not RULER's own harness.** RULER ships 13
+  tasks; this covers the four categories outside the needle family, at short
+  contexts, with generators written here rather than RULER's code. Numbers
+  are not comparable to published RULER scores — treat them as a
+  *relative* comparison between the cache methods on this machine.
+* **Not RULER's QA task.** RULER's QA wraps SQuAD and HotpotQA. Pulling those
+  in would add a dataset dependency to a repo that has none, so the QA arm
+  here is synthetic multi-hop over generated paragraphs. It measures the same
+  capability shape (locate two facts, join them) but is an easier task, and
+  it is labelled ``qa_synthetic`` everywhere to keep that distinction visible.
+* **Not Expected Attention.** Not implemented in this repo, so it cannot be
+  a comparison arm (issue #177 says the same).
+* **Not a speedup claim.** Same caveat as the NIAH harness: these caches run
+  a per-(B, H) Python loop in ``update_and_fetch``, so wall-clock is an
+  artifact of the implementation. No timings are reported here at all.
+
+PREFILL PATH-DEPENDENCE APPLIES HERE TOO
+----------------------------------------
+``qfilters_update`` absorbs a block then evicts to budget in one shot, so a
+single-shot prefill makes one large eviction decision against a filter frozen
+on that same block. The NIAH harness measured this costing coherence outright
+at budget 256. This harness prefills the same way — one ``model(prompt,
+cache=...)`` call — so the Q-Filters rows are that method's worst case, and a
+chunked-prefill deployment should do better than what is reported here.
+
+Usage:
+    python benchmark_scripts/qfilters_ruler_beyond_niah.py [MODEL ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import random
+import re
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+import mlx_lm
+from mlx_lm.models.cache import KVCache
+
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from veloxquant_mlx.cache.base import KVCacheConfig  # noqa: E402
+from veloxquant_mlx.cache.knorm_cache import L2NormKVCache  # noqa: E402
+from veloxquant_mlx.cache.qfilters_cache import QFiltersKVCache  # noqa: E402
+from veloxquant_mlx.cache.snapkv_cache import SnapKVKVCache  # noqa: E402
+from veloxquant_mlx.cache.streaming_llm_cache import StreamingLLMKVCache  # noqa: E402
+from veloxquant_mlx.quantizers.qfilters_calibration import (  # noqa: E402
+    average_gqa_filters,
+    collect_query_activations,
+    compute_qfilters,
+)
+
+DEFAULT_MODELS = [
+    "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "mlx-community/Qwen2.5-7B-Instruct-4bit",
+]
+
+# Matched to the NIAH harness so the two result sets sit on the same axis.
+BUDGETS = [256, 512, 1024]
+CTX_LENS = [1024, 2048]
+METHODS = ["fp16", "qfilters", "snapkv", "streaming_llm", "knorm"]
+TASKS = ["vt", "cwe", "fwe", "qa_synthetic"]
+
+# Per-task seed offsets. CWE and FWE both derive their answer from a shuffle of
+# WORD_POOL, so without this they would produce identical expected words for
+# the same (ctx, repeat) and the two tasks would not be independent draws.
+TASK_SEED_OFFSET = {"vt": 0, "cwe": 10_000, "fwe": 20_000, "qa_synthetic": 30_000}
+
+# Minimum fp16 score for a (model, task) cell to be treated as a real
+# comparison. Below this the model cannot do the task with a *complete* cache,
+# so every eviction arm sits in floor noise and any ordering between them is
+# sampling luck. Measured at fp16, ctx 1024, 3 seeds: Llama-3.2-1B scores
+# 0.11 / 0.16 / 0.26 on vt / cwe / fwe and belongs below this line; Qwen2.5-7B
+# scores 0.66 / 1.00 / 0.78 and belongs above it.
+CEILING_MIN = 0.50
+
+# Calibration corpus for the query-SVD filters. Identical to the NIAH
+# harness's, and deliberately disjoint from every eval construction below —
+# no variable names, no word lists, no QA entities.
+CALIB = [
+    "The Roman Republic was established after the overthrow of the Roman Kingdom, "
+    "traditionally dated to 509 BC. Power was held by annually elected magistrates "
+    "and the Senate, an assembly drawn largely from the patrician class. ",
+    "Photosynthesis is the process by which green plants, algae and some bacteria "
+    "convert light energy into chemical energy stored in carbohydrate molecules. "
+    "In plants the reaction takes place in chloroplasts. ",
+    "Modern cryptography relies on problems believed to be computationally hard, "
+    "such as factoring large integers or computing discrete logarithms in finite "
+    "groups. Public-key systems let two parties agree on a shared secret. ",
+    "Plate tectonics describes the movement of large sections of the Earth's "
+    "lithosphere over the underlying asthenosphere. Where plates converge one may "
+    "subduct beneath another, producing deep ocean trenches and volcanic arcs. ",
+]
+
+# Filler prose. Bland and repetitive in topic but not literally looped, so the
+# task-bearing spans are the only distinctive ones. Shared with the NIAH
+# harness on purpose: a difference between the two result sets should come
+# from the task, not from the haystack.
+HAYSTACK_SENTENCES = [
+    "The committee reviewed the quarterly figures and found them consistent with prior guidance.",
+    "Rainfall across the northern districts remained close to the seasonal average this year.",
+    "The library extended its opening hours during the examination period as usual.",
+    "Maintenance work on the eastern bridge is scheduled to continue through the autumn.",
+    "Attendance at the regional conference was slightly higher than the organisers expected.",
+    "The survey team completed its mapping of the coastal path ahead of the deadline.",
+    "Local suppliers reported steady demand throughout the second half of the period.",
+    "The archive catalogued several hundred additional documents over the winter months.",
+    "Bus timetables were adjusted to reflect the revised school opening times.",
+    "The laboratory replaced two ageing spectrometers during the scheduled shutdown.",
+]
+
+# Word pool for CWE / FWE. Common English nouns, no overlap with the filler
+# sentences above — otherwise filler occurrences would corrupt the counts the
+# task is asking the model to make.
+WORD_POOL = [
+    "lantern",
+    "harbour",
+    "meadow",
+    "compass",
+    "granite",
+    "thicket",
+    "cobalt",
+    "pelican",
+    "trellis",
+    "quarry",
+    "sable",
+    "juniper",
+    "marlin",
+    "fennel",
+    "obsidian",
+    "cypress",
+    "pewter",
+    "walrus",
+    "saffron",
+    "basalt",
+    "otter",
+    "amber",
+    "ridge",
+    "cinder",
+    "willow",
+    "kestrel",
+    "onyx",
+    "bramble",
+    "canyon",
+    "lichen",
+    "mackerel",
+    "topaz",
+    "birch",
+    "heron",
+    "flint",
+    "sorrel",
+    "puffin",
+    "slate",
+    "hazel",
+    "curlew",
+    "opal",
+    "alder",
+]
+
+# QA entity pool, kept disjoint from WORD_POOL and from the calibration text.
+QA_PEOPLE = [
+    "Marisol Vance",
+    "Teodor Halvorsen",
+    "Priya Raghunathan",
+    "Callum Ashworth",
+    "Ingrid Sorensen",
+    "Rafael Duarte",
+]
+QA_PLACES = ["Kestrel Bay", "Thornfield", "Vellamo", "Ardenmoor", "Cape Lisandro", "Norwick"]
+QA_ITEMS = ["seismograph", "astrolabe", "chronometer", "barograph", "theodolite", "hygrometer"]
+
+
+# ── cache construction ───────────────────────────────────────────────────────
+def make_caches(method: str, n_layers: int, head_dim: int, budget: int, filters=None):
+    """One cache instance per layer for the named method at a matched budget.
+
+    Every eviction method is configured to retain the same total token count,
+    so a row difference is a difference in *which* tokens were kept, not how
+    many. ``fp16`` ignores the budget and is the quality ceiling.
+    """
+    if method == "fp16":
+        return [KVCache() for _ in range(n_layers)]
+
+    if method == "qfilters":
+        cfg = KVCacheConfig(
+            method="qfilters",
+            head_dim=head_dim,
+            qfilters_budget=budget,
+            qfilters_n_sink=4,
+            qfilters_recent=budget // 4,
+            qfilters_calib_tokens=min(128, budget // 2),
+        )
+        return [
+            QFiltersKVCache(cfg, filters=None if filters is None else filters[i])
+            for i in range(n_layers)
+        ]
+
+    if method == "snapkv":
+        cfg = KVCacheConfig(
+            method="snapkv",
+            head_dim=head_dim,
+            snap_budget=budget,
+            snap_obs_window=min(32, budget // 2),
+            snap_n_sink=4,
+        )
+        return [SnapKVKVCache(cfg) for _ in range(n_layers)]
+
+    if method == "streaming_llm":
+        # Matched total footprint: sinks + window == budget.
+        cfg = KVCacheConfig(
+            method="streaming_llm",
+            head_dim=head_dim,
+            stream_n_sink=4,
+            stream_window_size=budget - 4,
+        )
+        return [StreamingLLMKVCache(cfg) for _ in range(n_layers)]
+
+    if method == "knorm":
+        # Included per #174, which generalised the `_true_offset` RoPE fix to
+        # this cache. Before that it carried the same position drift the NIAH
+        # harness documents, and could not be a fair arm.
+        cfg = KVCacheConfig(
+            method="knorm",
+            head_dim=head_dim,
+            knorm_budget=budget,
+            knorm_n_sink=4,
+            knorm_recent=budget // 4,
+        )
+        return [L2NormKVCache(cfg) for _ in range(n_layers)]
+
+    raise ValueError(f"unknown method {method!r}")
+
+
+# ── filler ───────────────────────────────────────────────────────────────────
+def _grow_filler(tok, ctx_tokens: int, rng: random.Random) -> list[str]:
+    """Sentences totalling at least ``ctx_tokens`` tokens.
+
+    Grown geometrically then trimmed: encoding after every single append is
+    O(n^2) in tokeniser calls and dominates runtime at 2k contexts.
+    """
+    filler = [rng.choice(HAYSTACK_SENTENCES) for _ in range(8)]
+    while len(tok.encode(" ".join(filler))) < ctx_tokens:
+        filler.extend(rng.choice(HAYSTACK_SENTENCES) for _ in range(len(filler)))
+    while len(filler) > 1 and len(tok.encode(" ".join(filler[:-1]))) >= ctx_tokens:
+        filler.pop()
+    return filler
+
+
+def _scatter(filler: list[str], spans: list[str], rng: random.Random) -> str:
+    """Insert ``spans`` at evenly-spread positions through ``filler``.
+
+    Even spread rather than random placement: with random positions the
+    variance across seeds is dominated by whether the chain happened to land
+    inside a recency window, which would measure luck rather than method.
+    """
+    out = list(filler)
+    n = len(spans)
+    for i, span in enumerate(spans):
+        frac = (i + 1) / (n + 1)
+        pos = min(int(len(out) * frac), len(out))
+        out.insert(pos, span)
+    return " ".join(out)
+
+
+# ── task builders ────────────────────────────────────────────────────────────
+def build_vt(tok, ctx_tokens: int, seed: int, n_chains: int = 2, hops: int = 3):
+    """Variable tracking: follow assignment chains to their root value.
+
+    ``n_chains`` independent chains of ``hops`` variables each are scattered
+    through the filler. One chain's root value is queried; the answer is every
+    variable name in that chain. The other chain is a distractor with the same
+    surface form, so surface matching on ``VAR`` alone does not solve it.
+
+    ``hops`` defaults to 3 because that is where the fp16 ceiling sits in a
+    usable range on the models here. Measured on Qwen2.5-7B at ctx 1024, fp16,
+    4 seeds: 4 hops scored 0.46, 3 hops 0.66, 2 hops 1.00. At 4 hops the model
+    starts inventing variable names that never appear in the text, and at 2 it
+    saturates -- neither leaves room to see a cache method degrade.
+
+    Returns ``(prompt, expected_strings, pool)``. Every expected string must
+    appear in the decoded answer; ``pool`` is the candidate set used to
+    compute the precision cap in ``score_answer``.
+    """
+    rng = random.Random(seed)
+    chains: list[tuple[int, list[str]]] = []
+    per_chain_spans: list[list[str]] = []
+    used: set[str] = set()
+    for _c in range(n_chains):
+        value = rng.randint(10000, 99999)
+        names: list[str] = []
+        while len(names) < hops:
+            nm = f"X{rng.randint(1, 999)}"
+            if nm not in used:
+                used.add(nm)
+                names.append(nm)
+        chain_spans = [f"VAR {names[0]} = {value}."]
+        chain_spans += [f"VAR {names[i]} = {names[i - 1]}." for i in range(1, hops)]
+        per_chain_spans.append(chain_spans)
+        chains.append((value, names))
+
+    target_value, target_names = chains[0]
+
+    # Interleave the chains but keep each chain's spans in assignment order.
+    # A global shuffle would place `VAR B = A` before `VAR A = 12345`, forcing
+    # backward resolution over a scrambled graph -- much harder than RULER's
+    # VT, which scatters hops through the text without reordering them. On
+    # Qwen2.5-7B the shuffled form scored 0.29 at fp16, too low a ceiling to
+    # tell cache methods apart.
+    spans = [s for group in zip(*per_chain_spans, strict=True) for s in group]
+
+    filler = _grow_filler(tok, ctx_tokens, rng)
+    body = _scatter(filler, spans, rng)
+    prompt = (
+        "Below is a text containing variable assignments. A variable may be "
+        "assigned a number directly, or assigned the value of another "
+        "variable, in which case it inherits that variable's value.\n\n"
+        f"{body}\n\n"
+        f"Question: Find all variables that are assigned the value "
+        f"{target_value}, including variables that inherit it indirectly "
+        f"through other variables. There are exactly {hops}.\n"
+        "Answer: The variables are"
+    )
+    # Pool = every variable name in the text, so naming all of them scores
+    # hops / (n_chains * hops) rather than full marks.
+    all_names = [n for _v, ns in chains for n in ns]
+    return prompt, list(target_names), all_names
+
+
+def build_cwe(tok, ctx_tokens: int, seed: int, n_common: int = 3):
+    """Common-word extraction: report the words that repeat many times.
+
+    ``n_common`` words appear 10x; the rest of the list appears 2x each. The
+    list is padded with filler to the context length. Aggregation over the
+    whole context — no single position carries the answer, which is precisely
+    the property a recency-window method cannot exploit.
+    """
+    rng = random.Random(seed)
+    pool = list(WORD_POOL)
+    rng.shuffle(pool)
+    common = pool[:n_common]
+    rare = pool[n_common:]
+
+    words = []
+    for w in common:
+        words.extend([w] * 10)
+    for w in rare:
+        words.extend([w] * 2)
+    rng.shuffle(words)
+
+    filler = _grow_filler(tok, max(ctx_tokens - len(words), 64), rng)
+    body = " ".join(filler)
+    prompt = (
+        f"{body}\n\n"
+        "Below is a list of words. Some words appear many times, most appear "
+        "only twice.\n\n"
+        f"{', '.join(words)}\n\n"
+        f"Question: Which {n_common} words appear most often in the list "
+        "above?\nAnswer: The words are"
+    )
+    return prompt, common, list(set(words))
+
+
+def build_fwe(tok, ctx_tokens: int, seed: int, alpha: float = 2.0, top_k: int = 3):
+    """Frequent-word extraction with Zeta-distributed frequencies.
+
+    RULER draws word frequencies from a Zeta distribution rather than using a
+    hard common/rare split, so the top-k are separated by frequency alone.
+    That makes this strictly harder than CWE: the boundary between "frequent"
+    and "not" is a judgement about counts, not a visible gap.
+    """
+    rng = random.Random(seed)
+    pool = list(WORD_POOL)
+    rng.shuffle(pool)
+    n = min(len(pool), 20)
+    pool = pool[:n]
+
+    # Zeta-like: count(rank r) proportional to r^-alpha, floored at 2 so every
+    # word actually appears and the top-k are a genuine ranking.
+    counts = [max(2, int(round(40 * (r + 1) ** (-alpha)))) for r in range(n)]
+    words = []
+    for w, c in zip(pool, counts, strict=True):
+        words.extend([w] * c)
+    rng.shuffle(words)
+
+    expected = pool[:top_k]
+    filler = _grow_filler(tok, max(ctx_tokens - len(words), 64), rng)
+    body = " ".join(filler)
+    prompt = (
+        f"{body}\n\n"
+        "Below is a list of words whose frequencies differ.\n\n"
+        f"{', '.join(words)}\n\n"
+        f"Question: Which {top_k} words appear most frequently in the list "
+        "above?\nAnswer: The words are"
+    )
+    return prompt, expected, list(set(words))
+
+
+def build_qa_synthetic(tok, ctx_tokens: int, seed: int, n_distractor: int = 3):
+    """Two-hop QA over generated paragraphs.
+
+    NOT RULER's QA task, which wraps SQuAD/HotpotQA — see the module
+    docstring. Two supporting facts sit far apart in the context and must be
+    joined: person -> place, place -> item. Distractor paragraphs use the same
+    template with different entities, so retrieving one hop is not enough.
+    """
+    rng = random.Random(seed)
+    people = rng.sample(QA_PEOPLE, n_distractor + 1)
+    places = rng.sample(QA_PLACES, n_distractor + 1)
+    items = rng.sample(QA_ITEMS, n_distractor + 1)
+
+    hop1, hop2, spans = [], [], []
+    for i in range(n_distractor + 1):
+        hop1.append(f"{people[i]} spent the survey season at {places[i]}.")
+        hop2.append(f"The instrument installed at {places[i]} was a {items[i]}.")
+    # Interleave so the two hops for the target are never adjacent.
+    spans = hop1 + hop2
+
+    filler = _grow_filler(tok, ctx_tokens, rng)
+    body = _scatter(filler, spans, rng)
+    prompt = (
+        "Read the following text carefully and then answer the question.\n\n"
+        f"{body}\n\n"
+        f"Question: Which instrument was installed at the location where "
+        f"{people[0]} spent the survey season?\nAnswer:"
+    )
+    # No pool: the answer space is free-form prose, not a candidate list.
+    return prompt, [items[0]], None
+
+
+BUILDERS = {
+    "vt": build_vt,
+    "cwe": build_cwe,
+    "fwe": build_fwe,
+    "qa_synthetic": build_qa_synthetic,
+}
+
+
+# ── scoring ──────────────────────────────────────────────────────────────────
+# Chat models keep talking after answering: they emit an EOS-ish special token
+# and then start a fresh turn that re-states or revises the answer. Only the
+# first segment is the answer to the question that was asked.
+_STOP_MARKERS = ("<|eot_id|>", "<|im_end|>", "<|endoftext|>", "<|start_header_id|>")
+
+
+def _first_segment(text: str) -> str:
+    """The answer up to the first turn boundary.
+
+    Without this the scorer sees the model's follow-on turns too, and a model
+    that answers wrongly then rambles through a dozen more candidates gets
+    credited for whichever one happens to be right.
+    """
+    cut = len(text)
+    for marker in _STOP_MARKERS:
+        i = text.find(marker)
+        if i != -1:
+            cut = min(cut, i)
+    seg = text[:cut]
+    # Newline-newline is a turn boundary for models that do not emit a special
+    # token here at all.
+    j = seg.find("\n\n")
+    return seg[:j] if j != -1 else seg
+
+
+def _normalise(text: str) -> str:
+    """Lowercase and collapse to bare alphanumeric tokens for matching."""
+    return " " + " ".join(re.findall(r"[a-z0-9]+", text.lower())) + " "
+
+
+def score_answer(text: str, expected: list[str], pool: list[str] | None = None) -> float:
+    """Score one answer in [0, 1]: recall of the expected items, capped by precision.
+
+    Partial credit, not exact match. VT and CWE/FWE expect several items, and
+    an all-or-nothing score would collapse "found two of three" and "found
+    none" into the same 0 — exactly the distinction this evaluation exists to
+    draw. Matching is on normalised whitespace-delimited tokens, so a
+    substring hit inside a longer word does not count.
+
+    Recall alone is not enough, though. On CWE a model that simply lists
+    fourteen words from the list scores 100% recall without having aggregated
+    anything, and that was observed on Llama-3.2-1B during development. So
+    when ``pool`` is supplied (the candidate set the answer is drawn from),
+    the score is multiplied by precision over the pool words actually named.
+    Naming every candidate then scores ``len(expected) / len(pool)``, not 1.0.
+
+    ``pool`` is None for tasks with a free-form answer space (QA), where there
+    is no candidate set to measure precision against.
+    """
+    if not expected:
+        return 0.0
+    hay = _normalise(text)
+    hits = sum(1 for e in expected if f" {_normalise(e).strip()} " in hay)
+    recall = hits / len(expected)
+    if pool is None or recall == 0.0:
+        return recall
+    named = sum(1 for w in pool if f" {_normalise(w).strip()} " in hay)
+    precision = hits / named if named else 0.0
+    return recall * precision
+
+
+def run_case(
+    model,
+    tok,
+    caches,
+    prompt: str,
+    expected: list[str],
+    pool: list[str] | None = None,
+    max_new: int = 48,
+) -> tuple[float, str]:
+    """Greedy-decode an answer and score it. Returns ``(score, first_segment)``.
+
+    Greedy rather than sampled: the comparison is between caches, and sampling
+    noise would need many more repeats per cell to see through.
+    """
+    ids = tok.encode(prompt)
+    logits = model(mx.array([ids]), cache=caches)
+    cur = mx.argmax(logits[0, -1]).reshape(1, 1)
+    out = [int(cur.item())]
+    for _ in range(max_new - 1):
+        logits = model(cur, cache=caches)
+        cur = mx.argmax(logits[0, -1]).reshape(1, 1)
+        out.append(int(cur.item()))
+    text = _first_segment(tok.decode(out))
+    return score_answer(text, expected, pool), text
+
+
+# ── driver ───────────────────────────────────────────────────────────────────
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("models", nargs="*", default=None)
+    ap.add_argument(
+        "--seeds",
+        type=int,
+        default=3,
+        help="repeats per (task, ctx) cell; each uses a distinct seed",
+    )
+    ap.add_argument("--out", default=None, help="output JSON path")
+    args = ap.parse_args()
+
+    models = args.models or DEFAULT_MODELS
+    out_path = (
+        Path(args.out)
+        if args.out
+        else (_repo_root / "figures" / "qfilters" / "ruler_beyond_niah.json")
+    )
+
+    results: dict = {
+        "_comment": (
+            "RULER task categories outside the NIAH family, for issue #177. "
+            "Generators follow the constructions in Hsieh et al. "
+            "(arXiv:2404.06654) but are written in this repo, not RULER's own "
+            "harness, and run at short contexts. Scores are NOT comparable to "
+            "published RULER numbers -- they are a relative comparison between "
+            "cache methods on identical prompts. 'qa_synthetic' is not RULER's "
+            "QA task (which wraps SQuAD/HotpotQA); it is a synthetic two-hop "
+            "task and is easier. Expected Attention is not implemented in this "
+            "repo and is therefore absent as an arm."
+        ),
+        "scoring": (
+            "Fraction of expected strings present in the greedy-decoded answer "
+            "(partial credit), matched on normalised whitespace-delimited "
+            "tokens. Reported per cell as the mean over seeds."
+        ),
+        "config": {
+            "budgets": BUDGETS,
+            "context_lengths": CTX_LENS,
+            "methods": METHODS,
+            "tasks": TASKS,
+            "seeds_per_cell": args.seeds,
+            "prefill": "one-shot (worst case for Q-Filters; see module docstring)",
+            "qfilters_recent": "budget // 4",
+            "knorm_recent": "budget // 4",
+        },
+        "models": {},
+    }
+
+    for model_id in models:
+        print(f"\n{'=' * 78}\n{model_id}\n{'=' * 78}", flush=True)
+        model, tok = mlx_lm.load(model_id)
+        inner = getattr(model, "model", model)
+        n_layers = len(inner.layers)
+        kv_heads = model.args.num_key_value_heads
+        # Qwen2's ModelArgs omits head_dim; Llama's carries it. Derive when absent.
+        head_dim = (
+            getattr(model.args, "head_dim", None)
+            or model.args.hidden_size // model.args.num_attention_heads
+        )
+
+        print("calibrating query-SVD filters ...", flush=True)
+        acts = collect_query_activations(
+            model, tok, CALIB, max_length=512, max_samples_per_head=2000
+        )
+        filters = [average_gqa_filters(compute_qfilters(a), kv_heads) for a in acts]
+        del acts
+        gc.collect()
+
+        mrec: dict = {}
+        samples: dict = {}
+
+        for task in TASKS:
+            print(f"\n--- {task} ---", flush=True)
+            print(
+                f"{'method':<16}{'budget':>8}"
+                + "".join(f"{f'ctx {c}':>10}" for c in CTX_LENS)
+                + f"{'mean':>9}"
+            )
+            mrec[task] = {}
+            fp16_mean = None
+            for method in METHODS:
+                # fp16 ignores the budget entirely -- measure it once and carry
+                # that row as the ceiling for every budget.
+                budgets = [BUDGETS[0]] if method == "fp16" else BUDGETS
+                for nb in budgets:
+                    per_ctx = []
+                    for ctx in CTX_LENS:
+                        cell = []
+                        for s in range(args.seeds):
+                            # Offset per task: CWE and FWE both shuffle
+                            # WORD_POOL, so a shared seed would hand them the
+                            # same answer set and stop them being independent
+                            # samples of the same model.
+                            seed = ctx * 100 + s + TASK_SEED_OFFSET[task]
+                            prompt, expected, pool = BUILDERS[task](tok, ctx, seed)
+                            caches = make_caches(method, n_layers, head_dim, nb, filters)
+                            sc, text = run_case(model, tok, caches, prompt, expected, pool)
+                            cell.append(sc)
+                            if s == 0 and ctx == CTX_LENS[0]:
+                                samples[f"{task}/{method}/{nb}"] = {
+                                    "expected": expected,
+                                    "decoded": text[:200],
+                                    "score": sc,
+                                    "pool_size": len(pool) if pool else None,
+                                }
+                            del caches
+                            gc.collect()
+                        per_ctx.append(sum(cell) / len(cell))
+                    mean = sum(per_ctx) / len(per_ctx)
+                    if method == "fp16":
+                        fp16_mean = mean
+                    label = "fp16 (any)" if method == "fp16" else method
+                    mrec[task].setdefault(method, {})[str(nb)] = {
+                        "per_ctx": {str(c): v for c, v in zip(CTX_LENS, per_ctx, strict=True)},
+                        "mean": mean,
+                    }
+                    print(
+                        f"{label:<16}{nb:>8}"
+                        + "".join(f"{v:>9.0%} " for v in per_ctx)
+                        + f"{mean:>8.0%}",
+                        flush=True,
+                    )
+
+            # Record whether this (model, task) cell can discriminate at all.
+            # Where fp16 itself scores near the floor, the eviction arms are
+            # measuring the model's inability to do the task, not the cache's
+            # effect on it, and the row must not be read as a method comparison.
+            # Llama-3.2-1B lands here on vt/cwe/fwe; Qwen2.5-7B clears it on all four.
+            mrec[task]["_fp16_ceiling"] = fp16_mean
+            mrec[task]["_discriminative"] = bool(fp16_mean is not None and fp16_mean >= CEILING_MIN)
+            if not mrec[task]["_discriminative"]:
+                print(
+                    f"  [!] fp16 ceiling {fp16_mean:.0%} < {CEILING_MIN:.0%} -- "
+                    f"this model cannot do {task}; rows above are not a method comparison",
+                    flush=True,
+                )
+
+        results["models"][model_id] = {"tasks": mrec, "samples": samples}
+        # Write after each model: a 7B run is long enough that losing it to a
+        # crash on the next model would be a real cost.
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(results, indent=2))
+        print(f"\n  [checkpoint] {out_path}", flush=True)
+
+        del model, tok, filters
+        gc.collect()
+
+    print(f"\nSaved {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_scripts/qfilters_ruler_budget_verification.py
+++ b/benchmark_scripts/qfilters_ruler_budget_verification.py
@@ -1,0 +1,112 @@
+"""Verify the RULER arms compress equally, so score gaps are selection not budget (#177).
+
+On common-word extraction the RULER harness reports a 0%-to-93% spread across
+eviction methods at the same nominal budget. Before treating that as a
+selection-quality result it has to be ruled out that some arm simply keeps
+more tokens, or reports RoPE positions wrongly -- the ``offset`` defect that
+:issue:`171` fixed for Q-Filters and :issue:`174` for L2Norm would produce
+exactly this kind of spread for entirely the wrong reason.
+
+This measures the retained cache rows and the reported offset directly, after
+a real prefill, for every arm on one identical prompt.
+
+Result on Qwen2.5-7B, CWE prompt of 1272 tokens, budget 512:
+
+    method          cache.keys.shape        offset   CWE mean
+    snapkv          (1, 4, 512, 128)        1272        0%
+    qfilters        (1, 4, 512, 128)        1272       33%
+    knorm           (1, 4, 512, 128)        1272       38%
+    streaming_llm   (1, 4, 512, 128)        1272       93%
+
+Every arm retains exactly 512 of 1272 tokens and reports the true final
+position. No arm is advantaged by keeping more, and none carries a position
+defect, so the spread is entirely *which* tokens each method selected.
+
+WHY SNAPKV SCORES ZERO HERE
+---------------------------
+SnapKV picks tokens by attention from a trailing ``snap_obs_window`` (32
+tokens) used as proxy queries. In the CWE construction that window lands on
+the question text rather than on the word list it asks about, so the proxy is
+unrepresentative: SnapKV scores the question region as important and evicts
+the list it needs to count. Decoded answers on the same prompt make the
+failure mode legible:
+
+    snapkv b512    ' 10000000000000000000000000000000000000000000000'
+    snapkv b1024   ': "opportunity", "innovation", and "inspiration".'
+    stream b1024   ' opal, juniper, and birch. Each of these words appears 9 times ...'
+
+The b1024 answer is fluent, well-formed and entirely fabricated -- none of
+those three words appear anywhere in the prompt. Having lost the list, the
+model answers from priors. StreamingLLM on the identical prompt cites the
+counts, showing it still held the data.
+
+This is a statement about a proxy-query method meeting a task whose relevant
+span is not where its proxy looks. It is not a general claim about SnapKV.
+
+Usage:
+    python benchmark_scripts/qfilters_ruler_budget_verification.py [MODEL]
+"""
+
+from __future__ import annotations
+
+import gc
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+import mlx_lm
+
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from benchmark_scripts.qfilters_ruler_beyond_niah import (  # noqa: E402
+    BUILDERS,
+    make_caches,
+    run_case,
+)
+
+DEFAULT_MODEL = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+BUDGET = 512
+CTX = 1024
+METHODS = ["snapkv", "qfilters", "knorm", "streaming_llm"]
+
+
+def main() -> None:
+    model_id = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_MODEL
+    model, tok = mlx_lm.load(model_id)
+    inner = getattr(model, "model", model)
+    n_layers = len(inner.layers)
+    head_dim = (
+        getattr(model.args, "head_dim", None)
+        or model.args.hidden_size // model.args.num_attention_heads
+    )
+
+    prompt, expected, pool = BUILDERS["cwe"](tok, CTX, CTX * 100 + 10_000)
+    ids = tok.encode(prompt)
+    print(f"CWE prompt = {len(ids)} tokens, budget {BUDGET}, expected {expected}\n")
+    print(f"{'method':<16}{'cache.keys.shape':<26}{'offset':>8}{'score':>8}")
+
+    for method in METHODS:
+        # Shape after a real prefill -- the retained rows, not a counter.
+        # `tokens_kept` on these caches is a cumulative sum across (B, H) and
+        # is NOT the current cache size; reading it as one is misleading.
+        caches = make_caches(method, n_layers, head_dim, BUDGET, None)
+        logits = model(mx.array([ids]), cache=caches)
+        mx.eval(logits)
+        shape = tuple(caches[0].keys.shape)
+        offset = caches[0].offset
+        del caches
+        gc.collect()
+
+        caches = make_caches(method, n_layers, head_dim, BUDGET, None)
+        score, text = run_case(model, tok, caches, prompt, expected, pool)
+        del caches
+        gc.collect()
+
+        print(f"{method:<16}{str(shape):<26}{offset:>8}{score:>7.0%}")
+        print(f"    {text[:100]!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_scripts/qfilters_ruler_prefill_chunking.py
+++ b/benchmark_scripts/qfilters_ruler_prefill_chunking.py
@@ -1,0 +1,130 @@
+"""Does chunked prefill rescue Q-Filters on variable tracking? (#177)
+
+The NIAH harness documents that Q-Filters' output quality depends strongly on
+how the prompt is fed: ``qfilters_update`` absorbs a block then evicts to
+budget in one shot, so a single large prefill makes one eviction decision
+against a filter frozen on that same block. Measured there on Llama-3.2-1B,
+identical prompt and budget, output went from degenerate at one shot to
+coherent at <=64-token chunks.
+
+The RULER harness prefills in one shot (what ``model(prompt, cache=...)``
+does by default), so its Q-Filters rows are that method's worst case. Before
+reporting "Q-Filters scores 0% on variable tracking" it is worth establishing
+whether the collapse is inherent to the task or an artifact of that path.
+
+Result on Qwen2.5-7B, budget 512, ctx 1024, 3 seeds (fp16 ceiling 69%):
+
+    one-shot          0.00   [0.00, 0.00, 0.00]
+    256-token chunks  0.00   [0.00, 0.00, 0.00]
+    64-token chunks   0.11   [0.00, 0.00, 0.33]
+
+Chunking does not rescue it. On NIAH the 256-token setting already produced
+partial recovery; here it produces none, and the <=64 setting that restored
+coherence there yields a single partial hit across three seeds. Against a 69%
+ceiling, 0.11 is still collapse -- but it is not zero, and the run is 3 seeds
+at one budget, so this establishes "chunking does not rescue it" rather than a
+precise chunked score.
+
+The likely reason is structural rather than about prefill: VT requires every
+hop of a scattered chain to survive eviction, and a projection-based
+importance score has no way to mark a bare ``VAR X502 = X684.`` as
+load-bearing. Retaining most of a chain still scores zero, because a broken
+chain yields no correct answer. NIAH differs -- retaining the single needle
+suffices.
+
+Usage:
+    python benchmark_scripts/qfilters_ruler_prefill_chunking.py [MODEL]
+"""
+
+from __future__ import annotations
+
+import gc
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+import mlx_lm
+
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from benchmark_scripts.qfilters_ruler_beyond_niah import (  # noqa: E402
+    BUILDERS,
+    CALIB,
+    _first_segment,
+    make_caches,
+    run_case,
+    score_answer,
+)
+from veloxquant_mlx.quantizers.qfilters_calibration import (  # noqa: E402
+    average_gqa_filters,
+    collect_query_activations,
+    compute_qfilters,
+)
+
+DEFAULT_MODEL = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+BUDGET = 512
+CTX = 1024
+SEEDS = 3
+CHUNKS = [None, 256, 64]  # None == one-shot, the harness default
+
+
+def run_chunked(model, tok, caches, prompt, expected, pool, chunk, max_new=48):
+    """Prefill in ``chunk``-token blocks, then greedy-decode and score.
+
+    Each block is a separate ``update_and_fetch``, so Q-Filters evicts once
+    per block against a filter frozen on that block rather than making one
+    decision over the whole prompt.
+    """
+    ids = tok.encode(prompt)
+    logits = None
+    for i in range(0, len(ids), chunk):
+        logits = model(mx.array([ids[i : i + chunk]]), cache=caches)
+        mx.eval(logits)
+    cur = mx.argmax(logits[0, -1]).reshape(1, 1)
+    out = [int(cur.item())]
+    for _ in range(max_new - 1):
+        logits = model(cur, cache=caches)
+        cur = mx.argmax(logits[0, -1]).reshape(1, 1)
+        out.append(int(cur.item()))
+    return score_answer(_first_segment(tok.decode(out)), expected, pool)
+
+
+def main() -> None:
+    model_id = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_MODEL
+    model, tok = mlx_lm.load(model_id)
+    inner = getattr(model, "model", model)
+    n_layers = len(inner.layers)
+    kv_heads = model.args.num_key_value_heads
+    head_dim = (
+        getattr(model.args, "head_dim", None)
+        or model.args.hidden_size // model.args.num_attention_heads
+    )
+
+    print("calibrating query-SVD filters ...", flush=True)
+    acts = collect_query_activations(model, tok, CALIB, max_length=512, max_samples_per_head=2000)
+    filters = [average_gqa_filters(compute_qfilters(a), kv_heads) for a in acts]
+    del acts
+    gc.collect()
+
+    print(f"\nVT, {model_id}, budget {BUDGET}, ctx {CTX} -- prefill chunk sweep ({SEEDS} seeds)")
+    for chunk in CHUNKS:
+        scores = []
+        for s in range(SEEDS):
+            prompt, expected, pool = BUILDERS["vt"](tok, CTX, CTX * 100 + s)
+            caches = make_caches("qfilters", n_layers, head_dim, BUDGET, filters)
+            if chunk is None:
+                sc = run_case(model, tok, caches, prompt, expected, pool)[0]
+            else:
+                sc = run_chunked(model, tok, caches, prompt, expected, pool, chunk)
+            scores.append(sc)
+            del caches
+            gc.collect()
+        label = "one-shot" if chunk is None else f"{chunk}-tok chunks"
+        mean = sum(scores) / len(scores)
+        print(f"  {label:<16} mean={mean:.2f}  {[f'{x:.2f}' for x in scores]}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_scripts/qfilters_ttft_throughput_niah.py
+++ b/benchmark_scripts/qfilters_ttft_throughput_niah.py
@@ -8,8 +8,10 @@ WHAT THIS IS NOT
 ----------------
 * **Not RULER.** The retrieval arm here is the NIAH family only (single-key,
   multi-key, multi-value), generated synthetically in-process. RULER's other
-  ten task categories (variable tracking, common/frequent-word extraction, QA)
-  are not covered.
+  task categories (variable tracking, common/frequent-word extraction, QA)
+  are covered separately by ``qfilters_ruler_beyond_niah.py`` (:issue:`177`),
+  which finds Q-Filters at 0% on variable tracking and two-hop QA against
+  ceilings of 69% and 90% -- it does not generalise past single-span lookup.
 * **Not Expected Attention.** That method is not implemented in this repo, so
   it cannot be a comparison arm.
 * **Not a speedup claim over fp16.** These caches run a per-(B, H) Python loop

--- a/blogs/ruler-beyond-niah.md
+++ b/blogs/ruler-beyond-niah.md
@@ -1,0 +1,241 @@
+# The Needle Was the Easy Part
+
+## A KV cache compressor that aces needle-in-a-haystack scores zero on variable tracking — and the reason is about the task, not the method
+
+---
+
+I had a benchmark result I was happy with. Q-Filters, a KV cache eviction method I'd spent weeks fixing, was retrieving needles from haystacks at aggressive compression. Single-key, multi-key, multi-value — the whole NIAH family. The numbers were committed, the docs were written.
+
+Then I ran it on variable tracking and it scored **zero**. Every budget. Every context length. Against a model that solves the task 69% of the time with a full cache.
+
+Not "degraded." Not "worse than the baseline." Zero, in every cell.
+
+The interesting part isn't that it failed. It's that *every* importance-scoring method failed the same way, on the same two tasks, while degrading gracefully on two others — and the split doesn't fall where you'd expect. This is what I found, including a wrong conclusion I published to myself for about ten minutes before checking it.
+
+---
+
+## What NIAH actually tests
+
+Needle-in-a-haystack is the standard long-context retrieval benchmark. You bury a distinctive sentence — "The access code for the Aurora project is 4471" — in filler text and ask for it back.
+
+For a cache eviction method, this is a specific and narrow challenge: **one span must survive**. Everything else in that context is disposable. If your scoring function assigns high importance to the needle and low importance to the filler, you keep the needle and answer correctly, even at 4× compression.
+
+That's a real capability. It's also a soft target, in a way that isn't obvious until you test something else. The needle is *lexically distinctive* — it's the only sentence containing digits, the only one naming a project. Almost any importance signal keyed to "unusual" will find it.
+
+[RULER](https://arxiv.org/abs/2404.06654) (Hsieh et al., 2024) exists because of this. It ships 13 task categories precisely to stop NIAH being the whole story. My repo covered the needle family and nothing else, and the docs said so under a heading reading "Still not measured." That heading is the reason this experiment happened.
+
+---
+
+## The setup
+
+Four task categories outside the needle family, following RULER's constructions but generated in-process (I didn't want a dataset dependency in a repo that has none):
+
+- **VT** — variable tracking. `VAR X742 = 87319.` then `VAR X375 = X742.` then `VAR X581 = X375.` Scattered through filler. Name every variable holding 87319.
+- **CWE** — common-word extraction. A word list where three words appear 10 times and the rest twice. Name the frequent ones.
+- **FWE** — frequent-word extraction. Same shape, but frequencies follow a Zeta distribution, so there's no clean gap between "common" and "rare" — you're ranking, not thresholding.
+- **QA** — two-hop question answering. `Rafael Duarte spent the survey season at Vellamo.` … `The instrument installed at Vellamo was a theodolite.` Which instrument did Rafael Duarte's location have?
+
+Five eviction arms at matched budgets: **fp16** (no compression, the ceiling), **Q-Filters**, **SnapKV**, **StreamingLLM**, **L2Norm**. Qwen2.5-7B-Instruct-4bit, five seeds per cell, contexts 1024 and 2048, budgets 256/512/1024.
+
+---
+
+## The results
+
+| Task | fp16 | Q-Filters | SnapKV | StreamingLLM | L2Norm |
+|---|---|---|---|---|---|
+| VT (chain tracking) | 69% | 0 / 0 / 0 | 0 / 0 / 3 | 0 / 12 / **46** | 0 / 0 / 3 |
+| CWE (common words) | 100% | 9 / 33 / **56** | 0 / 0 / 0 | **100 / 93 / 100** | 23 / 38 / 53 |
+| FWE (frequent words) | 69% | 43 / 40 / 46 | 0 / 0 / 13 | **77 / 64 / 52** | 49 / 43 / 43 |
+| QA (two-hop) | 90% | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 |
+
+Cells are budget 256 / 512 / 1024.
+
+Three different shapes across four tasks. That's the finding, and it took me a while to see it as one result rather than four.
+
+---
+
+## First: is the benchmark measuring anything?
+
+Before reading a single row I had to answer a question that kills most quick evaluations: **can the model do the task at all?**
+
+This matters more than it sounds. I originally ran all of this on Llama-3.2-1B. Here's what that produced on common-word extraction:
+
+```
+fp16 (the ceiling)      17%
+streaming_llm  b256     35%
+snapkv         b256     28%
+```
+
+Two eviction methods "beat" the uncompressed baseline. By a factor of two.
+
+That is impossible. Discarding 75% of the cache cannot make a model *better* at counting words. What those numbers actually measure is a 1B model failing to do the task in various random ways, with partial-credit scoring occasionally catching a word by luck.
+
+If I'd reported that table, the headline would have been "StreamingLLM doubles fp16 accuracy" — a claim with no meaning whatsoever.
+
+So every cell in my harness records the fp16 ceiling and a `_discriminative` flag. Below 50%, the row prints a warning and is not a method comparison. Llama-3.2-1B trips it on three of four tasks (ceilings 11% / 16% / 26%). That's not a bug in the model — it's a statement about where this benchmark applies, and it's why the final results run on a 7B.
+
+**The general lesson:** when your baseline is near the floor, every arm is measuring noise, and noise sometimes looks like a win. An eviction method scoring above the uncompressed ceiling is not a discovery. It's a warning light.
+
+---
+
+## The zeros are real, and they're structural
+
+Q-Filters scores 0% on VT and 0% on QA. Every budget. My first instinct was that something was broken.
+
+The harness prefills in one shot — one `model(prompt, cache=...)` call — and I already knew from prior work that Q-Filters is unusually sensitive to this. It absorbs a whole block, then evicts to budget in a single decision, against a filter frozen on that same block. Feed it 64-token chunks instead and output quality changes materially.
+
+So I swept the prefill path:
+
+| prefill | VT score | per-seed |
+|---|---|---|
+| one-shot | 0.00 | 0.00, 0.00, 0.00 |
+| 256-token chunks | 0.00 | 0.00, 0.00, 0.00 |
+| 64-token chunks | 0.11 | 0.00, 0.00, 0.33 |
+
+On NIAH, 256-token chunks had already produced partial recovery. Here they produce nothing. The 64-token setting — the one that restored coherence on needles — yields a single partial hit across three seeds.
+
+0.11 against a 69% ceiling is still collapse. But note that it isn't zero, and I'm not going to write it as zero because the cleaner number would tell a tidier story. Three seeds at one budget supports "chunking doesn't rescue it," not a precise chunked score.
+
+The failure isn't about how the prompt is fed.
+
+---
+
+## Why VT and QA break when CWE doesn't
+
+Here's the part I find genuinely useful, and it only becomes visible once you have four tasks instead of one.
+
+Look at what each task requires to survive eviction.
+
+**Variable tracking needs a conjunction.** To answer "which variables hold 87319," you need `VAR X742 = 87319` **and** `VAR X375 = X742` **and** `VAR X581 = X375`. Drop any one and the chain breaks. There's no partial answer — you can't name two-thirds of a chain you can't trace.
+
+And critically: none of those spans is distinctive. `VAR X375 = X742.` is four tokens of nothing. It carries no lexical signal, no unusual vocabulary, no marker saying *this one matters*. A projection-based importance score has no way to know it's load-bearing. Neither does a key-norm score.
+
+Here's Q-Filters' actual output at budget 512:
+
+```
+' assigned the values 87319, 87319, and 87319. There are exactly 3.'
+```
+
+The model found the *value* — that span has digits, it's distinctive, it survives. It lost the variable names entirely and echoed the number three times to fill the slot.
+
+**Two-hop QA is the same shape.** You need `Rafael Duarte → Vellamo` and `Vellamo → theodolite`. Lose either link and you can't answer. And the failure looks like this:
+
+```
+qfilters/256   ' The guitar was installed at the location where Rafael Duarte spent...'
+qfilters/1024  ' The instrument installed at Kestrel Bay was a chronometer.'
+knorm/1024     ' The instrument installed at Kestrel Bay was a chronometer.'
+```
+
+Fluent. Confident. Naming a *distractor* pair — Kestrel Bay and chronometer are both in the prompt, just not connected to Rafael Duarte. One method invented "guitar," which appears nowhere at all.
+
+Every arm scored 0% on QA. All four. That uniformity is what convinced me this is about task structure rather than any method's scoring function.
+
+**Now compare CWE**, where Q-Filters goes 9% → 33% → 56% as budget grows. Naming two of three common words is genuinely worth two-thirds of the answer. Partial retention earns partial credit, so degradation is graded instead of catastrophic.
+
+**And FWE breaks the pattern again** — Q-Filters is *flat* across budgets: 43 / 40 / 46. More cache doesn't help. Zeta-distributed frequencies mean the answer depends on counting across the whole list, so retaining a larger *arbitrary* subset doesn't improve your count. You need the right tokens, not more tokens.
+
+Three shapes:
+
+- **Conjunctive tasks** (VT, QA) → cliff. Everything or nothing.
+- **Additive tasks** (CWE) → graded decline, scales with budget.
+- **Global-aggregate tasks** (FWE) → flat. Budget is the wrong lever.
+
+NIAH is none of these. It's a *disjunctive* task with one term: keep one span, win. That's why a method can look strong there and collapse here, and why "we validated on NIAH" is a weaker claim than it sounds.
+
+---
+
+## The zero I nearly got wrong
+
+SnapKV scores 0% on CWE at every budget. Unlike VT, partial credit was available here — the other three methods all scored something. That asymmetry made me suspicious it was a bug rather than a result.
+
+I checked `tokens_kept` and found **2236** at budget 512. On a 1272-token prompt. Retaining more than four times the budget, and more tokens than exist in the input.
+
+I wrote that up as a probable budget-enforcement defect.
+
+Then I read the source. `tokens_kept` is a **cumulative counter summed across batch and heads** — it accumulates across every call, and it isn't a cache size at all. My "4× over-retention" was arithmetic on a number that doesn't mean what I assumed.
+
+So I measured the thing directly instead, via `cache.keys.shape` after a real prefill:
+
+| method | retained rows | offset | CWE |
+|---|---|---|---|
+| snapkv | (1, 4, **512**, 128) | 1272 ✓ | 0% |
+| qfilters | (1, 4, **512**, 128) | 1272 ✓ | 33% |
+| knorm | (1, 4, **512**, 128) | 1272 ✓ | 38% |
+| streaming_llm | (1, 4, **512**, 128) | 1272 ✓ | 93% |
+
+Every arm keeps exactly 512 of 1272 rows. Every arm reports the true final position — no RoPE offset drift, which was worth confirming because that exact defect had previously produced convincing-but-meaningless results in this codebase twice.
+
+The budgets are enforced. The positions are right. **The 0%-to-93% spread is entirely which tokens each method chose to keep.**
+
+That makes SnapKV's zero a genuine result, and a mechanically explicable one. SnapKV scores tokens by attention from a trailing `snap_obs_window` — the last 32 tokens, used as proxy queries. In this construction those 32 tokens are the *question*, not the word list. So it scores the question region as important and evicts the data it was asked to count.
+
+The output makes it vivid:
+
+```
+snapkv  b512   ' 10000000000000000000000000000000000000000000000'
+snapkv  b1024  ': "opportunity", "innovation", and "inspiration".'
+```
+
+That second one is my favourite result in the whole run. It's fluent, well-formed, correctly punctuated, and **completely fabricated** — none of those three words appear anywhere in the prompt. Having evicted the list, the model answered from priors. It's what confabulation looks like from the inside.
+
+Compare StreamingLLM on the identical prompt, same 512 retained tokens:
+
+```
+' opal, juniper, and birch. Each of these words appears 9 times in the given list.
+- opal: 9 times
+- juniper: 9 times
+- birch: 9 times'
+```
+
+It still had the data, so it counted.
+
+This is not "SnapKV is bad." It's a proxy-query method meeting a task whose relevant span isn't where its proxy looks. Put the word list at the end and SnapKV would very likely win.
+
+---
+
+## Two things I'm not claiming
+
+**StreamingLLM's 100% on CWE is partly my fault.** In my construction, the word list sits at the end of the prompt, immediately before the question — which is exactly where a trailing window keeps tokens. That's a property of how I built the task, not evidence that recency is the right eviction policy for aggregation. A different layout would move that number a lot.
+
+**StreamingLLM's 77% on FWE is above the 69% fp16 ceiling**, and I flagged that pattern myself as a noise signature earlier in this post. Here the cell is discriminative and the margin is small, so the honest reading is that StreamingLLM is *at* the ceiling and 77-vs-69 is seed variance. Compression still cannot beat no compression. I'm reporting it as measured rather than clipping it to 69% to look tidy — but I'm not calling it a win.
+
+There's also a subtlety in the budget labels worth knowing if you build something similar. My context lengths size the *filler* only; the instruction, task spans, and question add 100–250 tokens on top. A nominal 1024-token QA prompt is actually **1169 tokens**, so "budget 1024" still evicts ~145 tokens — sometimes including the trailing question, which is why a few methods score *worse* at the largest budget. The harness now records real prefilled token counts so the implied compression ratio is checkable rather than inferred.
+
+---
+
+## What this changes
+
+If you're choosing a KV cache eviction method, NIAH results tell you about one narrow capability: preserving a single lexically distinctive span. That capability does not transfer to:
+
+- tasks needing a **conjunction** of facts (multi-hop reasoning, chain tracing, anything where a broken link scores zero)
+- tasks needing **global aggregation** (counting, frequency ranking — where more cache doesn't help if it's the wrong cache)
+
+Q-Filters remains a reasonable method with a real theoretical basis. Its projection score is cheap, calibration-free at inference, and it holds up where partial retention earns partial credit. But "validated on needle retrieval" is a much narrower claim than it appears, and I'd been treating it as broader.
+
+The honest summary of my own library got shorter and more specific: this method works for single-span retrieval and graded aggregation, and fails on conjunctive tasks. That's more useful than the version where I only had needles.
+
+---
+
+## Limitations, stated plainly
+
+**One model.** These results are Qwen2.5-7B only. Llama-3.2-1B can't perform three of the four tasks even at fp16, so it can't evaluate cache methods at that scale. Llama-3.2-3B would have contributed real CWE and FWE cells and was cut for runtime — a genuine gap, not a considered choice.
+
+**Contexts stop at 2048 tokens.** RULER is built to stress long context. This doesn't.
+
+**Not RULER's harness, and not RULER's scores.** The generators follow the paper's constructions but are written by me and run short. Read the numbers as a relative comparison between cache methods on identical prompts, not as RULER results. The QA arm in particular is synthetic two-hop, not RULER's QA (which wraps SQuAD and HotpotQA), and it's easier.
+
+**Expected Attention isn't an arm** because it isn't implemented in my repo. It's the one I most want to see here: it scores by *predicted future attention* rather than intrinsic key geometry, which makes it the natural test of whether the conjunctive-task cliff is specific to intrinsic scorers or general to eviction.
+
+---
+
+## The reusable part
+
+If you take one thing from this, take the ceiling check.
+
+Before comparing methods on any task, measure what the *uncompressed* baseline scores. If it's near the floor, stop — every arm you compare is sampling noise, and noise occasionally produces a number that looks like a breakthrough. I built that check as a gate in the harness after watching a 1B model hand me "StreamingLLM beats fp16 by 2×," and it earned its keep immediately.
+
+The second thing: when a result is suspiciously clean — a flat zero, a perfect score — measure the mechanism directly before you explain it. I had a tidy story about SnapKV over-retaining by 4×, built on a counter that meant something else entirely. Ten minutes with the source and a shape probe replaced it with a better story that happened to be true.
+
+---
+
+*Code and raw results: [`qfilters_ruler_beyond_niah.py`](https://github.com/rajveer43/VeloxQuant-MLX/blob/master/benchmark_scripts/qfilters_ruler_beyond_niah.py), [`ruler_beyond_niah.json`](https://github.com/rajveer43/VeloxQuant-MLX/blob/master/figures/qfilters/ruler_beyond_niah.json). The verification probes are committed too — [budget/offset](https://github.com/rajveer43/VeloxQuant-MLX/blob/master/benchmark_scripts/qfilters_ruler_budget_verification.py) and [prefill chunking](https://github.com/rajveer43/VeloxQuant-MLX/blob/master/benchmark_scripts/qfilters_ruler_prefill_chunking.py) — because a claim about mechanism should ship with the thing that checked it.*

--- a/docs-site/docs/algorithms/qfilters.md
+++ b/docs-site/docs/algorithms/qfilters.md
@@ -444,14 +444,97 @@ them) and RoPE is relative, so reporting the true position is sufficient and
 survivors need no re-rotation — unlike H2O/Keyformer, which renumber and
 therefore need a delta-rotation pass.
 
+#### Beyond NIAH: the other RULER categories (#177)
+
+The retrieval evidence above is the needle family only. That leaves the
+question of whether the method generalises past single-span lookup, which
+these four task categories answer. Script:
+`benchmark_scripts/qfilters_ruler_beyond_niah.py`, raw numbers in
+`figures/qfilters/ruler_beyond_niah.json`.
+
+Qwen2.5-7B-Instruct-4bit, 5 seeds per cell, mean over contexts 1024 and 2048,
+every arm at a matched budget. These are **not** RULER's own harness or its
+scores — the generators follow the constructions in Hsieh et al.
+(arXiv:2404.06654) but are written here and run at short contexts, so read
+them as a relative comparison between cache methods, not as RULER numbers.
+`qa_synthetic` is not RULER's QA task, which wraps SQuAD/HotpotQA; it is
+synthetic two-hop QA and is easier.
+
+| Task | fp16 | Q-Filters | SnapKV | StreamingLLM | L2Norm |
+|---|---|---|---|---|---|
+| VT (chain tracking) | 69% | 0 / 0 / 0 | 0 / 0 / 3 | 0 / 12 / **46** | 0 / 0 / 3 |
+| CWE (common words) | 100% | 9 / 33 / **56** | 0 / 0 / 0 | **100 / 93 / 100** | 23 / 38 / 53 |
+| FWE (frequent words) | 69% | 43 / 40 / 46 | 0 / 0 / 13 | **77 / 64 / 52** | 49 / 43 / 43 |
+| QA (two-hop) | 90% | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 |
+
+Cells are budget 256 / 512 / 1024. fp16 ignores the budget and is the
+ceiling. All four task rows clear the harness's discriminative gate (fp16
+well above the floor), so each is a method comparison rather than a
+measurement of what the model cannot do.
+
+**Q-Filters does not generalise past needle retrieval.** It scores 0% on
+variable tracking and 0% on two-hop QA at every budget, against ceilings of
+69% and 90%. This is not a prefill artifact: chunking the prefill — the
+path-dependence lever that restored coherence in the NIAH harness — leaves VT
+at 0.00 one-shot, 0.00 at 256-token chunks and 0.11 at 64-token chunks
+(`qfilters_ruler_prefill_chunking.py`).
+
+**The failures are task-shaped, not method-shaped.** VT and QA need a
+specific *conjunction* to survive: a whole assignment chain, or both hops of
+person → place → instrument. Partial retention earns nothing, so every arm
+bottoms out. CWE and FWE award partial credit, and there Q-Filters degrades
+gracefully instead — 9 → 33 → 56% on CWE, scaling cleanly with budget. Three
+task categories, three different shapes; NIAH alone shows none of this.
+
+**Budget does not always help.** On FWE, Q-Filters is flat across budgets
+(43 / 40 / 46%) and so is L2Norm. Zeta-distributed frequencies make the answer
+depend on counting the whole list, so retaining a larger arbitrary subset
+does not improve the count.
+
+**SnapKV floors on the three aggregation tasks** because its trailing
+`snap_obs_window` lands on the question text rather than on the data it must
+aggregate, so the proxy queries score the wrong region as important. Having
+evicted the word list, the model answers from priors: at budget 1024 on CWE it
+returns a fluent, well-formed and entirely fabricated `"opportunity",
+"innovation", "inspiration"` — none of which appear in the prompt. This is a
+proxy-query method meeting a task whose relevant span is not where its proxy
+looks, not a general claim about SnapKV.
+
+Two caveats on the StreamingLLM column, which otherwise looks like a clean
+win. Its 100% on CWE is partly a property of the construction: the word list
+sits at the end of the prompt, immediately before the question, which is
+exactly where a trailing window keeps tokens. And its 77% on FWE sits *above*
+the 69% fp16 ceiling — that is seed variance at the ceiling, not compression
+beating no compression, and it is reported as measured rather than clipped.
+
+Every arm was verified to compress equally before these numbers were read:
+at budget 512 on a 1272-token CWE prompt, all four retain exactly 512 rows
+and report offset 1272 (`qfilters_ruler_budget_verification.py`). No arm is
+advantaged by keeping more, and none carries the `offset` defect #171/#174
+fixed, so the 0%–100% spread is entirely *which* tokens each method selected.
+
+One caution on reading budgets. The harness's context lengths size the filler
+only; instruction, task spans and question add 100–250 tokens, so a nominal
+1024-token QA prompt is 1169 tokens and budget 1024 still evicts ~145 of them
+— enough to break a hop. `prompt_tokens` in the JSON records the real
+prefilled length per task and context.
+
 #### Still not measured
 
-**RULER** beyond the NIAH family — the other ten task categories (variable
-tracking, common/frequent-word extraction, QA) are not covered.
+**RULER's remaining task categories.** #177 covers variable tracking,
+common/frequent-word extraction and QA (above); RULER ships 13 tasks, and the
+rest — multi-hop tracing variants and the aggregation tasks at long context —
+are not covered, nor is any context beyond 2048 tokens.
+**Model coverage for the RULER results is a single model.** Llama-3.2-1B
+cannot perform VT, CWE or FWE even at fp16 (ceilings 11% / 16% / 26%), so
+those cells cannot evaluate cache methods at that scale; Llama-3.2-3B would
+have contributed genuine CWE and FWE cells (ceilings 100% / 81%) and was cut
+for runtime.
 **Expected Attention** is not implemented in this repo, so it cannot be a
-comparison arm. [L2Norm](../algorithms/knorm) previously carried the same
-`offset` defect and was excluded for that reason; #174 generalised the
-`_true_offset` fix to it, so it is now included as a fair comparison arm.
+comparison arm — tracked in #178. [L2Norm](../algorithms/knorm) previously
+carried the same `offset` defect and was excluded for that reason; #174
+generalised the `_true_offset` fix to it, so it is now included as a fair
+comparison arm.
 
 **TTFT / decode throughput of the fused-Metal-kernel path** (#179). The
 kernel wiring above is correctness-tested (bit-for-bit parity against the

--- a/figures/qfilters/ruler_beyond_niah.json
+++ b/figures/qfilters/ruler_beyond_niah.json
@@ -1,0 +1,972 @@
+{
+  "_comment": "RULER task categories outside the NIAH family, for issue #177. Generators follow the constructions in Hsieh et al. (arXiv:2404.06654) but are written in this repo, not RULER's own harness, and run at short contexts. Scores are NOT comparable to published RULER numbers -- they are a relative comparison between cache methods on identical prompts. 'qa_synthetic' is not RULER's QA task (which wraps SQuAD/HotpotQA); it is a synthetic two-hop task and is easier. Expected Attention is not implemented in this repo and is therefore absent as an arm.",
+  "scoring": "Fraction of expected strings present in the greedy-decoded answer (partial credit), matched on normalised whitespace-delimited tokens. Reported per cell as the mean over seeds.",
+  "config": {
+    "budgets": [
+      256,
+      512,
+      1024
+    ],
+    "context_lengths": [
+      1024,
+      2048
+    ],
+    "methods": [
+      "fp16",
+      "qfilters",
+      "snapkv",
+      "streaming_llm",
+      "knorm"
+    ],
+    "tasks": [
+      "vt",
+      "cwe",
+      "fwe",
+      "qa_synthetic"
+    ],
+    "seeds_per_cell": 5,
+    "prefill": "one-shot (worst case for Q-Filters; see module docstring)",
+    "qfilters_recent": "budget // 4",
+    "knorm_recent": "budget // 4"
+  },
+  "models": {
+    "mlx-community/Qwen2.5-7B-Instruct-4bit": {
+      "tasks": {
+        "vt": {
+          "fp16": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.7277777777777777,
+                "2048": 0.6444444444444445
+              },
+              "mean": 0.6861111111111111
+            }
+          },
+          "qfilters": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            }
+          },
+          "snapkv": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.06666666666666667,
+                "2048": 0.0
+              },
+              "mean": 0.03333333333333333
+            }
+          },
+          "streaming_llm": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.2444444444444444,
+                "2048": 0.0
+              },
+              "mean": 0.1222222222222222
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.7777777777777778,
+                "2048": 0.13333333333333333
+              },
+              "mean": 0.45555555555555555
+            }
+          },
+          "knorm": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.06666666666666667,
+                "2048": 0.0
+              },
+              "mean": 0.03333333333333333
+            }
+          },
+          "_fp16_ceiling": 0.6861111111111111,
+          "_discriminative": true
+        },
+        "cwe": {
+          "fp16": {
+            "256": {
+              "per_ctx": {
+                "1024": 1.0,
+                "2048": 1.0
+              },
+              "mean": 1.0
+            }
+          },
+          "qfilters": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.13333333333333333,
+                "2048": 0.04444444444444444
+              },
+              "mean": 0.08888888888888888
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.2444444444444444,
+                "2048": 0.4222222222222222
+              },
+              "mean": 0.3333333333333333
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.7777777777777778,
+                "2048": 0.3333333333333333
+              },
+              "mean": 0.5555555555555556
+            }
+          },
+          "snapkv": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            }
+          },
+          "streaming_llm": {
+            "256": {
+              "per_ctx": {
+                "1024": 1.0,
+                "2048": 1.0
+              },
+              "mean": 1.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 1.0,
+                "2048": 0.86
+              },
+              "mean": 0.9299999999999999
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 1.0,
+                "2048": 1.0
+              },
+              "mean": 1.0
+            }
+          },
+          "knorm": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.27999999999999997,
+                "2048": 0.17777777777777776
+              },
+              "mean": 0.22888888888888886
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.2777777777777778,
+                "2048": 0.4888888888888888
+              },
+              "mean": 0.3833333333333333
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.8666666666666666,
+                "2048": 0.1933333333333333
+              },
+              "mean": 0.5299999999999999
+            }
+          },
+          "_fp16_ceiling": 1.0,
+          "_discriminative": true
+        },
+        "fwe": {
+          "fp16": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.6888888888888889,
+                "2048": 0.6888888888888889
+              },
+              "mean": 0.6888888888888889
+            }
+          },
+          "qfilters": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.4666666666666666,
+                "2048": 0.4
+              },
+              "mean": 0.43333333333333335
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.4,
+                "2048": 0.4
+              },
+              "mean": 0.4
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.4444444444444445,
+                "2048": 0.4666666666666666
+              },
+              "mean": 0.45555555555555555
+            }
+          },
+          "snapkv": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.26666666666666666,
+                "2048": 0.0
+              },
+              "mean": 0.13333333333333333
+            }
+          },
+          "streaming_llm": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.7333333333333333,
+                "2048": 0.8
+              },
+              "mean": 0.7666666666666666
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.72,
+                "2048": 0.5555555555555556
+              },
+              "mean": 0.6377777777777778
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.5777777777777777,
+                "2048": 0.4666666666666666
+              },
+              "mean": 0.5222222222222221
+            }
+          },
+          "knorm": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.5111111111111111,
+                "2048": 0.4666666666666666
+              },
+              "mean": 0.4888888888888888
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.4,
+                "2048": 0.4666666666666666
+              },
+              "mean": 0.43333333333333335
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.5333333333333333,
+                "2048": 0.3333333333333333
+              },
+              "mean": 0.43333333333333335
+            }
+          },
+          "_fp16_ceiling": 0.6888888888888889,
+          "_discriminative": true
+        },
+        "qa_synthetic": {
+          "fp16": {
+            "256": {
+              "per_ctx": {
+                "1024": 1.0,
+                "2048": 0.8
+              },
+              "mean": 0.9
+            }
+          },
+          "qfilters": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            }
+          },
+          "snapkv": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            }
+          },
+          "streaming_llm": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            }
+          },
+          "knorm": {
+            "256": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "512": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            },
+            "1024": {
+              "per_ctx": {
+                "1024": 0.0,
+                "2048": 0.0
+              },
+              "mean": 0.0
+            }
+          },
+          "_fp16_ceiling": 0.9,
+          "_discriminative": true
+        }
+      },
+      "prompt_tokens": {
+        "vt": {
+          "1024": 1177,
+          "2048": 2198
+        },
+        "cwe": {
+          "1024": 1272,
+          "2048": 2310
+        },
+        "fwe": {
+          "1024": 1222,
+          "2048": 2213
+        },
+        "qa_synthetic": {
+          "1024": 1169,
+          "2048": 2208
+        }
+      },
+      "samples": {
+        "vt/fp16/256": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": " X375, X581, and X742. X742 is assigned the value 87319 directly. X375 is assigned the value of X742, and X",
+          "score": 1.0,
+          "pool_size": 6
+        },
+        "vt/qfilters/256": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": number, number, number.0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/qfilters/512": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": " assigned the values 87319, 87319, and 87319. There are exactly 3. The variables are assigned the values 87319, 873",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/qfilters/1024": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": x1, x2, x3. ",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/snapkv/256": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": "\n1.000000000000000000000000000000000000000000000",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/snapkv/512": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": " the\n0100000000000000000000000000000000000000000000",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/snapkv/1024": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": x1, x2, x3. ",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/streaming_llm/256": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": " X386, X540, and X87319. X540 = X386. X87319 = X540. The committee reviewed the quarterly figures and found",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/streaming_llm/512": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": \"VAR X581\", \"VAR X540\", \"VAR X540\" inherits it indirectly from \"X581\" through \"X375\". The archive catalogued several hundred additional documents over",
+          "score": 0.4444444444444444,
+          "pool_size": 6
+        },
+        "vt/streaming_llm/1024": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": VAR X742, VAR X375, VAR X581. ",
+          "score": 1.0,
+          "pool_size": 6
+        },
+        "vt/knorm/256": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": archive, catalogued, and documents. The value 87319 is assigned to these variables directly or indirectly through other variables. There are exactly 3. ",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/knorm/512": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": var1, var2, and var3. All three variables are assigned the value 87319. The variables are assigned the value 87319 directly or indirectly through other variables. There are exactly ",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "vt/knorm/1024": {
+          "expected": [
+            "X742",
+            "X375",
+            "X581"
+          ],
+          "decoded": ": X1, X2, X3. The value 87319 is assigned to X1, X2, X3. There are exactly 3 variables. The answer is: X1, X2, X",
+          "score": 0.0,
+          "pool_size": 6
+        },
+        "cwe/fp16/256": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " opal, juniper, and birch. Each of these words appears 7 times in the list.\nYou are an AI assistant. User will you give you a task. Your goal is to complete the task as faithfully as you can",
+          "score": 1.0,
+          "pool_size": 42
+        },
+        "cwe/qfilters/256": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " \"jack\", \"willow\", and \"jack\". ",
+          "score": 0.0,
+          "pool_size": 42
+        },
+        "cwe/qfilters/512": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " \"juniper\", \"basalt\", and \"opal\".11,12,13,14,15,16,17,18,19,20,21,22",
+          "score": 0.4444444444444444,
+          "pool_size": 42
+        },
+        "cwe/qfilters/1024": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " juniper, opal, and birch.11111111111111111111111111111111111111",
+          "score": 1.0,
+          "pool_size": 42
+        },
+        "cwe/snapkv/256": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " the size of the class isn,1000000000000000000000000000000000000000",
+          "score": 0.0,
+          "pool_size": 42
+        },
+        "cwe/snapkv/512": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " 10000000000000000000000000000000000000000000000",
+          "score": 0.0,
+          "pool_size": 42
+        },
+        "cwe/snapkv/1024": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": ": \"opportunity\", \"innovation\", and \"inspiration\".",
+          "score": 0.0,
+          "pool_size": 42
+        },
+        "cwe/streaming_llm/256": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " \"birch,\" \"juniper,\" and \"opal,\" each appearing 5 times in the list. ",
+          "score": 1.0,
+          "pool_size": 42
+        },
+        "cwe/streaming_llm/512": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " opal, birch, and juniper. To determine the answer, we counted the occurrences of each word in the provided list. The words opal, birch, and juniper appeared the most frequently.",
+          "score": 1.0,
+          "pool_size": 42
+        },
+        "cwe/streaming_llm/1024": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " opal, juniper, and birch. Each of these words appears 9 times in the given list.\n- opal: 9 times\n- juniper: 9 times\n- birch: 9 times",
+          "score": 1.0,
+          "pool_size": 42
+        },
+        "cwe/knorm/256": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " \"birch\", \"willow\", and \"opal\" which all appear twice in the list. ",
+          "score": 0.4444444444444444,
+          "pool_size": 42
+        },
+        "cwe/knorm/512": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " \"juniper\"0 and \"juniper\" are synonyms, meaning \"a type of evergreen shrub or small tree of the genus Juniperus.\" The phrase \"juniper\" is used to describe the same type of plant.",
+          "score": 0.3333333333333333,
+          "pool_size": 42
+        },
+        "cwe/knorm/1024": {
+          "expected": [
+            "birch",
+            "opal",
+            "juniper"
+          ],
+          "decoded": " \"juniper\", \"birch\", and \"opal\" which appear the most often in the list. ",
+          "score": 1.0,
+          "pool_size": 42
+        },
+        "fwe/fp16/256": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " opal, quarry, and opal (again, as it appears the most) and opal (a third time, as it appears the most) and quarry (a second time, as it appears frequently).\nTo determine the three most",
+          "score": 0.6666666666666666,
+          "pool_size": 20
+        },
+        "fwe/qfilters/256": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " the most frequently used words in the given text. The words are the most frequently used words in the given text. The words are the most frequently used words in the given text. The words are the mos",
+          "score": 0.0,
+          "pool_size": 20
+        },
+        "fwe/qfilters/512": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " \"opal\", \"opal\", and \"opal\". These words appear most frequently in the list because they are repeated multiple times. The word \"opal\" appears at least 11 times in the list, which is the",
+          "score": 0.3333333333333333,
+          "pool_size": 20
+        },
+        "fwe/qfilters/1024": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " \"opal\", \"quarry\", and \"opal\". These words appear most frequently in the list above.1111111111111111111111111",
+          "score": 0.6666666666666666,
+          "pool_size": 20
+        },
+        "fwe/snapkv/256": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " 1575. ## Step 1\\n",
+          "score": 0.0,
+          "pool_size": 20
+        },
+        "fwe/snapkv/512": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " p\u00e9rdida, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and, and,",
+          "score": 0.0,
+          "pool_size": 20
+        },
+        "fwe/snapkv/1024": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " \"opal\" and \"opal\" which each appear 4 times. The word \"opalescent\" also appears, but it is not a 3-word phrase. ",
+          "score": 0.3333333333333333,
+          "pool_size": 20
+        },
+        "fwe/streaming_llm/256": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " \"opal\" which appears 21 times, \"quarry\" which appears 9 times, and \"opal\" which also appears 21 times (note that the question might have intended to ask for different words that appear most frequentl",
+          "score": 0.6666666666666666,
+          "pool_size": 20
+        },
+        "fwe/streaming_llm/512": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " opal, quarry, and opal. To determine the three most frequent words in the given list, we need to count the occurrences of each word.",
+          "score": 0.6666666666666666,
+          "pool_size": 20
+        },
+        "fwe/streaming_llm/1024": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " opal, quarry, and ridge. To determine the frequency of each word in the list, count the occurrences of each word:",
+          "score": 0.4444444444444444,
+          "pool_size": 20
+        },
+        "fwe/knorm/256": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " \"opal\", \"opal\", and \"opal\". The word \"opal\" appears to be a variation of \"opals\", and \"opals\" is a variation of \"opal\". Therefore, the word \"opal\" appears most",
+          "score": 0.3333333333333333,
+          "pool_size": 20
+        },
+        "fwe/knorm/512": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " used to create a sentence that is coherent, clear and meaningful. The sentence \"opal\" is used to create a coherent and meaningful sentence. The sentence \"opal, opal, opal, opal, opal, opal,",
+          "score": 0.3333333333333333,
+          "pool_size": 20
+        },
+        "fwe/knorm/1024": {
+          "expected": [
+            "opal",
+            "quarry",
+            "alder"
+          ],
+          "decoded": " \"opal\", \"quarry\", and \"opal\" which appear the most frequently in the list.11111111111111111111111111",
+          "score": 0.6666666666666666,
+          "pool_size": 20
+        },
+        "qa_synthetic/fp16/256": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The instrument installed at Vellamo was a theodolite. Since Rafael Duarte spent the survey season at Vellamo, the theodolite was the instrument installed at his location. ",
+          "score": 1.0,
+          "pool_size": null
+        },
+        "qa_synthetic/qfilters/256": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The guitar was installed at the location where Rafael Duarte spent the survey season.",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/qfilters/512": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The instrument installed at the location where Rafael Duarte spent the survey season was the total station.",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/qfilters/1024": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The instrument installed at Kestrel Bay was a chronometer.",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/snapkv/256": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " \n\\0000000000000000000000000000000000000000000000",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/snapkv/512": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " p\u00e9rdida\n```",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/snapkv/1024": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " Rafael Duarte spent the survey season at the location where the sextant was installed. The sextant is the instrument that was installed at the location where Rafael Duarte spent the survey season. Th",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/streaming_llm/256": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The instrument installed at Kestrel Bay was a chronometer.",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/streaming_llm/512": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The instrument installed at Rafael Duarte's survey location was a barograph. The instrument installed at Rafael Duarte's survey location was a barograph.",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/streaming_llm/1024": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The instrument installed at Thornfield was a barograph, as mentioned in the document where Rafael Duarte spent the survey season at Thornfield.",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/knorm/256": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " Based on the information provided, the instrument that was installed at the location where Rafael Duarte spent the survey season was a seismometer. The seismometer was installed to record earthquake ",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/knorm/512": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " Based on the information provided, the instrument that was installed at the location where Rafael Duarte spent the survey season was a GPS unit. The text mentions that \"Rafael Duarte used a GPS unit ",
+          "score": 0.0,
+          "pool_size": null
+        },
+        "qa_synthetic/knorm/1024": {
+          "expected": [
+            "theodolite"
+          ],
+          "decoded": " The instrument installed at Kestrel Bay was a chronometer.",
+          "score": 0.0,
+          "pool_size": null
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extends Q-Filters evaluation past the needle family to the RULER task
categories issue #177 asks for: variable tracking, common-word extraction,
frequent-word extraction, and question answering.

Qwen2.5-7B-Instruct-4bit, 5 seeds per cell, mean over contexts 1024 and 2048,
every arm at a matched budget. Cells are budget 256 / 512 / 1024.

| Task | fp16 | Q-Filters | SnapKV | StreamingLLM | L2Norm |
|---|---|---|---|---|---|
| VT (chain tracking) | 69% | 0 / 0 / 0 | 0 / 0 / 3 | 0 / 12 / **46** | 0 / 0 / 3 |
| CWE (common words) | 100% | 9 / 33 / **56** | 0 / 0 / 0 | **100 / 93 / 100** | 23 / 38 / 53 |
| FWE (frequent words) | 69% | 43 / 40 / 46 | 0 / 0 / 13 | **77 / 64 / 52** | 49 / 43 / 43 |
| QA (two-hop) | 90% | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 |

All four task rows clear the discriminative gate, so each is a method
comparison rather than a measurement of what the model cannot do.

## Q-Filters does not generalise past needle retrieval

It scores **0% on variable tracking and 0% on two-hop QA at every budget**,
against ceilings of 69% and 90%. Q-Filters performs well on NIAH, where one
distinctive span must survive eviction; it fails here, where a distributed
set must.

This is not an artifact of the harness's one-shot prefill. Chunking the
prefill is the lever that restored coherence in the NIAH harness, and
`qfilters_ruler_prefill_chunking.py` sweeps it at budget 512, ctx 1024,
3 seeds:

| prefill | mean | per-seed |
|---|---|---|
| one-shot | 0.00 | 0.00, 0.00, 0.00 |
| 256-token chunks | 0.00 | 0.00, 0.00, 0.00 |
| 64-token chunks | 0.11 | 0.00, 0.00, 0.33 |

On NIAH, 256-token chunks already produced partial recovery. Here they
produce none. Against a 69% ceiling, 0.11 is still collapse — but it is not
zero and is not reported as zero. Three seeds at one budget supports
"chunking does not rescue it", not a precise chunked score.

## The failures are task-shaped, not method-shaped

This is the more useful finding, and NIAH alone cannot show it. Three task
categories produce three different shapes:

**VT and QA bottom out** because both need a specific *conjunction* to
survive: a whole assignment chain, or both hops of person → place →
instrument. Partial retention earns nothing. The QA samples show the failure
directly — methods return fluent answers naming the wrong distractor pair
(`"at Kestrel Bay was a chronometer"`), having lost one link.

**CWE degrades gracefully and scales with budget** — Q-Filters 9 → 33 → 56%,
L2Norm 23 → 38 → 53%. Partial retention earns partial credit.

**FWE is flat across budgets** for Q-Filters (43 / 40 / 46%) and L2Norm
(49 / 43 / 43%). Zeta-distributed frequencies make the answer depend on
counting the whole list, so a larger arbitrary subset does not improve it.

## SnapKV's zero is real, and was verified before being reported

SnapKV floors on all three aggregation tasks. Because a flat zero can equally
mean a defect, `qfilters_ruler_budget_verification.py` measures retained rows
and RoPE offsets directly after prefill — the `offset` bug #171 fixed for
Q-Filters and #174 for L2Norm would produce exactly this spread for the wrong
reason. At budget 512 on a 1272-token CWE prompt:

| method | `cache.keys.shape` | offset | CWE |
|---|---|---|---|
| snapkv | (1, 4, 512, 128) | 1272 ✓ | 0% |
| qfilters | (1, 4, 512, 128) | 1272 ✓ | 33% |
| knorm | (1, 4, 512, 128) | 1272 ✓ | 38% |
| streaming_llm | (1, 4, 512, 128) | 1272 ✓ | 93% |

Every arm retains exactly 512 of 1272 rows with correct positions, so the
0%–93% spread is entirely *which* tokens each selected. SnapKV's trailing
`snap_obs_window` lands on the question text rather than the word list, so
its proxy queries score the wrong region as important. Having evicted the
list, the model answers from priors: at budget 1024 it returns a fluent,
well-formed and entirely fabricated `"opportunity", "innovation",
"inspiration"` — none of which appear in the prompt. StreamingLLM on the
identical prompt cites the actual counts. This is a proxy-query method
meeting a task whose relevant span is not where its proxy looks, not a
general claim about SnapKV.

*(Note for anyone reading these caches: `tokens_kept` is a cumulative sum
across (B, H), not the current cache size. Read as a size it suggests SnapKV
retains 2236 rows at budget 512; the actual retained count is 512.)*

## Two caveats on the StreamingLLM column

It otherwise looks like a clean win, and both qualifications are in the docs
rather than left for the reader to infer.

Its **100% on CWE is partly a construction artifact**: the word list sits at
the end of the prompt, immediately before the question, which is exactly
where a trailing window keeps tokens.

Its **77% on FWE sits above the 69% fp16 ceiling**. That is seed variance at
the ceiling, not compression beating no compression — discarding 75% of the
cache cannot improve aggregation. It is reported as measured rather than
clipped.

## Three things the harness does that a naive version gets wrong

**Scoring is recall capped by precision.** Under bare recall, a model that
lists fourteen candidate words scores 100% on CWE without having aggregated
anything — observed on Llama-3.2-1B during development. Answers are also
truncated at the first turn boundary, so a model that answers wrongly and
then rambles through more candidates is not credited for whichever one
happens to be right.

**VT keeps each chain's assignments in order.** A global shuffle places
`VAR B = A` before `VAR A = 12345`, forcing backward resolution over a
scrambled graph. That is harder than RULER's VT and scored 0.29 at fp16 on
Qwen2.5-7B — too low a ceiling to tell cache methods apart. Hop count is 3:
measured at fp16, 4 hops scored 0.46 (the model starts inventing variable
names that never appear in the text), 3 scored 0.66, 2 saturated at 1.00.

**Every cell records its fp16 ceiling and a `_discriminative` flag.** Where
fp16 itself is near the floor, the eviction arms measure the model's
inability to do the task rather than the cache's effect on it. This is not
hypothetical: on Llama-3.2-1B CWE, StreamingLLM at budget 256 scored 35%
against a 17% fp16 ceiling, and SnapKV 28% — eviction arms "beating"
uncompressed fp16 is the signature of pure noise, since discarding 75% of the
cache cannot improve aggregation. Without the gate those rows would have
invited exactly the wrong conclusion.

## Scope and limitations

**One model.** The sweep covers Qwen2.5-7B only. Llama-3.2-1B cannot perform
VT, CWE or FWE even at fp16 (ceilings 11% / 16% / 26%), so those cells cannot
evaluate cache methods at that scale — a finding about where the benchmark
applies, not a result. Llama-3.2-3B would have contributed genuine CWE and
FWE cells (ceilings 100% / 81%) and was cut for runtime after the sweep was
narrowed. Budgets and context lengths are both still swept.

**Contexts stop at 2048 tokens**, so this says nothing about behaviour at the
long contexts RULER is designed to stress.

**Not the full RULER suite, and not RULER's harness.** RULER ships 13 tasks;
this covers the four categories outside the needle family, at short contexts,
with generators written here following the constructions in Hsieh et al.
(arXiv:2404.06654). Scores are not comparable to published RULER numbers —
they are a relative comparison between cache methods on identical prompts.

**The QA arm is not RULER's QA task**, which wraps SQuAD and HotpotQA.
Pulling those in would add a dataset dependency to a repo that has none, so
this is synthetic two-hop QA over generated paragraphs. It measures the same
capability shape but is easier, and is labelled `qa_synthetic` everywhere.

**Expected Attention is not an arm** because it is not implemented in this
repo, as #177 notes.

**Budgets evict more than their labels suggest.** `CTX_LENS` sizes the filler
only; instruction, task spans and question add 100–250 tokens, so a nominal
1024-token prompt is 1149–1273 tokens and budget 1024 still evicts. That is
why several methods score worse at the largest budget — the evicted span can
include the trailing question. Actual prefilled token counts are recorded per
task and context so the implied compression ratio is checkable rather than
inferred.

**No timings.** These caches run a per-(B, H) Python loop in
`update_and_fetch`, so wall-clock would measure the implementation, not the
algorithm.

Closes #177
