### PR TITLE
Q-Filters eviction semantics (#183): pin fallback chunk-dependence, add H2O/TOVA benchmark arms

### DIFF
--- a/benchmark_scripts/qfilters_real_model_perplexity.py
+++ b/benchmark_scripts/qfilters_real_model_perplexity.py
@@ -36,8 +36,10 @@ import numpy as np
 from mlx_lm.models.cache import KVCache
 
 from veloxquant_mlx.cache.base import KVCacheConfig
+from veloxquant_mlx.cache.h2o_cache import H2OKVCache
 from veloxquant_mlx.cache.knorm_cache import L2NormKVCache
 from veloxquant_mlx.cache.qfilters_cache import QFiltersKVCache
+from veloxquant_mlx.cache.tova_cache import TOVAKVCache
 from veloxquant_mlx.quantizers.qfilters_calibration import (
     average_gqa_filters,
     collect_query_activations,
@@ -264,12 +266,65 @@ def main() -> None:
             ],
             "L2Norm (key-norm eviction)",
         )
+        # H2O and TOVA join as comparison arms only now that their
+        # post-eviction RoPE handling is verified (#183): both report
+        # ``cache.offset`` as the true absolute token position rather than the
+        # retained-row count, so ``mlx_lm``'s rope(..., offset=cache.offset)
+        # stays correct after eviction. H2O additionally re-rotates survivors
+        # to a gap-free layout (it renumbers positions); TOVA, like Q-Filters,
+        # preserves original positions and needs no re-rotation. Without that
+        # verification these arms would be measuring position drift rather
+        # than eviction quality, and Q-Filters would look good for the wrong
+        # reason.
+        #
+        # Neither takes a `recent` window: H2O's accumulated-attention score
+        # and TOVA's last-query attention both carry intrinsic recency bias,
+        # so unlike pure projection ranking they do not need the trailing
+        # guard to stay coherent. Passing budget/n_sink alone is the faithful
+        # configuration for each, not an oversight.
+        h2o = perplexity(
+            model,
+            ids,
+            [
+                H2OKVCache(
+                    KVCacheConfig(
+                        method="h2o",
+                        head_dim=head_dim,
+                        h2o_budget=budget,
+                        h2o_n_sink=4,
+                        # Must match the model's own RoPE base or the
+                        # de-rotate/re-rotate pass will not cancel.
+                        h2o_rope_base=float(getattr(model.args, "rope_theta", 10000.0)),
+                    )
+                )
+                for _ in range(n_layers)
+            ],
+            "H2O (accumulated attention)",
+        )
+        tova = perplexity(
+            model,
+            ids,
+            [
+                TOVAKVCache(
+                    KVCacheConfig(
+                        method="tova",
+                        head_dim=head_dim,
+                        tova_budget=budget,
+                        tova_n_sink=4,
+                    )
+                )
+                for _ in range(n_layers)
+            ],
+            "TOVA (last-query attention)",
+        )
         gap = fb - base
         closed = 100 * (1 - (cal - base) / gap) if abs(gap) > 1e-9 else float("nan")
         print(
             f"    vs fp16 {base:.3f}:  calibrated {100 * (cal - base) / base:+7.1f}%   "
             f"fallback {100 * (fb - base) / base:+7.1f}%   "
             f"L2Norm {100 * (kn - base) / base:+7.1f}%   "
+            f"H2O {100 * (h2o - base) / base:+7.1f}%   "
+            f"TOVA {100 * (tova - base) / base:+7.1f}%   "
             f"(calibrated closes {closed:.0f}% of the fallback's gap)"
         )
 

--- a/docs-site/docs/algorithms/qfilters.md
+++ b/docs-site/docs/algorithms/qfilters.md
@@ -431,6 +431,82 @@ far less, so this does not contradict it — but if you use Q-Filters for
 open-ended generation, set `qfilters_recent` (≈ budget/4 worked best here).
 It remains off by default to keep the default paper-faithful.
 
+#### Comparison arms and the RoPE precondition (#183)
+
+An eviction cache may only join these comparisons once its post-eviction RoPE
+handling is verified. `mlx_lm` rotates both the query and the incoming key at
+`offset=cache.offset` *before* `update_and_fetch` runs, so a cache that reports
+the retained-row count instead of the true token position stalls its offset at
+`budget` the moment eviction begins, and the drift grows without bound. An arm
+in that state measures position drift rather than eviction quality — which
+would make whichever method is correct look good for the wrong reason.
+
+All four arms report the true absolute position, verified at zero drift through
+a 200-token prefill plus 120 decode steps at budget 64, and pinned as a shared
+contract in `tests/cache/test_eviction_rope_contract.py`. They reach it two
+different ways, both valid:
+
+| arm | positions after eviction | needs re-rotation | recency guard |
+|---|---|---|---|
+| Q-Filters | preserved (gapped) | no | `qfilters_recent` (default 0) |
+| TOVA | preserved (gapped) | no | none — intrinsic |
+| L2Norm | preserved (gapped) | no | `knorm_recent` (default 0) |
+| H2O | **renumbered** (gap-free) | **yes** | `h2o_grace` (default 16) |
+
+**Intentional differences from the original algorithms.** H2O renumbers
+survivors to a contiguous layout, so it de-rotates and re-rotates kept keys
+via `rope_remap_positions`; `h2o_rope_base` must match the model's own RoPE
+base or that correction will not cancel. Q-Filters, TOVA and L2Norm leave
+positions untouched, so surviving keys keep the rotation they were stored
+with and non-contiguous gaps are expected — neither the Q-Filters nor the
+TOVA paper addresses renumbering.
+
+H2O and TOVA are run at budget and `n_sink` only, with **no** trailing-window
+override. That is faithful rather than an oversight: H2O's accumulated-attention
+score and TOVA's last-query attention both carry intrinsic recency bias, so
+unlike pure projection ranking they do not need the trailing guard that
+Q-Filters requires to stay coherent (see `qfilters_recent` above).
+
+#### Eviction semantics: one-shot vs incremental (#172, #183)
+
+`qfilters_update` absorbs a whole block of `S` tokens and evicts down to budget
+**once**, rather than evicting after every sub-block. On the calibrated path this
+is not an approximation of incremental eviction — it is the *same function*. A
+token is scored once against a filter frozen before token 0, and its score never
+changes while cached, so top-k under a fixed key is order-invariant. Feeding a
+prompt as one block, in 256-token chunks, or one token at a time retains
+bit-identical K/V and the same `offset`
+(`test_calibrated_kept_set_is_invariant_to_prefill_chunk_size`).
+
+Incremental eviction is therefore pure overhead on that path. Prefilling 4096
+tokens, 8 heads, D=128, budget 512:
+
+| prefill chunk | eviction calls | prefill time |
+|---|---|---|
+| one-shot (4096) | 1 | **1.8 ms** |
+| 1024 | 4 | 3.4 ms |
+| 256 | 16 | 7.9 ms |
+| 64 | 64 | 23.7 ms |
+| 16 | 256 | 65.8 ms |
+
+Up to **36× slower for identical output**. One-shot stays the default; there is
+no cache-pressure or adaptive variant to add, because there is no quality
+difference to trade against.
+
+The **key-SVD fallback** is the genuine exception, and its path-dependence is a
+property of the *estimator*, not of the eviction step: the direction is frozen
+from whichever chunk first crosses `qfilters_calib_tokens`, so different
+chunkings freeze different directions (cosine to the one-shot direction measured
+at +0.65 / +0.43 / +0.56 for chunks of 512 / 256 / 64) and retain different
+token sets. The budget bound and `offset` hold at every chunk size regardless
+(`test_fallback_respects_budget_at_every_prefill_chunk_size`). Chunked prefill
+on the fallback is not more correct than one-shot — just different. If you need
+chunk-invariance, supply calibrated filters.
+
+Chunk size was originally suspected as the cause of degenerate `"the the the
+the"` generation. It is not: the retained set is chunk-invariant on the
+calibrated path. The actual cause is `qfilters_recent=0` — see above.
+
 #### RoPE positions had to be fixed first (#171)
 
 `mlx_lm` rotates both the query and the incoming key at `offset=cache.offset`

--- a/veloxquant_mlx/tests/cache/test_eviction_rope_contract.py
+++ b/veloxquant_mlx/tests/cache/test_eviction_rope_contract.py
@@ -1,0 +1,128 @@
+"""Cross-cache RoPE contract for eviction caches (#171, #174, #183).
+
+``mlx_lm``'s attention module rotates BOTH the query and the incoming key with
+``self.rope(x, offset=cache.offset)`` *before* ``update_and_fetch`` is called.
+An eviction cache therefore cannot correct that rotation after the fact: the
+only way it can be right is for ``cache.offset`` to equal the true absolute
+token position at all times, never the number of rows the cache happens to
+still be holding.
+
+The base ``mlx_lm`` ``KVCache`` sets ``offset`` to the stored row count, which
+is the same number right up until the first eviction and wrong forever after —
+once ``n_kept`` pins at the budget, ``offset`` stops advancing while the true
+position keeps climbing, and the drift grows without bound.
+
+Each cache already tests this for itself. This module pins it as a *shared*
+contract across every eviction cache used as a benchmark comparison arm, so a
+cache cannot be added to those comparisons while silently drifting. That
+matters for benchmark integrity specifically: an arm with a broken offset
+measures position drift rather than eviction quality, which would make
+whichever method is correct look good for the wrong reason (#183).
+
+How each cache satisfies the contract differs, and both ways are valid:
+  - Q-Filters / TOVA / L2Norm PRESERVE original positions (eviction drops rows
+    but never renumbers), so stored keys already carry the right rotation and
+    reporting the true offset is sufficient.
+  - H2O RENUMBERS to a gap-free layout, so it additionally de-rotates and
+    re-rotates survivors; ``h2o_rope_base`` must match the model's RoPE base
+    for that correction to cancel.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from veloxquant_mlx.cache.base import KVCacheConfig, KVCacheFactory
+
+# Large enough that every arm has evictable room: H2O protects `h2o_grace`
+# (default 16) trailing rows on top of its sinks, and a budget that leaves
+# nothing evictable is rejected at construction.
+BUDGET = 64
+HEAD_DIM = 32
+
+# (id, config kwargs) — every eviction cache used as a Q-Filters benchmark arm.
+ARMS = [
+    ("qfilters", dict(method="qfilters", qfilters_budget=BUDGET, qfilters_n_sink=4)),
+    ("h2o", dict(method="h2o", h2o_budget=BUDGET, h2o_n_sink=4)),
+    ("tova", dict(method="tova", tova_budget=BUDGET, tova_n_sink=4)),
+    ("knorm", dict(method="knorm", knorm_budget=BUDGET, knorm_n_sink=4)),
+]
+
+
+def _kv(S, H=2, D=HEAD_DIM, seed=0):
+    rng = np.random.default_rng(seed)
+    return (
+        mx.array(rng.standard_normal((1, H, S, D)).astype(np.float16)),
+        mx.array(rng.standard_normal((1, H, S, D)).astype(np.float16)),
+    )
+
+
+def _make(cfg_kwargs):
+    return KVCacheFactory.create(KVCacheConfig(head_dim=HEAD_DIM, **cfg_kwargs))
+
+
+@pytest.mark.parametrize("name,cfg", ARMS, ids=[a[0] for a in ARMS])
+def test_offset_never_drifts_from_true_position_during_decode(name, cfg) -> None:
+    """Token-by-token decode well past the budget: offset == true position."""
+    cache = _make(cfg)
+    n_steps = 6 * BUDGET
+    for t in range(n_steps):
+        k, v = _kv(S=1, seed=t)
+        cache.update_and_fetch(k, v)
+        assert cache.offset == t + 1, (
+            f"{name}: offset {cache.offset} != true position {t + 1} at step {t} — "
+            "RoPE would rotate this token at the wrong position"
+        )
+
+
+@pytest.mark.parametrize("name,cfg", ARMS, ids=[a[0] for a in ARMS])
+def test_offset_tracks_true_position_across_prefill_then_decode(name, cfg) -> None:
+    """A long prefill (forcing eviction) followed by decode keeps offset exact.
+
+    This is the shape the benchmarks actually run, and the case where a
+    row-count offset diverges fastest: after prefill the cache holds ``budget``
+    rows but has consumed ``S_pre`` positions.
+    """
+    S_pre, n_dec = 8 * BUDGET, 3 * BUDGET
+    cache = _make(cfg)
+
+    k, v = _kv(S=S_pre, seed=99)
+    k_out, _ = cache.update_and_fetch(k, v)
+    mx.eval(k_out)
+
+    assert cache.offset == S_pre, f"{name}: offset stalled at {cache.offset} after prefill"
+    # Eviction genuinely happened — otherwise this test proves nothing.
+    assert k_out.shape[2] <= BUDGET < S_pre
+
+    for t in range(n_dec):
+        k1, v1 = _kv(S=1, seed=1000 + t)
+        cache.update_and_fetch(k1, v1)
+        assert cache.offset == S_pre + t + 1, (
+            f"{name}: offset {cache.offset} != true position {S_pre + t + 1} "
+            f"{t + 1} tokens into decode"
+        )
+
+
+@pytest.mark.parametrize("name,cfg", ARMS, ids=[a[0] for a in ARMS])
+def test_offset_is_independent_of_retained_row_count(name, cfg) -> None:
+    """The invariant that fails first: offset must decouple from ``n_kept``.
+
+    Two caches fed the same number of positions at different budgets retain
+    different row counts but must report the *same* offset. A cache reporting
+    a row count would report the two budgets differently.
+    """
+    S = 8 * BUDGET
+    small = _make(cfg)
+    wide = dict(cfg)
+    wide[next(kk for kk in wide if kk.endswith("_budget"))] = BUDGET * 4
+    large = _make(wide)
+
+    k, v = _kv(S=S, seed=7)
+    ks, _ = small.update_and_fetch(k, v)
+    kl, _ = large.update_and_fetch(k, v)
+    mx.eval(ks, kl)
+
+    assert ks.shape[2] != kl.shape[2], f"{name}: budgets did not change the retained count"
+    assert small.offset == large.offset == S

--- a/veloxquant_mlx/tests/cache/test_qfilters_cache.py
+++ b/veloxquant_mlx/tests/cache/test_qfilters_cache.py
@@ -406,6 +406,79 @@ def test_recent_window_protects_prompt_tail_at_every_chunk_size(chunk: int) -> N
     assert np.array_equal(np.array(k_out)[:, :, -recent:], tail_expected)
 
 
+@pytest.mark.parametrize("chunk", [1073, 512, 256, 64, 16, 1])
+def test_fallback_respects_budget_at_every_prefill_chunk_size(chunk: int) -> None:
+    """The key-SVD fallback is path-dependent, but never over budget (#183).
+
+    Unlike the calibrated path, the fallback estimates its direction from
+    whichever chunk first crosses ``calib_tokens``, so the *kept set* legitimately
+    varies with chunking — that is documented behaviour, not a bug. What must
+    hold at every chunk size is the safety property the investigation in #183
+    asked about: once the filter freezes, the cache is pinned at ``budget`` and
+    the reported offset is the true token position, so RoPE cannot drift.
+    """
+    B, H, S, D = 1, 2, 1073, 16
+    cfg = KVCacheConfig(
+        method="qfilters",
+        head_dim=D,
+        qfilters_budget=128,
+        qfilters_n_sink=4,
+        qfilters_calib_tokens=128,
+    )
+    k, v = _kv(B, H, S, D, seed=11)
+
+    cache = QFiltersKVCache(cfg)
+    k_out = None
+    for i in range(0, S, chunk):
+        k_out, _ = cache.update_and_fetch(k[:, :, i : i + chunk], v[:, :, i : i + chunk])
+    mx.eval(k_out)
+
+    assert k_out.shape[2] == 128
+    assert cache.offset == S
+    # A frozen, unit-norm direction — whatever chunk froze it.
+    d = np.array(cache.states[0].filter_dir)
+    assert abs(float(np.linalg.norm(d)) - 1.0) < 1e-4
+
+
+def test_fallback_kept_set_is_chunk_dependent_calibrated_is_not() -> None:
+    """The documented asymmetry between the two filter sources (#183).
+
+    #172 established that the calibrated path is chunk-invariant. The mirror
+    claim — that the fallback is *not* — was documented but never pinned. If a
+    future change accidentally made the fallback path-independent (or the
+    calibrated path path-dependent), the module docstrings would silently
+    become wrong; this fails instead.
+    """
+    B, H, S, D = 1, 2, 1073, 16
+    cfg = KVCacheConfig(
+        method="qfilters",
+        head_dim=D,
+        qfilters_budget=128,
+        qfilters_n_sink=4,
+        qfilters_calib_tokens=128,
+    )
+    k, v = _kv(B, H, S, D, seed=12)
+
+    def run(filters, chunk):
+        cache = QFiltersKVCache(cfg, filters=filters)
+        out = None
+        for i in range(0, S, chunk):
+            out, _ = cache.update_and_fetch(k[:, :, i : i + chunk], v[:, :, i : i + chunk])
+        mx.eval(out)
+        return np.array(out)
+
+    # Calibrated: bit-identical one-shot vs chunked.
+    filters = _calibrated_filters(H, D, seed=13)
+    assert np.array_equal(run(filters, S), run(filters, 256))
+
+    # Fallback: the frozen direction depends on which chunk crossed
+    # calib_tokens, so the kept set differs. Both stay at budget.
+    fb_one_shot = run(None, S)
+    fb_chunked = run(None, 256)
+    assert fb_one_shot.shape[2] == fb_chunked.shape[2] == 128
+    assert not np.array_equal(fb_one_shot, fb_chunked)
+
+
 def _reference_evict(k, v, filters, budget, n_sink, recent, sign):
     """Per-(b, h) numpy oracle for the vectorized path (#173).
 


### PR DESCRIPTION
Closes #183.

## Summary

#183 asks two things: whether Q-Filters should evict **incrementally** during large prefills, and whether **H2O/TOVA** can join the benchmark comparison once their post-eviction RoPE handling is verified.

The short answers are **no algorithm change is warranted**, and **yes, they were already correct** — but neither was previously pinned by a test, and the benchmark arms were genuinely missing. This PR closes both gaps.

## 1. Incremental eviction: the stated root cause does not hold

#183 supposes one-shot eviction "makes a much more aggressive eviction decision than several smaller prefill steps." On the calibrated path the two are **the same function**. A token is scored once against a filter frozen before token 0, and its score never changes while cached, so top-k under a fixed key is order-invariant. #172 established this and `test_calibrated_kept_set_is_invariant_to_prefill_chunk_size` already pins bit-identical output at chunks of 1073/512/256/64/16/1.

Incremental eviction is therefore pure overhead. Measured (4096 tokens, 8 heads, D=128, budget 512):

| prefill chunk | eviction calls | prefill time |
|---|---|---|
| one-shot | 1 | **1.8 ms** |
| 256 | 16 | 7.9 ms |
| 16 | 256 | 65.8 ms |

Up to **36x slower for bit-identical output**. This also rules out the adaptive/cache-pressure variants #183 proposes — there is no quality difference to trade against.

The actual cause of the degenerate `"the the the the"` output is `qfilters_recent=0`, not chunking. Small chunks *masked* the missing-recency problem rather than avoiding a bad eviction decision.

## 2. What was untested: the fallback's path-dependence

The key-SVD fallback is documented in three docstrings as path-**dependent**, but nothing tested it — so a change making it path-independent would silently falsify the docs. Measured (1073 tokens, budget 128): the frozen direction's cosine to the one-shot direction is +0.65 / +0.43 / +0.56 at chunks of 512 / 256 / 64, with different retained sets. Budget and offset hold at every chunk size.

Two new tests pin this. Mutation-checked: forcing the fallback to freeze on the full block fails the asymmetry test.

## 3. H2O/TOVA: audited clean, now added as arms

Both already track the true absolute position. Verified empirically rather than from docstrings — 200-token prefill plus 120 decode steps at budget 64:

```
h2o        after decode  true_pos=320  cache.offset=320  n_kept=64  drift=+0
tova       after decode  true_pos=320  cache.offset=320  n_kept=64  drift=+0
qfilters   after decode  true_pos=320  cache.offset=320  n_kept=64  drift=+0
```

`n_kept` pins at 64 while `offset` climbs to 320 — exactly the decoupling that breaks when a cache reports a row count. Nothing to reproduce, nothing to fix.

They satisfy the invariant **two different ways**, and the issue's framing assumes one:

| arm | positions after eviction | needs re-rotation | recency guard |
|---|---|---|---|
| Q-Filters / TOVA / L2Norm | preserved (gapped) | no | `recent` knob, default 0 |
| **H2O** | **renumbered (gap-free)** | **yes** | `h2o_grace`, default 16 |

H2O re-rotates survivors via `rope_remap_positions`, so **`h2o_rope_base` must match the model's RoPE base** or the correction will not cancel. That is a live footgun, so the benchmark wires it from `model.args.rope_theta` rather than leaving the `10000.0` default — silently wrong on Llama-3.

## Judgment calls worth reviewing

- **H2O/TOVA run at budget + `n_sink` only, with no trailing-window override.** This is faithful, not an oversight: their scoring carries intrinsic recency bias, so unlike pure projection ranking they do not need the guard `qfilters_recent` provides. Forcing one on them to "match" Q-Filters would be the *unfair* comparison.
- **No algorithm change.** If you would rather have an incremental mode built anyway as an explicitly-documented ablation arm, say so and I will add it behind a flag.

## Not included

- **Perplexity/generation numbers and the consolidated comparison table** need a model download. The harness is wired and both arms construct correctly; this is one `python benchmark_scripts/qfilters_real_model_perplexity.py <model>` away.
- **The RULER/NIAH scripts** route through a separate `make_caches` registry and are left untouched — worth doing if H2O/TOVA are wanted in the retrieval comparisons too.

## Testing

- `test_eviction_rope_contract.py` — 12 new tests over qfilters/h2o/tova/knorm pinning the offset invariant as a **shared** contract, so a cache cannot join these comparisons while silently drifting. Per-cache tests already existed; the cross-cache contract did not. Mutation-checked: reverting TOVA's offset fix fails exactly its three arms and nothing else.
- Full cache + h2o/tova/qfilters quantizer suites: **1004 passed, 1 skipped**.
- `ruff check` and `ruff format --check` clean on all touched files.

## Note on related issues

#183 substantially restates the closed #172. The `qfilters_recent` default remains **0** for paper-faithfulness, which is what actually produces the degenerate output people keep re-reporting as a chunking bug. #172 proposed `budget//8`; two issues later that may be worth revisiting, but it is a behavioural default change so I have left it alone and would open it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)