### PR TITLE
chore(landing): add Plausible analytics

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -57,6 +57,13 @@
       } catch (e) { /* storage unavailable */ }
     })();
   </script>
+
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-LnzxjiMH3B7SjXGL3VIDm.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
 

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -23,6 +23,13 @@
       } catch (e) { /* storage unavailable */ }
     })();
   </script>
+
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-LnzxjiMH3B7SjXGL3VIDm.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
Adds the privacy-friendly Plausible tracking snippet to index.html and playground.html.

## Summary

Brief description of what this PR changes and why.

## Related issue

Closes #

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
- [ ] New or updated unit tests cover the change
- [ ] Docs updated if user-facing behavior changed

## Number claims (if any)

Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.

- Script path:
- Results path:
- Metric type (check one):
  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
  - [ ] Full-KV accounting (keys + values + residual windows)
  - [ ] MLX peak memory (`mx.get_peak_memory`)
  - [ ] OS RSS / long-context OOM comparison
  - [ ] Throughput (tok/s)

Do not describe accounting ratios as resident RAM savings unless resident memory was measured.
