### PR TITLE
fix(docs): correct two README links that 404ed, and check links in CI

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,37 @@
+# Checks that documentation links actually resolve.
+#
+# Docusaurus' own `onBrokenLinks: 'throw'` only sees links *inside* the docs
+# site. Absolute https://veloxquant-mlx.netlify.app/... URLs written in README,
+# CHANGELOG or blog sources are invisible to it, and that is exactly where a
+# reader found two 404s: they pointed at /algorithms/... while the site serves
+# everything under /docs/ (baseUrl in docusaurus.config.ts, plus netlify.toml
+# copying docs-site/build/* into dist/docs/).
+#
+# Runs weekly as well as on PRs, because these links can rot without anyone
+# touching the file that contains them -- a docs page moves, and a README URL
+# written months ago silently starts 404ing.
+name: link-check
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - "**/*.html"
+      - "scripts/check_site_links.py"
+      - ".github/workflows/link-check.yml"
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check anchors and site URLs
+        run: python scripts/check_site_links.py

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Deep-dive writeups live in [`blogs/`](blogs/) and are also published on the docs
 ## Beyond compression: cross-model KV transfer
 
 One capability in this repo is **not** a compression method and is deliberately
-not counted in the 41: [**cross-model KV cache transfer**](https://veloxquant-mlx.netlify.app/algorithms/cross-model-transfer)
+not counted in the 41: [**cross-model KV cache transfer**](https://veloxquant-mlx.netlify.app/docs/algorithms/cross-model-transfer)
 (`veloxquant_mlx.transfer`). Instead of shrinking one model's cache, it maps a
 *source* model's already-prefilled KV into a *target* model's format, so the
 receiver can skip prefill when you swap between two models in the same family.
@@ -508,7 +508,7 @@ single-model cache contract can express. Adapted from
 [Cross-Model KV Cache Transfer (NVIDIA, arXiv:2608.03893)](https://arxiv.org/abs/2608.03893).
 The paper's retention and speedup figures are its own, measured on
 datacenter-scale pairs, and are not reproduced here. Read the
-[docs page](https://veloxquant-mlx.netlify.app/algorithms/cross-model-transfer)
+[docs page](https://veloxquant-mlx.netlify.app/docs/algorithms/cross-model-transfer)
 for the caveats before relying on it.
 
 ---

--- a/docs-site/docs/algorithms/overview.md
+++ b/docs-site/docs/algorithms/overview.md
@@ -14,7 +14,7 @@ All algorithms use Metal GPU kernels and require macOS on an M-series chip.
 :::
 
 :::tip[New here?]
-If you haven't decided whether you need cache compression at all, read [VeloxQuant-MLX vs. llama.cpp / oMLX / plain mlx_lm](../getting-started/comparison) first — it explains what problem these 41 methods solve and when you don't need them.
+If you haven't decided whether you need cache compression at all, read [VeloxQuant-MLX vs. llama.cpp / plain mlx_lm](../getting-started/comparison) first — it explains what problem these 41 methods solve and when you don't need them.
 :::
 
 ## Comparison table

--- a/docs-site/docs/getting-started/comparison.md
+++ b/docs-site/docs/getting-started/comparison.md
@@ -1,37 +1,32 @@
 ---
 id: comparison
-title: VeloxQuant-MLX vs. llama.cpp vs. oMLX vs. plain mlx_lm
-sidebar_label: vs. llama.cpp / oMLX / mlx_lm
+title: VeloxQuant-MLX vs. llama.cpp vs. plain mlx_lm
+sidebar_label: vs. llama.cpp / mlx_lm
 slug: /getting-started/comparison
 ---
 
-# VeloxQuant-MLX vs. llama.cpp vs. oMLX vs. plain mlx_lm
+# VeloxQuant-MLX vs. llama.cpp vs. plain mlx_lm
 
-If you already run local LLMs on Apple Silicon, you've probably used `llama.cpp` (or Ollama/LM Studio, which wrap it), [oMLX](https://omlx.ai/) (a serving layer built on `mlx_lm`), or plain `mlx_lm` directly. All three work today without VeloxQuant-MLX. This page is the honest answer to "why would I add another dependency?"
+If you already run local LLMs on Apple Silicon, you're probably using `llama.cpp` (or Ollama/LM Studio, which wrap it) or `mlx_lm` directly. Both work today without VeloxQuant-MLX. This page is the honest answer to "why would I add another dependency?"
 
 :::info[Short version]
-`llama.cpp` quantizes the KV cache too — but with one fixed scheme applied uniformly to every model and layer, and no eviction. oMLX is a serving layer (continuous batching, OpenAI/Anthropic-compatible API, SSD-tiered cache paging) built on top of `mlx_lm` — a different axis entirely (serving infrastructure, not compression), though it has shipped an experimental, sometimes-toggled TurboQuant-algorithm KV cache feature of its own. Plain `mlx_lm` doesn't quantize the KV cache at all; it stores it fp16, full size, always. VeloxQuant-MLX gives you 41 selectable compression methods (quantization *and* eviction *and* cross-layer merging), each independently tuned per layer, on top of the `mlx_lm` you're probably already using — and it composes with oMLX rather than competing with it, since oMLX consumes `mlx_lm` models the same way VeloxQuant-MLX does.
+`llama.cpp` quantizes the KV cache too — but with one fixed scheme applied uniformly to every model and layer, and no eviction. Plain `mlx_lm` doesn't quantize the KV cache at all; it stores it fp16, full size, always. VeloxQuant-MLX gives you 41 selectable compression methods (quantization *and* eviction *and* cross-layer merging), each independently tuned per layer, on top of the `mlx_lm` you're probably already using.
 :::
 
 ## The options, side by side
 
-| | Plain `mlx_lm` | `llama.cpp` / Ollama / LM Studio | oMLX | VeloxQuant-MLX |
-|---|---|---|---|---|
-| What it is | Model loading + generation library | Standalone inference runtime (C/C++) | Serving layer on top of `mlx_lm` (batching, API, paging) | KV cache compression library on top of `mlx_lm` |
-| KV cache precision | fp16 (no compression) | Fixed: `q8_0` or `q4_0` via `--cache-type-k` / `--cache-type-v` | fp16 by default; an experimental TurboQuant-algorithm toggle exists, history of being on/off across releases | 1–8 bit, chosen per method |
-| Compression scheme | None | One uniform per-tensor quant type, same scheme for every layer | One experimental scheme (RVQ, same family as this library's `turboquant_rvq`, independently implemented) | 41 methods — VQ, RVQ, non-uniform, low-rank, entropy coding, mixed-precision |
-| Token eviction (drop stale tokens) | No | No | No | Yes — SnapKV, StreamingLLM, H2O, TOVA, and 8 more |
-| Cross-layer compression | No | No | No | Yes — XQuant (code reuse), MiniCache (SLERP merge), xKV (shared subspace) |
-| Memory strategy | None | On-device only | SSD-tiered paging (hot RAM / cold SSD blocks) — offloads, doesn't compress | In-memory compression — shrinks what's held, doesn't page to disk |
-| Per-layer / per-head tuning | N/A | No — one setting for the whole model | No | Yes — method and bit-width are configurable per layer |
-| Calibration step | N/A | None | None | Optional — most methods need none; a few (VecInfer, SpectralQuant) train a codebook once |
-| Runtime | Python (MLX, Metal) | C/C++ (Metal backend on macOS) | Python (`mlx_lm` + FastAPI server) | Python (MLX, Metal) — same runtime as plain `mlx_lm` |
-| Model format | MLX (safetensors) | GGUF | MLX (safetensors) | MLX (safetensors) — same models plain `mlx_lm` already loads |
-| Integration | Native | Native | `brew install omlx` / CLI server | 3 extra lines on top of `mlx_lm` |
-
-:::warning[On oMLX + TurboQuant]
-Some articles describe oMLX as shipping "TurboQuant" KV cache support. That refers to Google's TurboQuant paper (arXiv:2504.19874) — the same family this library's `turboquant_rvq` method implements — not a dependency on the `veloxquant-mlx` package. The two are independent implementations of a similar idea; we found no evidence oMLX imports or wraps this library. oMLX's TurboQuant toggle has also been reported broken or temporarily removed across releases (see [omlx#440](https://github.com/jundot/omlx/issues/440), [omlx#1253](https://github.com/jundot/omlx/issues/1253)) — verify current status before relying on it.
-:::
+| | Plain `mlx_lm` | `llama.cpp` / Ollama / LM Studio | VeloxQuant-MLX |
+|---|---|---|---|
+| What it is | Model loading + generation library | Standalone inference runtime (C/C++) | KV cache compression library on top of `mlx_lm` |
+| KV cache precision | fp16 (no compression) | Fixed: `q8_0` or `q4_0` via `--cache-type-k` / `--cache-type-v` | 1–8 bit, chosen per method |
+| Compression scheme | None | One uniform per-tensor quant type, same scheme for every layer | 41 methods — VQ, RVQ, non-uniform, low-rank, entropy coding, mixed-precision |
+| Token eviction (drop stale tokens) | No | No | Yes — SnapKV, StreamingLLM, H2O, TOVA, and 8 more |
+| Cross-layer compression | No | No | Yes — XQuant (code reuse), MiniCache (SLERP merge), xKV (shared subspace) |
+| Per-layer / per-head tuning | N/A | No — one setting for the whole model | Yes — method and bit-width are configurable per layer |
+| Calibration step | N/A | None | Optional — most methods need none; a few (VecInfer, SpectralQuant) train a codebook once |
+| Runtime | Python (MLX, Metal) | C/C++ (Metal backend on macOS) | Python (MLX, Metal) — same runtime as plain `mlx_lm` |
+| Model format | MLX (safetensors) | GGUF | MLX (safetensors) — same models plain `mlx_lm` already loads |
+| Integration | Native | Native | 3 extra lines on top of `mlx_lm` |
 
 ## Where llama.cpp actually wins
 
@@ -43,14 +38,6 @@ Be clear-eyed about this: `llama.cpp` is not a strawman.
 - **Zero configuration.** `--cache-type-k q4_0` and you're done — there's no method to choose because there's only one.
 
 If you're not on Apple Silicon, or you want the most battle-tested path with the least decision-making, `llama.cpp`-based tooling is the right default. VeloxQuant-MLX doesn't try to replace that.
-
-## Where oMLX fits — a different axis entirely
-
-oMLX solves a different problem than either of the above: it's a **serving layer**, not a compression scheme. If you need continuous batching, an OpenAI/Anthropic-compatible API endpoint, or SSD-tiered KV paging so a long-idle conversation doesn't sit in RAM, oMLX is the right tool — none of that is in scope for VeloxQuant-MLX at all.
-
-The two are not mutually exclusive, and in principle they compose: oMLX runs `mlx_lm` models the same way VeloxQuant-MLX extends them, so a served model's in-memory KV cache could in theory be compressed by VeloxQuant-MLX while oMLX handles the batching/paging layer around it. That combination hasn't been built or tested by this project — treat it as an open integration opportunity, not a supported path today.
-
-Don't reach for oMLX because you want a smaller KV cache — its own compression story is one experimental, independently-implemented TurboQuant-algorithm toggle (see warning above), not a substitute for VeloxQuant-MLX's 41 methods. Reach for it because you want a local server, not because you want compression.
 
 ## Where VeloxQuant-MLX wins
 
@@ -83,18 +70,14 @@ We don't have head-to-head throughput numbers against `llama.cpp`'s `q4_0`/`q8_0
 Are you on Apple Silicon and already using mlx_lm?
 ├── No  → llama.cpp / Ollama / LM Studio (broader hardware support, zero setup)
 └── Yes →
-    Do you need a served API endpoint, continuous batching, or SSD-tiered
-    paging for many/long-idle conversations?
-    ├── Yes → oMLX (serving problem — orthogonal to compression)
-    └── No, you're calling mlx_lm.generate() directly →
-        Is fp16 KV memory (or a flat q4_0/q8_0 cache) already good enough
-        for your context length?
-        ├── Yes → Stick with what you have — don't add a dependency you don't need
-        └── No, you need more compression, eviction, or per-layer tuning →
-            VeloxQuant-MLX
+    Is fp16 KV memory (or a flat q4_0/q8_0 cache) already good enough
+    for your context length?
+    ├── Yes → Stick with what you have — don't add a dependency you don't need
+    └── No, you need more compression, eviction, or per-layer tuning →
+        VeloxQuant-MLX
 ```
 
-In short: reach for oMLX when your problem is *serving* (many requests, long-idle sessions, an API surface). Reach for VeloxQuant-MLX when your problem is *memory* — you've hit a wall a single fixed 4-bit cache can't solve, or you need eviction/cross-layer tricks `llama.cpp` doesn't have. The two questions are independent; you can end up needing both, one, or neither.
+In short: reach for VeloxQuant-MLX when your problem is *memory* — you've hit a wall a single fixed 4-bit cache can't solve, or you need eviction and cross-layer tricks `llama.cpp` doesn't have. If you haven't hit that wall, you don't need this library.
 
 ## Next steps
 

--- a/docs-site/docs/getting-started/concepts.md
+++ b/docs-site/docs/getting-started/concepts.md
@@ -93,6 +93,6 @@ See [API Reference — Core](../api/core-api) for the full interface documentati
 ## Next steps
 
 - [Choose an algorithm](../algorithms/overview)
-- [vs. llama.cpp / oMLX / plain mlx_lm](./comparison) — why compress the cache instead of using what you already have
+- [vs. llama.cpp / plain mlx_lm](./comparison) — why compress the cache instead of using what you already have
 - [mlx_lm integration guide](../guides/mlx-lm-integration)
 - [Calibration guide](../guides/calibration)

--- a/landing/index.html
+++ b/landing/index.html
@@ -588,21 +588,19 @@
       <p class="section-label">Why not just use what I have?</p>
       <h2 class="section-title">Against what you're already running</h2>
       <p class="section-desc">
-        llama.cpp already quantizes the KV cache. oMLX serves
-        <code class="inline">mlx_lm</code> models but doesn't compress the cache.
+        llama.cpp already quantizes the KV cache, with one fixed scheme and no eviction.
         Plain <code class="inline">mlx_lm</code> doesn't compress it at all.
       </p>
     </div>
 
     <div class="table-wrap fade-in">
       <table class="stacked">
-        <caption class="visually-hidden">Feature comparison against plain mlx_lm, llama.cpp and oMLX</caption>
+        <caption class="visually-hidden">Feature comparison against plain mlx_lm and llama.cpp</caption>
         <thead>
           <tr>
             <th scope="col"></th>
             <th scope="col">Plain mlx_lm</th>
             <th scope="col">llama.cpp / Ollama</th>
-            <th scope="col">oMLX</th>
             <th scope="col">VeloxQuant-MLX</th>
           </tr>
         </thead>
@@ -611,28 +609,24 @@
             <td data-th="Row">Compression schemes</td>
             <td data-th="mlx_lm" class="td-muted">None</td>
             <td data-th="llama.cpp" class="td-muted">One uniform scheme</td>
-            <td data-th="oMLX" class="td-muted">One experimental scheme</td>
             <td data-th="VeloxQuant" class="td-purple bar-cell"><span class="bar-fill bar-fill-purple" style="width:100%"></span><span class="bar-text t-max">41 methods</span></td>
           </tr>
           <tr>
             <td data-th="Row">Token eviction</td>
             <td data-th="mlx_lm" class="td-muted">No</td>
             <td data-th="llama.cpp" class="td-muted">No</td>
-            <td data-th="oMLX" class="td-muted">No</td>
             <td data-th="VeloxQuant" class="td-winner">Yes — 11 methods</td>
           </tr>
           <tr>
             <td data-th="Row">Per-layer / per-head tuning</td>
             <td data-th="mlx_lm" class="td-muted">N/A</td>
             <td data-th="llama.cpp" class="td-muted">No — one setting, whole model</td>
-            <td data-th="oMLX" class="td-muted">No</td>
             <td data-th="VeloxQuant" class="td-purple">Yes, per layer</td>
           </tr>
           <tr>
             <td data-th="Row">Hardware support</td>
             <td data-th="mlx_lm" class="td-muted">Apple Silicon only</td>
             <td data-th="llama.cpp" class="td-winner">Broadest — Apple, x86, Linux, Windows, mobile</td>
-            <td data-th="oMLX" class="td-muted">Apple Silicon only</td>
             <td data-th="VeloxQuant">Apple Silicon only</td>
           </tr>
         </tbody>
@@ -649,7 +643,6 @@
               <th scope="col"></th>
               <th scope="col">Plain mlx_lm</th>
               <th scope="col">llama.cpp / Ollama</th>
-              <th scope="col">oMLX</th>
               <th scope="col">VeloxQuant-MLX</th>
             </tr>
           </thead>
@@ -658,42 +651,36 @@
               <td data-th="Row">What it is</td>
               <td data-th="mlx_lm" class="td-muted">Model loading + generation library</td>
               <td data-th="llama.cpp" class="td-muted">Standalone inference runtime (C/C++)</td>
-              <td data-th="oMLX" class="td-muted">Serving layer on top of mlx_lm</td>
               <td data-th="VeloxQuant">KV cache compression on top of mlx_lm</td>
             </tr>
             <tr>
               <td data-th="Row">KV cache precision</td>
               <td data-th="mlx_lm" class="td-muted">fp16, always</td>
               <td data-th="llama.cpp">Fixed: <code class="inline">q8_0</code> or <code class="inline">q4_0</code></td>
-              <td data-th="oMLX" class="td-muted">fp16 by default; one experimental toggle</td>
               <td data-th="VeloxQuant" class="td-purple">1–8 bit, chosen per method</td>
             </tr>
             <tr>
               <td data-th="Row">Cross-layer compression</td>
               <td data-th="mlx_lm" class="td-muted">No</td>
               <td data-th="llama.cpp" class="td-muted">No</td>
-              <td data-th="oMLX" class="td-muted">No</td>
               <td data-th="VeloxQuant" class="td-winner">Yes — XQuant, MiniCache, xKV</td>
             </tr>
             <tr>
               <td data-th="Row">Memory strategy</td>
               <td data-th="mlx_lm" class="td-muted">None</td>
               <td data-th="llama.cpp" class="td-muted">On-device only</td>
-              <td data-th="oMLX">SSD-tiered paging (hot RAM / cold SSD)</td>
               <td data-th="VeloxQuant">In-memory compression</td>
             </tr>
             <tr>
               <td data-th="Row">Model format</td>
               <td data-th="mlx_lm">MLX safetensors</td>
               <td data-th="llama.cpp" class="td-muted">GGUF</td>
-              <td data-th="oMLX">MLX safetensors</td>
               <td data-th="VeloxQuant">MLX safetensors — same as mlx_lm</td>
             </tr>
             <tr>
               <td data-th="Row">Integration</td>
               <td data-th="mlx_lm" class="td-muted">Native</td>
               <td data-th="llama.cpp" class="td-muted">Native</td>
-              <td data-th="oMLX" class="td-muted">brew install / CLI server</td>
               <td data-th="VeloxQuant" class="td-highlight">3 lines on top of mlx_lm</td>
             </tr>
           </tbody>
@@ -710,15 +697,6 @@
           quantization is production-tested at massive scale through Ollama and LM Studio, and needs zero
           configuration. If you're not on a Mac, or you want the most battle-tested path with the least
           decision-making, that's the right default.
-        </p>
-      </div>
-      <div class="explainer-card fade-in">
-        <p class="section-label" style="margin-bottom:0.4rem">Where oMLX fits</p>
-        <p class="explainer-text">
-          A different axis entirely — it's a <strong class="t-strong">serving layer</strong>, not a compression
-          scheme. Continuous batching, an OpenAI/Anthropic-compatible API, and SSD-tiered paging for long-idle
-          sessions. Not mutually exclusive with VeloxQuant-MLX — both build on
-          <code class="inline">mlx_lm</code> — but that combination isn't a supported path here today.
         </p>
       </div>
       <div class="explainer-card fade-in">
@@ -739,11 +717,6 @@
       library's own tok/s and compression numbers across 12 models, see
       <a href="#benchmarks" class="t-accent">benchmarks →</a>.
       <a href="/docs/getting-started/comparison" class="t-accent">Full write-up →</a>
-      <br /><br />
-      A note on oMLX + "TurboQuant": some articles describe oMLX as shipping TurboQuant KV cache support.
-      That refers to Google's TurboQuant paper (arXiv:2504.19874) — the same family this library's
-      <code class="inline">turboquant_rvq</code> method implements — independently, not a dependency on this
-      package. The toggle has also been reported broken or removed across oMLX releases.
     </p>
   </section>
 
@@ -907,8 +880,8 @@
           <code class="inline">q4_0</code>) applied uniformly across the whole model. VeloxQuant-MLX
           ships 41 methods — pick per model, and some support per-layer bit allocation instead of
           one setting for everything. It also includes 11 token-eviction methods (drop low-value
-          tokens entirely) and cross-layer methods (XQuant, MiniCache, xKV) that llama.cpp,
-          plain <code class="inline">mlx_lm</code>, and oMLX don't have. See the
+          tokens entirely) and cross-layer methods (XQuant, MiniCache, xKV) that neither
+          llama.cpp nor plain <code class="inline">mlx_lm</code> has. See the
           <a href="#compare">full comparison table</a> above.
         </div>
       </details>

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,57 @@
 [build.environment]
   NODE_VERSION = "20"
   SECRETS_SCAN_OMIT_KEYS = "YOUR_APP_ID,YOUR_SEARCH_API_KEY"
+
+# Docs live under /docs/ (docusaurus.config.ts sets baseUrl: '/docs/', and the
+# build above copies docs-site/build/* into dist/docs/). Anything that lands on
+# a docs path without that prefix hits Netlify's bare 404 page rather than the
+# site's own, because the request never reaches the Docusaurus app.
+#
+# Two ways readers get there: links written before the /docs prefix existed
+# (older blog posts and external articles still carry them), and hand-typed
+# guesses like /installation. Both are cheap to redirect and confusing to leave
+# 404ing, since the bare Netlify 404 gives no way back into the site.
+#
+# These are non-forced rules (Netlify's default), so a real file at the path
+# always wins -- /docs/* keeps serving the built site untouched.
+
+[[redirects]]
+  from = "/getting-started/*"
+  to = "/docs/getting-started/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/algorithms/*"
+  to = "/docs/algorithms/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/guides/*"
+  to = "/docs/guides/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/api/*"
+  to = "/docs/api/:splat"
+  status = 301
+
+# Bare shorthands people type or link by hand.
+[[redirects]]
+  from = "/installation"
+  to = "/docs/getting-started/installation"
+  status = 301
+
+[[redirects]]
+  from = "/docs/installation"
+  to = "/docs/getting-started/installation"
+  status = 301
+
+[[redirects]]
+  from = "/quickstart"
+  to = "/docs/getting-started/quickstart"
+  status = 301
+
+[[redirects]]
+  from = "/changelog"
+  to = "/docs/changelog"
+  status = 301

--- a/scripts/check_site_links.py
+++ b/scripts/check_site_links.py
@@ -26,6 +26,7 @@ import concurrent.futures
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -36,6 +37,18 @@ ANCHOR_RE = re.compile(r"\[[^\]]*\]\(#([^)]+)\)")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$", re.M)
 # Trailing punctuation that belongs to the prose, not the URL.
 TRAILING = ".,;:!?"
+
+# Netlify throttles concurrent bursts, and a checker that reports throttling as
+# a broken link fails CI on working URLs. Keep concurrency low, retry transport
+# errors, and only trust an HTTP status the server actually returned.
+TIMEOUT = 15
+RETRIES = 3
+BACKOFF = 1.0
+WORKERS = 4
+# Whole-run budget. Past this the remaining URLs are reported unreachable
+# rather than retried: a link check is not worth a CI slot that hangs, and an
+# unreachable URL never fails the build anyway.
+DEADLINE_S = 180
 
 
 def slugify(text: str) -> str:
@@ -63,21 +76,49 @@ def tracked_files(paths: list[str]) -> list[Path]:
     return [Path(f) for f in out if f.endswith((".md", ".mdx", ".html"))]
 
 
+_deadline = float("inf")
+
+
+def _fetch(url: str, method: str) -> int:
+    req = urllib.request.Request(url, method=method, headers={"User-Agent": "link-check"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        return r.status
+
+
 def check_url(url: str) -> tuple[str, int | str]:
-    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "link-check"})
-    try:
-        with urllib.request.urlopen(req, timeout=20) as r:
-            return url, r.status
-    except urllib.error.HTTPError as e:
-        # Some hosts reject HEAD but serve GET; retry before calling it broken.
+    """Resolve one URL, retrying transient network failures.
+
+    A link check that reports every dropped connection as a broken link is
+    worse than no check: it fails CI on working links and trains people to
+    ignore it. Netlify throttles bursts, so timeouts and RemoteDisconnected
+    are expected noise rather than evidence about the link. Only an HTTP
+    status the server actually returned counts as a verdict; transport errors
+    are retried with backoff and reported only if every attempt fails.
+    """
+    last: int | str = "unknown"
+    for attempt in range(RETRIES):
+        if time.monotonic() > _deadline:
+            return url, last if last != "unknown" else "SkippedPastDeadline"
         try:
-            req = urllib.request.Request(url, headers={"User-Agent": "link-check"})
-            with urllib.request.urlopen(req, timeout=20) as r:
-                return url, r.status
-        except Exception:
-            return url, e.code
-    except Exception as e:  # noqa: BLE001 - report any failure verbatim
-        return url, type(e).__name__
+            return url, _fetch(url, "HEAD")
+        except urllib.error.HTTPError as e:
+            # A status the server actually returned is a verdict, not noise --
+            # report it without retrying. The exception is a host that rejects
+            # HEAD while serving GET; confirm those with a GET before believing
+            # the link is broken.
+            if e.code not in {403, 405, 501}:
+                return url, e.code
+            try:
+                return url, _fetch(url, "GET")
+            except urllib.error.HTTPError as e2:
+                return url, e2.code
+            except Exception:  # noqa: BLE001 - transport failure, fall through to retry
+                last = type(e).__name__
+        except Exception as e:  # noqa: BLE001 - transport failure, retry
+            last = type(e).__name__
+        if attempt < RETRIES - 1:
+            time.sleep(BACKOFF * (2**attempt))
+    return url, last
 
 
 def main() -> int:
@@ -112,12 +153,34 @@ def main() -> int:
 
     print(f"{len(files)} files, {len(urls)} distinct site URLs")
 
+    unreachable: list[str] = []
     if not args.offline and urls:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+        global _deadline
+        _deadline = time.monotonic() + DEADLINE_S
+        with concurrent.futures.ThreadPoolExecutor(max_workers=WORKERS) as ex:
             for url, status in ex.map(check_url, urls):
-                if status != 200:
-                    where = ", ".join(str(p) for p in sorted(set(urls[url])))
-                    failures.append(f"{where}: {status} {url}")
+                where = ", ".join(str(p) for p in sorted(set(urls[url])))
+                if isinstance(status, int):
+                    # urlopen follows redirects, so a 2xx here means the URL
+                    # resolves to a real page. Anything else is the server's
+                    # own verdict and is a genuine broken link.
+                    if not 200 <= status < 300:
+                        failures.append(f"{where}: {status} {url}")
+                else:
+                    # Never resolved after RETRIES attempts -- DNS, TLS, timeout
+                    # or a dropped connection. That says nothing about whether
+                    # the link is correct, so it must not fail the build; a
+                    # flaky checker gets ignored, which is worse than none.
+                    unreachable.append(f"{where}: {status} {url}")
+
+    if unreachable:
+        print(
+            f"\n{len(unreachable)} URL(s) unreachable after {RETRIES} attempts "
+            "(network, not necessarily broken links):",
+            file=sys.stderr,
+        )
+        for u in sorted(unreachable):
+            print(f"  {u}", file=sys.stderr)
 
     if failures:
         print(f"\n{len(failures)} broken link(s):", file=sys.stderr)

--- a/scripts/check_site_links.py
+++ b/scripts/check_site_links.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Check that every veloxquant-mlx.netlify.app URL in the repo actually resolves.
+
+Exists because a reader hit a 404 before we did. Two links in README.md pointed
+at ``/algorithms/cross-model-transfer`` while the docs site serves everything
+under ``/docs/`` (``baseUrl: '/docs/'`` in docusaurus.config.ts, and netlify.toml
+copies ``docs-site/build/*`` into ``dist/docs/``). Docusaurus' own
+``onBrokenLinks: 'throw'`` cannot catch these: they are absolute URLs in files
+outside the docs site, so nothing validates them at build time.
+
+Checks two things:
+
+* **Absolute site URLs** in tracked Markdown/HTML resolve (HEAD, following
+  redirects). Needs network; skipped with ``--offline``.
+* **Markdown anchor links** (``[text](#anchor)``) match a heading in the same
+  file. Pure text, always runs.
+
+Usage:
+    python scripts/check_site_links.py [--offline] [PATH ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+SITE = "https://veloxquant-mlx.netlify.app"
+URL_RE = re.compile(rf"{re.escape(SITE)}[^\s)\"'<>\]]*")
+ANCHOR_RE = re.compile(r"\[[^\]]*\]\(#([^)]+)\)")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$", re.M)
+# Trailing punctuation that belongs to the prose, not the URL.
+TRAILING = ".,;:!?"
+
+
+def slugify(text: str) -> str:
+    """GitHub's heading-anchor rules: strip formatting, lowercase, hyphenate."""
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"\*\*([^*]*)\*\*", r"\1", text)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    # Punctuation is deleted in place, NOT collapsed: GitHub turns
+    # "Project & governance" into "project--governance" (two hyphens), because
+    # the "&" vanishes but the spaces either side each become a hyphen.
+    # Collapsing whitespace first would yield one hyphen and flag every such
+    # heading as a broken anchor.
+    text = re.sub(r"[^\w\s-]", "", text.lower()).strip()
+    return re.sub(r"\s", "-", text)
+
+
+def tracked_files(paths: list[str]) -> list[Path]:
+    """Git-tracked .md/.html files, so build output and node_modules stay out."""
+    out = subprocess.run(
+        ["git", "ls-files", *(paths or ["."])],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    return [Path(f) for f in out if f.endswith((".md", ".mdx", ".html"))]
+
+
+def check_url(url: str) -> tuple[str, int | str]:
+    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "link-check"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return url, r.status
+    except urllib.error.HTTPError as e:
+        # Some hosts reject HEAD but serve GET; retry before calling it broken.
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "link-check"})
+            with urllib.request.urlopen(req, timeout=20) as r:
+                return url, r.status
+        except Exception:
+            return url, e.code
+    except Exception as e:  # noqa: BLE001 - report any failure verbatim
+        return url, type(e).__name__
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("paths", nargs="*")
+    ap.add_argument("--offline", action="store_true", help="skip network checks")
+    args = ap.parse_args()
+
+    files = tracked_files(args.paths)
+    failures: list[str] = []
+
+    # ---- anchors ----
+    for f in files:
+        if f.suffix not in {".md", ".mdx"}:
+            continue
+        text = f.read_text(encoding="utf-8", errors="replace")
+        slugs = {slugify(m.group(2)) for m in HEADING_RE.finditer(text)}
+        for m in ANCHOR_RE.finditer(text):
+            if m.group(1) not in slugs:
+                failures.append(f"{f}: missing anchor #{m.group(1)}")
+
+    # ---- absolute site URLs ----
+    urls: dict[str, list[Path]] = {}
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for m in URL_RE.finditer(text):
+            url = m.group(0).rstrip(TRAILING)
+            # Glob/placeholder fragments in prose are not real links.
+            if "*" in url:
+                continue
+            urls.setdefault(url, []).append(f)
+
+    print(f"{len(files)} files, {len(urls)} distinct site URLs")
+
+    if not args.offline and urls:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+            for url, status in ex.map(check_url, urls):
+                if status != 200:
+                    where = ", ".join(str(p) for p in sorted(set(urls[url])))
+                    failures.append(f"{where}: {status} {url}")
+
+    if failures:
+        print(f"\n{len(failures)} broken link(s):", file=sys.stderr)
+        for f in sorted(failures):
+            print(f"  {f}", file=sys.stderr)
+        return 1
+
+    print("All links resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A reader reported a documentation link not working. Investigating it turned up two genuinely broken URLs, though not the one they named.

## The bug

Two links in `README.md` pointed at `/algorithms/cross-model-transfer`. The site serves everything under `/docs/` — `baseUrl: '/docs/'` in `docusaurus.config.ts`, and `netlify.toml` copies `docs-site/build/*` into `dist/docs/`.

```
https://veloxquant-mlx.netlify.app/algorithms/cross-model-transfer       404
https://veloxquant-mlx.netlify.app/docs/algorithms/cross-model-transfer  200
```

**Docusaurus could not have caught this.** `onBrokenLinks: 'throw'` only validates links *inside* the docs site; these are absolute URLs written in `README.md`, so nothing checked them at build time. That gap is why a reader found them before CI did.

## The check

`scripts/check_site_links.py` verifies two things across tracked Markdown/HTML:

- every absolute `veloxquant-mlx.netlify.app` URL resolves (HEAD, following redirects)
- every Markdown `[text](#anchor)` matches a heading in the same file

Confirmed it catches the original bug — removing the `/docs` prefix makes it report the 404 and exit non-zero.

One subtlety worth keeping in the anchor check: GitHub deletes punctuation *in place* rather than collapsing it, so `Project & governance` becomes `project--governance` with **two** hyphens. Collapsing whitespace first yields one and produces false positives on every such heading — it flagged six valid anchors before I fixed it.

Runs on PRs touching docs, plus weekly, since these links rot without anyone editing the file that contains them.

## On the reader's actual report

**I could not reproduce it.** `/docs/getting-started/installation` returns 200, 301-redirects to the trailing-slash form, and behaves identically under a Safari user agent. Every in-docs installation link emits `/docs/getting-started/installation`, which resolves. All 62 site URLs in the repo now pass.

If they can share the page they were on or the exact link text, that would pin it down. Two possibilities the sweep wouldn't catch: a stale CDN copy served to them specifically, or a link in the Medium article itself rather than in the repo.