### PR TITLE
Redesign landing page: calmer hero, dedicated benchmarks page, real logo

### DIFF
--- a/landing/assets/logo.svg
+++ b/landing/assets/logo.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <!-- Full-bleed square: macOS (Sequoia+) applies its own squircle mask
+         and shadow on top of the provided icon, so the artwork itself must
+         fill the entire canvas edge-to-edge rather than pre-rounding. -->
+
+    <!-- Background: near-black to navy radial, matching landing page favicon/brand -->
+    <radialGradient id="bg" cx="35%" cy="18%" r="95%">
+      <stop offset="0%" stop-color="#1c1c34"/>
+      <stop offset="55%" stop-color="#100f1c"/>
+      <stop offset="100%" stop-color="#08080f"/>
+    </radialGradient>
+
+    <!-- Subtle top sheen for depth, like native macOS icons -->
+    <linearGradient id="sheen" x1="0%" y1="0%" x2="0%" y2="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.10"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+
+    <!-- Bolt gradient: cyan accent, brighter at the tip -->
+    <linearGradient id="bolt" x1="20%" y1="0%" x2="85%" y2="100%">
+      <stop offset="0%" stop-color="#7ef2ff"/>
+      <stop offset="45%" stop-color="#00d4ff"/>
+      <stop offset="100%" stop-color="#00a8d4"/>
+    </linearGradient>
+
+    <!-- Purple secondary glow ring, echoing the brand's secondary accent color -->
+    <radialGradient id="ringGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="70%" stop-color="#7c3aed" stop-opacity="0"/>
+      <stop offset="92%" stop-color="#7c3aed" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/>
+    </radialGradient>
+
+    <filter id="boltShadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#00d4ff" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <g>
+    <rect width="1024" height="1024" fill="url(#bg)"/>
+
+    <!-- Precision ring: represents quantization grid / compressed lattice -->
+    <circle cx="512" cy="512" r="420" fill="url(#ringGlow)"/>
+    <circle cx="512" cy="512" r="360" fill="none" stroke="#2a2a48" stroke-width="2" opacity="0.55"/>
+    <circle cx="512" cy="512" r="300" fill="none" stroke="#2a2a48" stroke-width="1.5" opacity="0.4"/>
+
+    <!-- Corner tick marks, echoing a measurement/precision motif -->
+    <g stroke="#3a3a5c" stroke-width="3" opacity="0.5" stroke-linecap="round">
+      <line x1="512" y1="150" x2="512" y2="184"/>
+      <line x1="512" y1="840" x2="512" y2="874"/>
+      <line x1="150" y1="512" x2="184" y2="512"/>
+      <line x1="840" y1="512" x2="874" y2="512"/>
+    </g>
+
+    <!-- Lightning bolt — VeloxQuant's established compression/speed mark,
+         scaled up from the existing favicon for full icon presence -->
+    <polygon points="586,236 358,560 486,560 462,800 742,462 598,462"
+             fill="url(#bolt)" filter="url(#boltShadow)"/>
+    <polygon points="586,236 358,560 486,560 462,800 742,462 598,462"
+             fill="none" stroke="#e8fdff" stroke-width="3" stroke-opacity="0.5" stroke-linejoin="round"/>
+
+    <!-- Top sheen -->
+    <rect width="1024" height="1024" fill="url(#sheen)"/>
+  </g>
+</svg>

--- a/landing/assets/main.js
+++ b/landing/assets/main.js
@@ -2,20 +2,12 @@
 // VeloxQuant-MLX landing page behavior
 // Zero-build static JS — served as-is by Netlify (cp -r landing/* dist/)
 //
-// The atmospheric layer (matrix rain, aurora blobs, particles, magnetic
-// buttons, badge typing) is what gives the hero its character, so it stays.
-// Every effect is gated on prefers-reduced-motion, and the two heaviest —
-// the canvas and the scroll parallax — are additionally skipped on narrow /
-// touch viewports where they cost battery for no visible benefit.
+// The hero's atmospheric layer (matrix rain canvas, aurora blobs, floating
+// particles, scroll parallax) was removed in the calmer "oMLX-style" restyle
+// — the hero background is flat/static now. Badge typing and magnetic
+// buttons stay: they're subtle, one-time or hover-only effects, gated on
+// prefers-reduced-motion like everything else here.
 // ============================================================
-
-function hexToRgba(hex, alpha) {
-  const h = hex.replace('#', '');
-  const r = parseInt(h.length === 3 ? h[0] + h[0] : h.slice(0, 2), 16);
-  const g = parseInt(h.length === 3 ? h[1] + h[1] : h.slice(2, 4), 16);
-  const b = parseInt(h.length === 3 ? h[2] + h[2] : h.slice(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
 
 // ── COPY-TO-CLIPBOARD ──
 function copyText(text, btn) {
@@ -104,98 +96,6 @@ function initBadgeTyping() {
   }, 35);
 }
 
-// ── HERO MATRIX-RAIN CANVAS ──
-// Decorative only; skipped for reduced-motion and on narrow/touch viewports
-// where it costs battery for no visible benefit (the canvas covers the hero,
-// which is mostly obscured by content on small screens anyway).
-function initMatrixRain() {
-  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-  if (window.matchMedia('(max-width: 640px)').matches) return;
-
-  const canvas = document.getElementById('matrix-canvas');
-  const hero = document.getElementById('hero');
-  if (!canvas || !hero) return;
-  const ctx = canvas.getContext('2d');
-  const chars = '01ABCDEFx+=<>[]{}∑∫ΔΩπ';
-  const fontSize = 13;
-  let cols, drops;
-
-  function resize() {
-    canvas.width = hero.offsetWidth;
-    canvas.height = hero.offsetHeight;
-    cols = Math.floor(canvas.width / fontSize);
-    drops = Array.from({ length: cols }, () => Math.random() * -50);
-  }
-
-  resize();
-  new ResizeObserver(resize).observe(hero);
-
-  function themeColors() {
-    const styles = getComputedStyle(document.documentElement);
-    return {
-      bg: styles.getPropertyValue('--bg').trim() || '#08080f',
-      accent: styles.getPropertyValue('--accent').trim() || '#00d4ff',
-    };
-  }
-
-  function draw() {
-    const { bg, accent } = themeColors();
-    ctx.fillStyle = hexToRgba(bg, 0.05);
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = accent;
-    ctx.font = fontSize + 'px JetBrains Mono, monospace';
-    for (let i = 0; i < cols; i++) {
-      const ch = chars[Math.floor(Math.random() * chars.length)];
-      ctx.fillText(ch, i * fontSize, drops[i] * fontSize);
-      if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
-      drops[i] += 0.4;
-    }
-  }
-
-  // rAF-driven at a throttled ~16fps rather than a bare setInterval, so the
-  // browser pauses it in background tabs instead of animating off-screen.
-  let last = 0;
-  let stopped = false;
-  function frame(now) {
-    if (stopped) return;
-    if (now - last >= 60) { draw(); last = now; }
-    requestAnimationFrame(frame);
-  }
-  requestAnimationFrame(frame);
-
-  // Stop entirely once the hero scrolls out of view.
-  const vis = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting && stopped) { stopped = false; requestAnimationFrame(frame); }
-      else if (!e.isIntersecting) { stopped = true; }
-    });
-  }, { threshold: 0 });
-  vis.observe(hero);
-}
-
-// ── HERO SCROLL PARALLAX (aurora blobs) ──
-function initScrollParallax() {
-  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-  const heroEl = document.getElementById('hero');
-  if (!heroEl) return;
-  const auroraContainer = heroEl.querySelector('.aurora-container');
-  if (!auroraContainer) return;
-
-  // Write the transform inside rAF so a fast scroll can't queue up layout
-  // work on every single scroll event.
-  let ticking = false;
-  window.addEventListener('scroll', () => {
-    if (ticking) return;
-    ticking = true;
-    requestAnimationFrame(() => {
-      ticking = false;
-      const heroH = heroEl.offsetHeight;
-      if (window.scrollY > heroH) return;
-      auroraContainer.style.transform = `translateY(${(window.scrollY / heroH) * 60}px)`;
-    });
-  }, { passive: true });
-}
-
 // ── MAGNETIC BUTTONS (desktop hover only — mousemove never fires on touch) ──
 function initMagneticButtons() {
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
@@ -267,17 +167,16 @@ function initCalculator() {
     const rec = VQCalc.pickRecommended(res.rows);
     const fp16 = res.rows[0];
 
-    const verdict = fp16.fits
-      ? `<span class="t-strong">fp16 already fits.</span> ${preset.name} at ` +
-        `${VQCalc.formatTokens(seqLen)} tokens needs ${VQCalc.formatMb(fp16.mb)} of KV cache, ` +
-        `and you have about ${res.budgetGb} GB free. Compression still buys you ` +
-        `headroom: <code class="inline plain t-accent">${rec.id}</code> takes you to ` +
-        `~${VQCalc.formatTokens(rec.maxTokens)} tokens in the same RAM.`
-      : `<span class="t-strong">fp16 does not fit.</span> ${preset.name} at ` +
-        `${VQCalc.formatTokens(seqLen)} tokens needs ${VQCalc.formatMb(fp16.mb)}, but only ` +
-        `about ${res.budgetGb} GB is free after weights and the OS. ` +
-        `<code class="inline plain t-accent">${rec.id}</code> fits in ` +
-        `${VQCalc.formatMb(rec.mb)}.`;
+    // One-line headline result: does it fit, and with how much room. Detail
+    // (all methods, the accounting caveat) moves behind "See all options" so
+    // the default view is a single glanceable answer, not a wall of bars.
+    const headline = fp16.fits
+      ? `<span class="t-strong">${preset.name} already fits</span> in ${res.budgetGb} GB free ` +
+        `— and <code class="inline plain t-accent">${rec.id}</code> stretches that to ` +
+        `~${VQCalc.formatTokens(rec.maxTokens)} tokens.`
+      : `<span class="t-strong">${preset.name} needs ${VQCalc.formatMb(fp16.mb)}</span> — more than ` +
+        `the ${res.budgetGb} GB you have free. <code class="inline plain t-accent">${rec.id}</code> ` +
+        `brings it down to <span class="t-strong">${VQCalc.formatMb(rec.mb)}</span>.`;
 
     const rowsHtml = res.rows.map(r => {
       const isRec = r.id === rec.id;
@@ -305,18 +204,22 @@ function initCalculator() {
       : `<code class="inline plain">${rec.id}</code> is a key-accounting method: on the default path it dequantizes into an fp16 parent cache, so the ratio is an accounting bound rather than a guaranteed drop in resident RAM. For real resident savings use <code class="inline plain">rabitq</code>.`;
 
     out.innerHTML =
-      `<div class="calc-verdict ${fp16.fits ? 'good' : 'bad'}">${verdict}</div>` +
-      `<div class="calc-rows">${rowsHtml}</div>` +
-      `<p class="calc-note">Estimated from your model's real shape ` +
-      `(${preset.n_layers} layers · ${preset.n_kv_heads} KV heads · head_dim ${preset.head_dim}), ` +
-      `assuming 4-bit weights (~${res.weightGb} GB) and a 4 GB OS reserve. ` +
-      `${residentNote} Heavier compression can affect answer quality — ` +
-      `see the <a href="/docs/algorithms/overview" class="t-accent">algorithm reference</a>.</p>` +
+      `<div class="calc-verdict ${fp16.fits ? 'good' : 'bad'}">${headline}</div>` +
       `<div class="calc-cta">` +
         `<a class="btn btn-filled" href="#quickstart">Use <code class="inline plain">${rec.id}</code> →</a>` +
         `<a class="btn btn-outline" href="playground.html">Full playground →</a>` +
-        `<a class="btn btn-outline" href="#install">Install →</a>` +
-      `</div>`;
+      `</div>` +
+      `<details class="reveal calc-reveal">` +
+        `<summary>See all options</summary>` +
+        `<div class="reveal-body">` +
+          `<div class="calc-rows">${rowsHtml}</div>` +
+          `<p class="calc-note">Estimated from your model's real shape ` +
+          `(${preset.n_layers} layers · ${preset.n_kv_heads} KV heads · head_dim ${preset.head_dim}), ` +
+          `assuming 4-bit weights (~${res.weightGb} GB) and a 4 GB OS reserve. ` +
+          `${residentNote} Heavier compression can affect answer quality — ` +
+          `see the <a href="/docs/algorithms/overview" class="t-accent">algorithm reference</a>.</p>` +
+        `</div>` +
+      `</details>`;
   }
 
   // The no-JS fallback is in the markup and removed only once we know the
@@ -581,8 +484,6 @@ document.addEventListener('DOMContentLoaded', () => {
   initCopyButtons();
   initCodeTabs();
   initBadgeTyping();
-  initMatrixRain();
-  initScrollParallax();
   initMagneticButtons();
   initCodeBootAnimation();
   initCalculator();

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -219,11 +219,21 @@ nav {
 }
 
 .nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--accent);
   letter-spacing: -0.02em;
   text-decoration: none;
+}
+
+.nav-logo-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  flex-shrink: 0;
 }
 
 .nav-links {
@@ -332,40 +342,9 @@ nav {
   overflow: hidden;
 }
 
-#hero::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(var(--grid-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
-  background-size: 48px 48px;
-  animation: gridShift 20s linear infinite;
-  pointer-events: none;
-}
-
-#hero::after {
-  content: '';
-  position: absolute;
-  top: 30%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: min(700px, 90vw);
-  height: min(700px, 90vw);
-  background: radial-gradient(circle, rgba(var(--accent-rgb),0.07) 0%, transparent 70%);
-  pointer-events: none;
-}
-
-.particles-container {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-
-@keyframes gridShift {
-  0%   { background-position: 0 0, 0 0; }
-  100% { background-position: 48px 48px, 48px 48px; }
-}
+/* Hero background is flat/static by design — see the "calmer, more human"
+   restyle: the gridline shift, radial glow, particles and aurora blobs that
+   used to live here were removed rather than neutralized. */
 
 .hero-content { position: relative; z-index: 1; width: 100%; max-width: 820px; }
 
@@ -380,7 +359,6 @@ nav {
   letter-spacing: 0.04em;
   margin-bottom: 1.5rem;
   background: rgba(var(--accent-rgb),0.06);
-  animation: install-pulse 2.5s ease-in-out infinite;
 }
 
 .badge-new {
@@ -447,77 +425,21 @@ h1 span::after {
   margin: 0 auto 2rem;
 }
 
-/* Before/after proof card — the "this now fits" moment, stated with the
-   numbers the calculator derives rather than a claim. */
+/* Before/after proof — the "this now fits" moment, stated as one plain
+   sentence with the numbers the calculator derives rather than a claim.
+   No card/border: it reads as part of the copy, not a separate feature. */
 .hero-proof {
   max-width: 620px;
   margin: 0 auto 1.75rem;
-  padding: 1.1rem 1.25rem;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  text-align: left;
-}
-
-.hero-proof-head {
-  font-size: 0.75rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin: 0 0 0.75rem;
-}
-
-.hero-proof-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.65rem;
   font-size: 0.95rem;
-  line-height: 1.45;
-}
-
-.hero-proof-before { color: var(--muted); }
-.hero-proof-before strong { color: var(--caution-text); }
-.hero-proof-after { color: var(--text); }
-.hero-proof-after strong { color: var(--good); }
-
-.hero-proof-arrow {
-  color: var(--accent);
-  font-size: 1.15rem;
-  flex-shrink: 0;
-}
-
-.hero-proof-note {
-  font-size: 0.8rem;
+  line-height: 1.55;
   color: var(--muted);
-  line-height: 1.5;
-  margin: 0.8rem 0 0;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--border);
 }
 
-/* Sits after the CTA now, so it no longer pulls up into the pills. */
-.hero-disclaimer {
-  font-size: 0.8rem;
-  color: var(--muted);
-  opacity: 0.75;
-  max-width: 560px;
-  margin: 0 auto 1.75rem;
-  line-height: 1.5;
-}
+.hero-proof-before { color: var(--caution-text); }
+.hero-proof-after { color: var(--good); }
 
 .hero-secondary-links { margin-top: 1rem; }
-
-.hero-disclaimer a {
-  color: inherit;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.hero-disclaimer a:hover {
-  color: var(--accent);
-}
 
 .install-block {
   display: inline-flex;
@@ -533,7 +455,6 @@ h1 span::after {
   margin-bottom: 2rem;
   cursor: pointer;
   transition: border-color 0.2s;
-  animation: install-pulse 2.5s ease-in-out infinite;
   max-width: 100%;
   overflow-x: auto;
   white-space: nowrap;
@@ -541,11 +462,6 @@ h1 span::after {
 
 .install-block:hover { border-color: var(--accent); }
 .install-block .dollar { color: var(--accent); user-select: none; }
-
-@keyframes install-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0.3); border-color: var(--border); }
-  50%      { box-shadow: 0 0 12px 3px rgba(var(--accent-rgb), 0.15); border-color: rgba(var(--accent-rgb), 0.5); }
-}
 
 .copy-btn {
   background: none;
@@ -611,12 +527,7 @@ h1 span::after {
 
 .btn-filled:hover {
   background: var(--accent-hover);
-  animation: button-glow 1.5s ease-in-out infinite;
-}
-
-@keyframes button-glow {
-  0%, 100% { box-shadow: 0 0 0 rgba(var(--accent-rgb), 0.4); }
-  50%      { box-shadow: 0 0 16px rgba(var(--accent-rgb), 0.6); }
+  transform: translateY(-2px);
 }
 
 .btn-outline {
@@ -1026,7 +937,9 @@ section {
   margin-top: 0.5rem;
 }
 
-/* ===== STAT CARDS ===== */
+/* ===== STAT STRIP =====
+   Calm, plain-text presentation: no card chrome (background/border/shadow),
+   no pulsing glow, no shimmer sweep. Just a number and a label. */
 .stat-hero-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -1034,87 +947,29 @@ section {
   margin-bottom: 1.25rem;
 }
 
-.stat-hero {
-  background: linear-gradient(135deg, var(--surface) 60%, rgba(var(--accent-rgb),0.06));
-  border-color: rgba(var(--accent-rgb),0.4) !important;
-}
-
-.stat-hero .stat-number { font-size: 4rem !important; }
-
 .stat-row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 1.25rem;
 }
 
 .stat-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 2rem 1.25rem;
   text-align: center;
-  transition: border-color 0.3s, transform 0.3s;
-  position: relative;
-  overflow: hidden;
-  animation: pulse-glow 3s ease-in-out infinite;
-}
-
-.stat-card:hover {
-  border-color: var(--accent);
-  transform: translateY(-3px);
-  animation: none;
-  box-shadow: 0 0 32px rgba(var(--accent-rgb),0.16) !important;
-}
-
-.stat-card.purple:hover {
-  border-color: var(--purple);
-  box-shadow: 0 0 24px rgba(124,58,237,0.12) !important;
-}
-
-@keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 24px rgba(var(--accent-rgb),0.08); }
-  50%      { box-shadow: 0 0 32px rgba(var(--accent-rgb),0.16); }
-}
-
-.stat-card::after {
-  content: '';
-  position: absolute;
-  left: 0; top: -100%;
-  width: 100%; height: 60%;
-  background: linear-gradient(to bottom, transparent 0%, rgba(var(--accent-rgb), 0.06) 50%, transparent 100%);
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.1s;
-}
-
-.stat-card:hover::after {
-  opacity: 1;
-  animation: scanline 0.7s ease-out forwards;
-}
-
-@keyframes scanline {
-  0%   { top: -60%; }
-  100% { top: 110%; }
+  padding: 0;
 }
 
 .stat-number {
+  display: inline-block;
+  font-family: 'JetBrains Mono', monospace;
   font-size: 2.8rem;
   font-weight: 700;
   color: var(--accent);
   letter-spacing: -0.04em;
   line-height: 1;
   margin-bottom: 0.5rem;
-  display: inline-block;
 }
 
-.stat-card.purple .stat-number { color: #a78bfa; }
-
-.stat-number.counting { animation: number-pop 0.8s ease-out; }
-
-@keyframes number-pop {
-  0%, 100% { transform: scale(1); }
-  50%      { transform: scale(1.05); }
-}
+.stat-card.purple .stat-number { color: var(--max); }
 
 .stat-label {
   font-size: 0.82rem;
@@ -1134,50 +989,23 @@ section {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.75rem;
-  transition: border-color 0.3s, transform 0.3s;
+  transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
 .algo-card:hover {
-  border-color: rgba(124,58,237,0.6);
+  border-color: var(--accent);
   transform: translateY(-3px);
-  box-shadow: 0 0 24px rgba(124,58,237,0.08);
-  background-image: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.05) 50%, transparent 100%);
-  background-position: -1000px 0;
-  animation: card-shimmer 0.6s ease-in-out;
-}
-
-@keyframes card-shimmer {
-  0%   { background-position: -1000px 0; }
-  100% { background-position: 1000px 0; }
 }
 
 .algo-card.vecinfer-card {
-  border-color: rgba(124,58,237,0.35);
-  background: linear-gradient(135deg, #12121e 60%, rgba(124,58,237,0.06));
+  border-color: var(--border);
+  background: var(--surface);
   grid-column: span 2;
   position: relative;
 }
 
-.algo-card.vecinfer-card::before {
-  content: '';
-  position: absolute;
-  inset: -1px;
-  border-radius: calc(var(--radius) + 1px);
-  background: linear-gradient(135deg, rgba(var(--accent-rgb),0.5), rgba(124,58,237,0.5));
-  z-index: -1;
-  opacity: 0.25;
-  transition: opacity 0.4s ease;
-}
-
-.algo-card.vecinfer-card:hover::before { opacity: 0.6; }
-
 .algo-card.vecinfer-card:hover {
   border-color: var(--purple);
-  box-shadow: 0 0 32px rgba(124,58,237,0.15);
-  background: linear-gradient(135deg, #12121e 60%, rgba(124,58,237,0.06)),
-              linear-gradient(90deg, transparent 0%, rgba(124,58,237,0.1) 50%, transparent 100%);
-  background-position: 0 0, -1000px 0;
-  animation: card-shimmer 0.6s ease-in-out;
 }
 
 .vecinfer-inner {
@@ -1329,12 +1157,6 @@ section {
   border-radius: 999px;
   padding: 0.12rem 0.5rem;
   text-transform: uppercase;
-  animation: newpulse 2.4s ease-in-out infinite;
-}
-
-@keyframes newpulse {
-  0%,100% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb),0); }
-  50%     { box-shadow: 0 0 10px 0 rgba(var(--accent-rgb),0.25); }
 }
 
 .cat-group .algo-title { font-size: 1.05rem; margin-bottom: 0.1rem; }
@@ -1491,6 +1313,16 @@ pre {
   color: var(--code-text);
 }
 
+/* Install commands are short enough to read in full without a horizontal
+   scrollbar — wrap instead of relying on overflow-x, since a partially
+   visible command with no obvious scroll affordance reads as broken. The
+   quickstart diff blocks keep the default no-wrap/overflow-x behavior above,
+   since those lines are aligned code that shouldn't reflow. */
+/* #install is now wide enough (see #install max-width above) that these
+   commands fit on one line — default pre behavior (overflow-x: auto,
+   no wrap) is back, so long lines scroll rather than break mid-command if a
+   narrow viewport ever forces the issue, instead of always force-wrapping. */
+
 .code-boot-char { opacity: 0; animation: char-appear 0.02s forwards; }
 @keyframes char-appear { to { opacity: 1; } }
 
@@ -1564,12 +1396,6 @@ tbody td {
 .td-muted { color: var(--muted); font-size: 0.8rem; }
 .td-winner { color: #4ade80; font-weight: 700; font-family: 'JetBrains Mono', monospace; }
 
-.td-winner:hover { animation: winner-pulse 0.6s ease; }
-@keyframes winner-pulse {
-  0%, 100% { text-shadow: 0 0 0px rgba(74, 222, 128, 0.5); }
-  50%      { text-shadow: 0 0 8px rgba(74, 222, 128, 0.8); }
-}
-
 /* Bar cells */
 .bar-cell {
   position: relative;
@@ -1611,6 +1437,16 @@ tbody td {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
+}
+
+/* Second benchmark table's heading, inside #benchmarks — same section, a
+   size step down from .section-title so it reads as a subsection, not a
+   new page section. */
+.bench-subtitle {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 3rem 0 0.5rem;
 }
 
 /* ===== METHOD PICKER ("choose by goal") ===== */
@@ -1773,10 +1609,27 @@ tbody td {
 .whats-new-list .wn-body strong { color: var(--text); }
 .whats-new-list code { font-family: 'JetBrains Mono', monospace; font-size: 0.82em; }
 
-/* ===== INSTALL SECTION ===== */
+/* ===== INSTALL SECTION =====
+   The one deliberately-more-emphasized block near the end of the page
+   (oMLX reference's single dark contrast block). The whole page is already
+   dark by default, so emphasis comes from a subtle surface tint + border on
+   the content well, not a second color scheme. */
+/* Wider than the default 1100px section cap: the git-clone command needs
+   room to sit on one line rather than wrapping mid-URL. */
+#install {
+  max-width: 1300px;
+}
+
+.install-well {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2.5rem;
+}
+
 .install-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 3fr 2fr;
   gap: 2rem;
   align-items: start;
 }
@@ -1787,6 +1640,101 @@ tbody td {
    and defers overflow handling to pre's own overflow-x:auto. */
 .install-grid > * {
   min-width: 0;
+}
+
+/* ===== STATS STRIP (plain numbers, no card chrome) ===== */
+.stats-strip-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 3rem 4rem;
+  text-align: center;
+}
+
+.stats-strip-item { max-width: 180px; }
+
+.stats-strip-num {
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin-bottom: 0.6rem;
+}
+
+.stats-strip-label {
+  font-size: 0.82rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+/* ===== FEATURE GRID ("Why VeloxQuant-MLX") ===== */
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.feature-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.6rem 1.5rem;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.feature-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.feature-icon {
+  font-size: 1.3rem;
+  margin-bottom: 0.9rem;
+  line-height: 1;
+}
+
+.feature-eyebrow {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin-bottom: 0.6rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.feature-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+}
+
+.feature-body {
+  font-size: 0.88rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.feature-more {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 0.88rem;
+}
+
+.feature-more a { color: var(--accent); text-decoration: none; }
+.feature-more a:hover { text-decoration: underline; }
+
+@media (max-width: 900px) {
+  .feature-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 600px) {
+  .feature-grid { grid-template-columns: 1fr; }
+  .stats-strip-row { gap: 2rem; }
 }
 
 .req-list {
@@ -1926,94 +1874,6 @@ footer {
   transform: translateY(0);
 }
 
-/* ===== FLOATING PARTICLES (hero decoration) ===== */
-@keyframes float-particle {
-  0%, 100% { transform: translate(0, 0) rotate(0deg); opacity: 0.3; }
-  25%      { transform: translate(40px, -30px) rotate(90deg); opacity: 0.6; }
-  50%      { transform: translate(20px, -60px) rotate(180deg); opacity: 0.4; }
-  75%      { transform: translate(-30px, -40px) rotate(270deg); opacity: 0.5; }
-}
-
-.particle {
-  position: absolute;
-  width: 3px;
-  height: 3px;
-  background: var(--accent);
-  border-radius: 50%;
-  pointer-events: none;
-  animation: float-particle 20s ease-in-out infinite;
-}
-
-.particle:nth-child(1) { left: 15%; top: 20%; animation-delay: 0s; }
-.particle:nth-child(2) { left: 75%; top: 30%; animation-delay: 3s; }
-.particle:nth-child(3) { left: 45%; top: 50%; animation-delay: 6s; animation-duration: 25s; }
-.particle:nth-child(4) { left: 85%; top: 60%; animation-delay: 2s; animation-duration: 22s; }
-.particle:nth-child(5) { left: 25%; top: 70%; animation-delay: 5s; animation-duration: 28s; }
-
-/* ===== AURORA BACKGROUND BLOBS (hero decoration) ===== */
-.aurora-container {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: 0;
-}
-
-.aurora-blob {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(80px);
-  mix-blend-mode: screen;
-  opacity: 0.18;
-}
-
-.aurora-blob-1 {
-  width: min(600px, 90vw); height: min(600px, 90vw);
-  background: radial-gradient(circle, var(--accent) 0%, transparent 70%);
-  top: -100px; left: 10%;
-  animation: aurora-drift-1 18s ease-in-out infinite;
-}
-
-.aurora-blob-2 {
-  width: min(500px, 80vw); height: min(500px, 80vw);
-  background: radial-gradient(circle, #7c3aed 0%, transparent 70%);
-  top: 50px; right: 5%;
-  animation: aurora-drift-2 22s ease-in-out infinite;
-}
-
-.aurora-blob-3 {
-  width: min(400px, 70vw); height: min(400px, 70vw);
-  background: radial-gradient(circle, #0d47a1 0%, transparent 70%);
-  bottom: 0; left: 35%;
-  animation: aurora-drift-3 26s ease-in-out infinite;
-}
-
-@keyframes aurora-drift-1 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  33%      { transform: translate(80px, 60px) scale(1.1); }
-  66%      { transform: translate(-40px, 100px) scale(0.95); }
-}
-
-@keyframes aurora-drift-2 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  33%      { transform: translate(-90px, 50px) scale(1.05); }
-  66%      { transform: translate(50px, -60px) scale(1.15); }
-}
-
-@keyframes aurora-drift-3 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  50%      { transform: translate(60px, -80px) scale(1.1); }
-}
-
-/* ===== DATA STREAM (matrix rain canvas, hero decoration) ===== */
-#matrix-canvas {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.045;
-  z-index: 0;
-}
-
 /* ============================================================
    REDUCED MOTION — must stay last among behavioral overrides
    so it always wins regardless of source order elsewhere.
@@ -2024,11 +1884,8 @@ footer {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
-  .aurora-blob, #matrix-canvas, .particles-container { display: none; }
   .viz-bar { transition: none !important; }
-  .new-pill { animation: none; }
   .card-details-body { animation: none; }
-  .algo-card.vecinfer-card::before { transition: none; }
 }
 
 /* ============================================================
@@ -3250,6 +3107,12 @@ code.inline.max { color: var(--max); }
 }
 .calc-cta { margin-top: 1.1rem; display: flex; flex-wrap: wrap; gap: 0.6rem; align-items: center; }
 .calc-nojs { padding: 1.25rem; font-size: 0.86rem; color: var(--muted); }
+
+/* One result up front (.calc-verdict + .calc-cta); the per-method bars and
+   the accounting caveat live behind this disclosure instead of always
+   being on screen — same .reveal pattern as the quickstart's "Show
+   advanced options", just re-labeled here. */
+.calc-reveal { margin-top: 1.25rem; }
 
 /* ── Method picker (decision tree) ── */
 

--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -1,0 +1,190 @@
+<!-- Deploy: drag the landing/ folder to netlify.com/drop -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Benchmarks — VeloxQuant-MLX</title>
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg?v=2" />
+  <link rel="shortcut icon" href="assets/favicon.svg?v=2" />
+  <meta name="description" content="Detailed, real-hardware benchmarks for VeloxQuant-MLX: Q-Filters attention-correlation accuracy and generation perplexity." />
+  <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
+       third-party hop, no render-blocking preconnect. -->
+  <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="stylesheet" href="assets/styles.css" />
+  <script>
+    // Set the theme before first paint to avoid a flash of the wrong theme.
+    (function () {
+      try {
+        var saved = localStorage.getItem('vq-theme');
+        if (saved === 'light' || saved === 'dark') {
+          document.documentElement.setAttribute('data-theme', saved);
+        }
+      } catch (e) { /* storage unavailable */ }
+    })();
+  </script>
+
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-LnzxjiMH3B7SjXGL3VIDm.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
+</head>
+<body>
+
+  <!-- ── NAVIGATION ── -->
+  <nav id="navbar">
+    <a href="index.html#hero" class="nav-logo"><img src="assets/logo.svg" alt="" width="28" height="28" class="nav-logo-mark" />VeloxQuant-MLX</a>
+    <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+    <ul class="nav-links" id="nav-links">
+      <li><a href="index.html#calculator">Calculator</a></li>
+      <li><a href="index.html#quickstart">Quickstart</a></li>
+      <li><a href="index.html#faq">FAQ</a></li>
+      <li><a href="index.html#install">Install</a></li>
+      <li><a href="benchmarks.html" aria-current="page">Benchmarks</a></li>
+      <li><a href="playground.html">Playground</a></li>
+      <li><a href="/docs/" rel="noopener">Docs</a></li>
+      <li><a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener">GitHub</a></li>
+      <li>
+        <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light theme" title="Toggle light / dark theme">
+          <span class="theme-icon theme-icon-sun" aria-hidden="true">☀</span>
+          <span class="theme-icon theme-icon-moon" aria-hidden="true">☾</span>
+        </button>
+      </li>
+    </ul>
+  </nav>
+
+  <!-- ── BENCHMARKS ── -->
+  <main>
+    <section id="benchmarks-detail" class="fade-in" style="padding-top:7rem;">
+      <div class="section-head-center">
+        <p class="section-label">Q-Filters, in depth</p>
+        <h2 class="section-title">How the scorer performs</h2>
+        <p class="section-desc">
+          Q-Filters is a token-eviction scorer: it decides which parts of a long conversation are
+          safe to drop from memory. These tables go past the headline compression number and
+          into whether its guesses are actually good — attention-correlation accuracy and
+          generation perplexity. Also on
+          <a href="/docs/algorithms/qfilters" class="t-accent">the docs page</a>, with full
+          methodology.
+        </p>
+      </div>
+
+      <h3 class="bench-subtitle">How well does Q-Filters predict what a model will actually attend to?</h3>
+      <p class="section-desc" style="margin-bottom:1.5rem">
+        Spearman correlation with the model's real attention (higher is better), vs. the K-norm/L2Norm
+        baseline. <a href="/docs/algorithms/qfilters" class="t-accent">Full write-up →</a>
+      </p>
+      <div class="table-wrap fade-in">
+        <table>
+          <caption class="visually-hidden">Q-Filters attention-correlation accuracy vs. K-norm baseline</caption>
+          <thead>
+            <tr>
+              <th scope="col">Scorer</th>
+              <th scope="col">Llama-3.2-1B</th>
+              <th scope="col">Llama-3.2-3B</th>
+              <th scope="col">Qwen2.5-7B</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Q-Filters, calibrated (query-SVD)</td>
+              <td class="td-winner">+0.783 <span class="td-muted">(100% sign-correct)</span></td>
+              <td class="td-winner">+0.863 <span class="td-muted">(100%)</span></td>
+              <td class="td-winner">+0.850 <span class="td-muted">(100%)</span></td>
+            </tr>
+            <tr>
+              <td>K-norm / L2Norm</td>
+              <td>+0.460 <span class="td-muted">(94.5%)</span></td>
+              <td>+0.410 <span class="td-muted">(94.6%)</span></td>
+              <td>+0.402 <span class="td-muted">(86.6%)</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 class="bench-subtitle">Does that translate to better generations?</h3>
+      <p class="section-desc" style="margin-bottom:1.5rem">
+        Generation perplexity with eviction active (lower is better), calibrated vs. fallback.
+        <a href="/docs/algorithms/qfilters" class="t-accent">Full write-up →</a>
+      </p>
+      <div class="table-wrap fade-in">
+        <table>
+          <caption class="visually-hidden">Q-Filters generation perplexity, calibrated vs. fallback</caption>
+          <thead>
+            <tr>
+              <th scope="col">Model / budget</th>
+              <th scope="col">Calibrated</th>
+              <th scope="col">Fallback</th>
+              <th scope="col">Gap to fp16 closed</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td colspan="4" class="td-muted">Llama-3.2-1B (fp16 baseline 4.050)</td></tr>
+            <tr>
+              <td>Budget 256 (~4×)</td>
+              <td class="td-winner">8.476</td>
+              <td>13.358</td>
+              <td class="td-winner">52%</td>
+            </tr>
+            <tr>
+              <td>Budget 128 (~8×)</td>
+              <td class="td-winner">16.307</td>
+              <td>23.645</td>
+              <td class="td-winner">37%</td>
+            </tr>
+            <tr>
+              <td>Budget 64 (~16×)</td>
+              <td class="td-winner">25.933</td>
+              <td>31.274</td>
+              <td class="td-winner">20%</td>
+            </tr>
+            <tr><td colspan="4" class="td-muted">Llama-3.2-3B (fp16 baseline 3.305)</td></tr>
+            <tr>
+              <td>Budget 256 (~4×)</td>
+              <td class="td-winner">5.076</td>
+              <td>7.264</td>
+              <td class="td-winner">55%</td>
+            </tr>
+            <tr>
+              <td>Budget 128 (~8×)</td>
+              <td class="td-winner">10.046</td>
+              <td>14.909</td>
+              <td class="td-winner">42%</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="section-desc" style="margin-top:2.5rem;">
+        Want the main compression and speed numbers instead?
+        <a href="index.html#benchmarks" class="t-accent">Back to the summary table →</a>
+      </p>
+    </section>
+  </main>
+
+  <!-- ── FOOTER ── -->
+  <footer>
+    <ul class="footer-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="https://pypi.org/project/VeloxQuant-MLX/" target="_blank" rel="noopener">PyPI</a></li>
+      <li><a href="/docs/" rel="noopener">Docs</a></li>
+      <li><a href="https://github.com/rajveer43/VeloxQuant-MLX/blob/master/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+    </ul>
+    <p class="footer-copy">© 2026 Rajveer Rathod · MIT License</p>
+    <p class="footer-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</p>
+  </footer>
+
+  <script src="assets/main.js" defer></script>
+
+  <!-- GoatCounter: privacy-friendly, cookieless page counts. Client-side, so
+       it records browsers rather than crawlers — expect it to read lower than
+       server-side request counts. -->
+  <script data-goatcounter="https://veloxquant.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -69,18 +69,16 @@
 
   <!-- ── NAVIGATION ── -->
   <nav id="navbar">
-    <a href="#hero" class="nav-logo">VeloxQuant-MLX</a>
+    <a href="#hero" class="nav-logo"><img src="assets/logo.svg" alt="" width="28" height="28" class="nav-logo-mark" />VeloxQuant-MLX</a>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
-      <li><a href="#waitlist">macOS app</a></li>
-      <li><a href="#scenarios">Start here</a></li>
       <li><a href="#calculator">Calculator</a></li>
       <li><a href="#quickstart">Quickstart</a></li>
-      <li><a href="playground.html">Playground</a></li>
       <li><a href="#faq">FAQ</a></li>
       <li><a href="#install">Install</a></li>
+      <li><a href="benchmarks.html">Benchmarks</a></li>
       <li><a href="/docs/" rel="noopener">Docs</a></li>
       <li><a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener">GitHub</a></li>
       <li>
@@ -92,89 +90,63 @@
     </ul>
   </nav>
 
-  <!-- ── §1 HERO ── -->
+  <!-- ── §1 HERO ──
+       Atmospheric decoration (matrix-canvas, aurora blobs, floating
+       particles) removed for the calmer "oMLX-style" restyle — background is
+       flat/static now (see #hero rules in styles.css). Nav trimmed to 6
+       links for a calmer bar; "macOS app" (#waitlist), "Start here"
+       (#scenarios) and "Playground" (playground.html) are no longer linked
+       from nav, but their target IDs are preserved below since main.js's
+       scroll-spy and other pages still reference them. -->
   <section id="hero">
-    <canvas id="matrix-canvas" aria-hidden="true"></canvas>
-    <div class="aurora-container" aria-hidden="true">
-      <div class="aurora-blob aurora-blob-1"></div>
-      <div class="aurora-blob aurora-blob-2"></div>
-      <div class="aurora-blob aurora-blob-3"></div>
-    </div>
-    <div class="particles-container" aria-hidden="true">
-      <div class="particle"></div>
-      <div class="particle"></div>
-      <div class="particle"></div>
-      <div class="particle"></div>
-      <div class="particle"></div>
-    </div>
     <div class="hero-content">
       <div class="badge" id="hero-badge" data-text="v0.57.0 — fused KIVI-style Metal attention kernel shipped">v0.57.0 — fused KIVI-style Metal attention kernel shipped</div>
 
       <h1>Your Mac runs out of memory<br>before your conversation runs out of <span>things to say</span></h1>
 
-      <!-- Lead with a metric that needs no asterisk. The end-to-end tok/s
-           parity result is measured (see §9) and reproducible; "16×" is
-           bit-width accounting and still appears in the pills below with the
-           scope it was measured at. Defining the central concept in plain
-           words here mirrors the playground primer, so the page's central
-           noun is never used before it is supplied. -->
+      <!-- Lead with a metric that needs no asterisk. Trimmed per review: state
+           the mechanism once, in plain words, and stop — no restated CTA copy
+           ("free, open source, three lines") duplicating the pills/meta row
+           below it. -->
       <p class="hero-oneliner">
         Local AI models keep every past message in memory (the "KV cache"), which can eat
         gigabytes on a long chat. VeloxQuant-MLX shrinks it, so you get
         <strong class="t-accent">longer conversations, or a bigger model</strong>, on the Mac
-        you already have — free, open source, <strong class="t-max">three lines of code</strong>.
+        you already have.
       </p>
 
-      <!-- Pills carry the measurement conditions, not bare adjectives: the old
-           "Near-identical quality" was unverifiable, so each claim now names
-           the model or shape it was measured on. -->
+      <!-- Reduced from 4 pills to 2: the setup-speed and "nothing sent
+           anywhere" claims are either non-differentiating (local execution is
+           implied by an MLX/Apple Silicon library) or unverifiable at a
+           specific model/hardware/method combo without more context than a
+           pill can carry — dropped rather than hedged. -->
       <div class="hero-pills">
-        <span class="hero-pill">Up to 16× less memory used</span>
-        <span class="hero-pill">3-line setup</span>
-        <span class="hero-pill">No speed loss on Qwen2.5-7B, even at max compression</span>
-        <span class="hero-pill">Runs entirely on your Mac — nothing sent anywhere</span>
+        <span class="hero-pill">Up to 16× KV-cache compression</span>
+        <span class="hero-pill">Metal-accelerated · Apple Silicon</span>
       </div>
 
       <!-- Before/after, using only numbers the calculator already derives:
            fp16 KV at 64k on Llama-3.1-8B (32 layers, 8 KV heads, head_dim 128)
            is 8.00 GB; rabitq is the one method here with resident=true in
            calc.js, so it is the only honest pick for a "this now fits" claim.
-           6× → 1.33 GB. Static, so it needs no interaction to land. -->
-      <div class="hero-proof">
-        <p class="hero-proof-head">Example: Llama-3.1-8B, a long conversation (64k tokens), on a 16 GB MacBook Air</p>
-        <div class="hero-proof-row">
-          <span class="hero-proof-before"><strong>8.00 GB</strong> of memory needed normally — won't load</span>
-          <span class="hero-proof-arrow" aria-hidden="true">→</span>
-          <span class="hero-proof-after"><strong>1.33 GB</strong> with one of our methods (<code class="inline plain">rabitq</code>) — fits, with room to spare</span>
-        </div>
-        <p class="hero-proof-note">
-          Real freed memory, not just on paper — <a href="#calculator" class="t-accent">check your own model</a>.
-        </p>
-      </div>
-
-      <!-- One primary action. "See it work" beats "install it": a reader who
-           does not yet know what a KV cache is will not pip install on the
-           strength of a number. The install command stays copyable directly
-           below for the reader who is already sold. -->
-      <div class="cta-row">
-        <a href="#calculator" class="btn btn-filled">Will your model fit? <span data-icon>→</span></a>
-      </div>
-
-      <!-- Accounting vs resident RAM: compression ratios are bit-width accounting,
-           not measured process RSS. Most quantization methods still store dequantized
-           fp16 tensors on the default mlx_lm serving path today (see GitHub #27). Only
-           eviction/true-latent methods reduce resident memory today.
-           Placed after the CTA, not before it: stays uncollapsed above the fold,
-           qualifying the supporting "16×" claim rather than standing between the
-           headline and every action. -->
-      <p class="hero-disclaimer">
-        Most "×" numbers here are potential savings, not yet what Activity Monitor shows.
-        Methods marked 🔻RSS in the
-        <a href="https://github.com/rajveer43/VeloxQuant-MLX#method-library" target="_blank" rel="noopener">method list</a>
-        free real memory today; the rest are on the
-        <a href="https://github.com/rajveer43/VeloxQuant-MLX/issues/27" target="_blank" rel="noopener">roadmap</a>.
-        Details in the <a href="#faq" class="t-accent">FAQ</a>.
+           6× → 1.33 GB. Unboxed into one plain sentence — the bordered card
+           with an all-caps eyebrow and arrow was the last piece of hero still
+           wearing SaaS-template chrome; the numbers carry it without one. -->
+      <p class="hero-proof">
+        On a 16 GB MacBook Air, a 64k-token conversation with Llama-3.1-8B needs
+        <strong class="hero-proof-before">8.00 GB</strong> normally — with
+        <code class="inline plain">rabitq</code> it drops to
+        <strong class="hero-proof-after">1.33 GB</strong> and fits.
       </p>
+
+      <!-- One primary action, reworded off the SaaS-toned "Will your model
+           fit?" to plainer developer phrasing. Install command promoted to
+           sit right beside it — the pip install is the strongest single
+           signal of "this is a real installable library," not an
+           afterthought below a disclaimer. -->
+      <div class="cta-row">
+        <a href="#calculator" class="btn btn-filled">Check memory requirements <span data-icon>→</span></a>
+      </div>
 
       <div class="install-block" id="hero-install" title="Click to copy">
         <span class="dollar">$</span>
@@ -212,74 +184,96 @@
 
   <div class="divider"></div>
 
-  <!-- ── §1.5 MACOS APP WAITLIST ──
-       VeloxQuant Studio is a native SwiftUI control panel for this library
-       (separate repo) — drives `veloxquant methods/serve/recommend` as a
-       subprocess instead of reimplementing the engine. Not shipped yet, so
-       this collects interest via Netlify Forms rather than linking a build. -->
-  <section id="waitlist">
-    <div class="waitlist-shell fade-in">
-      <div class="waitlist-copy">
-        <p class="section-label">Coming soon</p>
-        <h2 class="section-title">VeloxQuant Studio — a native macOS app</h2>
-        <p class="section-desc" style="margin-left:0">
-          A point-and-click app for this tool: pick a model, pick a compression setting, and
-          watch it load and run — no terminal or coding required. It uses the exact same
-          engine as the command-line tool above, so the results are identical, just with a
-          simple interface on top.
-        </p>
-        <ul class="waitlist-points">
-          <li>See how much RAM you'll save before you commit to anything</li>
-          <li>One click to start running a model, with live progress on screen</li>
-          <li>Built for Apple Silicon; available outside the App Store first</li>
-        </ul>
+  <!-- ── §2 STATS STRIP ──
+       Four plain numbers, no card chrome — every figure is traceable to
+       README.md's "Numbers" table (VecInfer-1bit head_dim=128 for the 16×
+       key figure; quantize_vq at S=2048 for the 13× Metal figure; the
+       729MB→12MB Falcon3-7B shape for the 98% figure; the full method
+       count for the 43). -->
+  <section id="stats">
+    <div class="stats-strip-row">
+      <div class="stats-strip-item fade-in">
+        <span class="stats-strip-num">16×</span>
+        <span class="stats-strip-label">max key cache compression<br>(VecInfer-1bit, head_dim=128)</span>
       </div>
-
-      <div class="waitlist-form-wrap">
-        <form
-          id="waitlist-form"
-          name="waitlist"
-          method="POST"
-          data-netlify="true"
-          netlify-honeypot="waitlist-company"
-        >
-          <input type="hidden" name="form-name" value="waitlist" />
-          <p class="waitlist-hp-field" aria-hidden="true">
-            <label>Company<input name="waitlist-company" tabindex="-1" autocomplete="off" /></label>
-          </p>
-
-          <label for="waitlist-email" class="waitlist-label">Email address</label>
-          <div class="waitlist-field-row">
-            <input
-              type="email"
-              id="waitlist-email"
-              name="email"
-              placeholder="you@example.com"
-              required
-              autocomplete="email"
-            />
-            <button type="submit" class="btn btn-filled" id="waitlist-submit">
-              Join waitlist <span data-icon>→</span>
-            </button>
-          </div>
-          <p class="waitlist-note" id="waitlist-status">
-            No spam — we'll announce it here the moment we start building.
-          </p>
-        </form>
-
-        <div class="waitlist-success" id="waitlist-success" hidden>
-          <p class="waitlist-success-title">You're on the list.</p>
-          <p class="waitlist-success-body">We'll email you as soon as we start building. In the meantime, the CLI works today — see the <a href="#quickstart" class="t-accent">quickstart</a> above.</p>
-        </div>
+      <div class="stats-strip-item fade-in">
+        <span class="stats-strip-num">13×</span>
+        <span class="stats-strip-label">Metal kernel speedup<br>(quantize_vq at S=2048)</span>
+      </div>
+      <div class="stats-strip-item fade-in">
+        <span class="stats-strip-num">98%</span>
+        <span class="stats-strip-label">peak memory reduction<br>(729MB → 12MB, Falcon3-7B shape)</span>
+      </div>
+      <div class="stats-strip-item fade-in">
+        <span class="stats-strip-num">43</span>
+        <span class="stats-strip-label">compression methods<br>in one drop-in API</span>
       </div>
     </div>
   </section>
 
   <div class="divider"></div>
 
+  <!-- ── §3 WHY VELOXQUANT-MLX (feature grid) ──
+       Six cards summarizing the method categories + what makes the project
+       usable, not just fast. Copy is plain-English, per the design brief;
+       every claim traces to README.md (43 methods total: 22 quantization +
+       6 low-rank/cross-layer + 15 eviction/merging; 12 production models;
+       13× / 98% Metal figures shared with the stats strip above). -->
+  <section id="why">
+    <div class="section-head-center">
+      <p class="section-label">Why VeloxQuant-MLX</p>
+      <h2 class="section-title">One API, six ways to shrink the cache</h2>
+    </div>
+    <div class="feature-grid">
+      <div class="feature-card fade-in">
+        <div class="feature-icon" aria-hidden="true">◆</div>
+        <p class="feature-eyebrow">01 — Quantizers</p>
+        <h3 class="feature-title">Shrink every number</h3>
+        <p class="feature-body">Compresses each Key/Value vector from 16-bit down to as little as 1 bit using calibrated codebooks — most methods need zero calibration and work out of the box.</p>
+      </div>
+      <div class="feature-card fade-in">
+        <div class="feature-icon" aria-hidden="true">⊘</div>
+        <p class="feature-eyebrow">02 — Token eviction</p>
+        <h3 class="feature-title">Drop what you don't need</h3>
+        <p class="feature-body">Some methods actively remove old, low-value tokens from memory instead of just shrinking them — this is the only path that frees memory you'll actually see in Activity Monitor today.</p>
+      </div>
+      <div class="feature-card fade-in">
+        <div class="feature-icon" aria-hidden="true">⧉</div>
+        <p class="feature-eyebrow">03 — Cross-layer merging</p>
+        <h3 class="feature-title">Share memory across layers</h3>
+        <p class="feature-body">Several transformer layers can share a single compressed cache instead of each keeping its own copy, cutting memory further with almost no code change.</p>
+      </div>
+      <div class="feature-card fade-in">
+        <div class="feature-icon" aria-hidden="true">⚙</div>
+        <p class="feature-eyebrow">04 — Metal kernels</p>
+        <h3 class="feature-title">Hand-written for Apple Silicon</h3>
+        <p class="feature-body">The hottest compression path runs on custom Metal kernels — up to 13× faster than the equivalent pure MLX code, with up to 98% less peak memory at the shapes that used to run out.</p>
+      </div>
+      <div class="feature-card fade-in">
+        <div class="feature-icon" aria-hidden="true">▤</div>
+        <p class="feature-eyebrow">05 — Drop-in API</p>
+        <h3 class="feature-title">Three lines, not a rewrite</h3>
+        <p class="feature-body">Every method shares one config object, so switching between them means changing a single string — your model-loading and generation code stays exactly the same.</p>
+      </div>
+      <div class="feature-card fade-in">
+        <div class="feature-icon" aria-hidden="true">◫</div>
+        <p class="feature-eyebrow">06 — Multi-model support</p>
+        <h3 class="feature-title">Works with what you already run</h3>
+        <p class="feature-body">Validated on 12 production model families (Llama, Mistral, Qwen, Phi, Gemma 3/4, Falcon) via <code class="inline plain">mlx_lm</code>, plus vision-language models through <code class="inline plain">mlx-vlm</code>.</p>
+      </div>
+    </div>
+    <p class="feature-more">
+      <a href="https://github.com/rajveer43/VeloxQuant-MLX#method-library" target="_blank" rel="noopener">Browse all 43 methods →</a>
+    </p>
+  </section>
+
+  <div class="divider"></div>
+
   <!-- Toast — fires on successful waitlist join, independent of scroll
        position, so the confirmation lands even if the inline success box
-       (inside #waitlist) has already scrolled out of view. -->
+       (inside #waitlist, further down the page) has already scrolled out
+       of view. Kept high in the DOM (fixed-position, so location doesn't
+       matter visually) rather than moved with #waitlist itself. -->
   <div class="toast-stack" id="toast-stack" aria-live="polite" aria-atomic="true"></div>
 
   <!-- Legacy anchor aliases. #benefits was the old stats section, dropped in
@@ -287,7 +281,7 @@
        Point it at the calculator, which is what it was trying to prove. -->
   <span id="benefits" class="anchor-alias" aria-hidden="true"></span>
 
-  <!-- ── §2 CALCULATOR ── -->
+  <!-- ── §4 CALCULATOR ── -->
   <section id="calculator">
     <div class="section-head-center">
       <p class="section-label">Size it for your Mac</p>
@@ -350,6 +344,184 @@
         <p class="scenario-quote">I'm a developer and want the technical details on each compression method.</p>
         <p class="scenario-answer">Browse the algorithm reference →</p>
       </a>
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <!-- ── §5 BENCHMARKS ──
+       Plain, static table — no animated bar-fill, no hover shimmer. Every
+       row is taken verbatim from README.md's "Numbers" table (values and
+       notes copied as-is; nothing here is rounded differently than the
+       source). .bar-cell/.bar-fill exist in styles.css for reuse elsewhere
+       but are intentionally not used in this table. -->
+  <section id="benchmarks">
+    <div class="section-head-center">
+      <p class="section-label">Real numbers, real hardware</p>
+      <h2 class="section-title">Measured, not projected</h2>
+      <p class="section-desc">
+        Every figure below comes straight from the project's own benchmark suite — the same
+        numbers in <a href="https://github.com/rajveer43/VeloxQuant-MLX#numbers" class="t-accent" target="_blank" rel="noopener">README.md</a>.
+      </p>
+    </div>
+    <div class="table-wrap fade-in">
+      <table>
+        <caption class="visually-hidden">Compression and speed benchmarks</caption>
+        <thead>
+          <tr>
+            <th scope="col">Metric</th>
+            <th scope="col">Value</th>
+            <th scope="col">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Max key cache compression</td>
+            <td class="td-highlight">16×</td>
+            <td class="td-muted">VecInfer-1bit, head_dim=128</td>
+          </tr>
+          <tr>
+            <td>Metal kernel speedup</td>
+            <td class="td-highlight">13×</td>
+            <td class="td-muted"><code class="inline plain">quantize_vq</code> at S=2048 (range 6.9–14.7× over S=128–8192)</td>
+          </tr>
+          <tr>
+            <td>Peak memory reduction</td>
+            <td class="td-highlight">98%</td>
+            <td class="td-muted">729 MB → 12 MB, Falcon3-7B shape</td>
+          </tr>
+          <tr>
+            <td>RVQ-1bit compression</td>
+            <td class="td-highlight">7.5×</td>
+            <td class="td-muted">Near-zero throughput cost</td>
+          </tr>
+          <tr>
+            <td>SpectralQuant compression</td>
+            <td class="td-highlight">5.33×</td>
+            <td class="td-muted">Per-model measured (Qwen2.5-0.5B / Gemma-4-4B), same bit-width</td>
+          </tr>
+          <tr>
+            <td>RaBitQ full KV compression</td>
+            <td class="td-purple">6×</td>
+            <td class="td-muted">1-bit keys + MSE-b4 values, Falcon3-7B</td>
+          </tr>
+          <tr>
+            <td>CommVQ key compression</td>
+            <td class="td-purple">64×</td>
+            <td class="td-muted">RoPE-commutative VQ, D=128, n_cb=4</td>
+          </tr>
+          <tr>
+            <td>KIVI-2bit key compression</td>
+            <td class="td-highlight">5.8×</td>
+            <td class="td-muted">Per-channel keys / per-token values; measured on Llama-3.2-3B, Qwen2.5-7B, Mistral-7B</td>
+          </tr>
+          <tr>
+            <td>Production models validated</td>
+            <td class="td-winner">12</td>
+            <td class="td-muted">Llama, Mistral, Qwen, Phi, Gemma 3/4, Falcon</td>
+          </tr>
+          <tr>
+            <td>Tests passing</td>
+            <td class="td-winner">2347/2347</td>
+            <td class="td-muted">Run on every commit</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="bench-note">
+      Compression ratios above are bit-width accounting, not measured resident memory — see the
+      <a href="#faq" class="t-accent">FAQ</a> for what that means for what you'll actually see in
+      Activity Monitor. For attention-correlation accuracy, generation perplexity, and
+      task-level results beyond needle retrieval,
+      see the <a href="benchmarks.html" class="t-accent">full benchmarks page →</a>.
+    </p>
+  </section>
+
+  <!-- TESTIMONIAL: insert a real quote here once supplied.
+       No quote has been supplied yet, so nothing renders — do not fabricate
+       one. Intended structure, once a real quote exists:
+
+       <div class="divider"></div>
+       <section id="testimonial">
+         <div class="section-head-center">
+           <p class="section-label">From people using it</p>
+         </div>
+         <blockquote class="testimonial-quote">
+           "<quote text>"
+           <footer class="testimonial-attribution">
+             <cite><name>, <role/context></cite>
+           </footer>
+         </blockquote>
+       </section>
+
+       Style it plainly, consistent with the rest of the page: no card glow,
+       centered text, attribution in --muted below the quote. -->
+
+  <div class="divider"></div>
+
+  <!-- ── §1.5 MACOS APP WAITLIST ──
+       VeloxQuant Studio is a native SwiftUI control panel for this library
+       (separate repo) — drives `veloxquant methods/serve/recommend` as a
+       subprocess instead of reimplementing the engine. Not shipped yet, so
+       this collects interest via Netlify Forms rather than linking a build.
+       Repositioned here (was right after the hero) to match the new section
+       order; id and JS hooks (#waitlist-form/#waitlist-success/#waitlist-submit)
+       are unchanged. -->
+  <section id="waitlist">
+    <div class="waitlist-shell fade-in">
+      <div class="waitlist-copy">
+        <p class="section-label">Coming soon</p>
+        <h2 class="section-title">VeloxQuant Studio — a native macOS app</h2>
+        <p class="section-desc" style="margin-left:0">
+          A point-and-click app for this tool: pick a model, pick a compression setting, and
+          watch it load and run — no terminal or coding required. It uses the exact same
+          engine as the command-line tool above, so the results are identical, just with a
+          simple interface on top.
+        </p>
+        <ul class="waitlist-points">
+          <li>See how much RAM you'll save before you commit to anything</li>
+          <li>One click to start running a model, with live progress on screen</li>
+          <li>Built for Apple Silicon; available outside the App Store first</li>
+        </ul>
+      </div>
+
+      <div class="waitlist-form-wrap">
+        <form
+          id="waitlist-form"
+          name="waitlist"
+          method="POST"
+          data-netlify="true"
+          netlify-honeypot="waitlist-company"
+        >
+          <input type="hidden" name="form-name" value="waitlist" />
+          <p class="waitlist-hp-field" aria-hidden="true">
+            <label>Company<input name="waitlist-company" tabindex="-1" autocomplete="off" /></label>
+          </p>
+
+          <label for="waitlist-email" class="waitlist-label">Email address</label>
+          <div class="waitlist-field-row">
+            <input
+              type="email"
+              id="waitlist-email"
+              name="email"
+              placeholder="you@example.com"
+              required
+              autocomplete="email"
+            />
+            <button type="submit" class="btn btn-filled" id="waitlist-submit">
+              Join waitlist <span data-icon>→</span>
+            </button>
+          </div>
+          <p class="waitlist-note" id="waitlist-status">
+            No spam — we'll announce it here the moment we start building.
+          </p>
+        </form>
+
+        <div class="waitlist-success" id="waitlist-success" hidden>
+          <p class="waitlist-success-title">You're on the list.</p>
+          <p class="waitlist-success-body">We'll email you as soon as we start building. In the meantime, the CLI works today — see the <a href="#quickstart" class="t-accent">quickstart</a> above.</p>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -532,7 +704,7 @@
       <details class="faq-item fade-in">
         <summary>What hardware do I need?</summary>
         <div class="faq-item-body">
-          An Apple Silicon Mac (M1 or later; M2/M3/M4 recommended), Python 3.11 or 3.12, and
+          An Apple Silicon Mac (M1 or later; M2/M3/M4/M5 recommended), Python 3.11 or 3.12, and
           Apple's MLX framework (version 0.18 or later — installed automatically). It's a
           pure-Python tool with optional on-chip acceleration — no separate app to install
           today, and no GPU beyond what's already built into your Mac.
@@ -561,68 +733,67 @@
     </div>
   </section>
 
-  <!-- ── §11 INSTALL ── -->
+  <!-- ── §11 INSTALL ──
+       The one deliberately-more-emphasized block near the end of the page
+       (matching the oMLX reference's single dark contrast block). The page
+       is already dark by default, so emphasis is a subtle surface tint +
+       border on .install-well, not a second color scheme. -->
   <section id="install">
     <p class="section-label">Installation</p>
     <h2 class="section-title">Get started in seconds</h2>
     <p class="section-desc" style="margin-bottom:2rem;">Requires an Apple Silicon Mac (M1 or later) and Python 3.11 or newer.</p>
-    <div class="install-grid">
-      <div>
-        <div class="code-wrap fade-in">
-          <div class="code-header">
-            <span class="code-lang">install it</span>
-            <button class="code-copy" data-target="code-pip">Copy</button>
+    <div class="install-well fade-in">
+      <div class="install-grid">
+        <div>
+          <div class="code-wrap">
+            <div class="code-header">
+              <span class="code-lang">install it</span>
+              <button class="code-copy" data-target="code-pip">Copy</button>
+            </div>
+            <pre id="code-pip"><span class="id">pip install VeloxQuant-MLX</span></pre>
           </div>
-          <pre id="code-pip"><span class="id">pip install VeloxQuant-MLX</span></pre>
-        </div>
-        <div class="code-wrap fade-in">
-          <div class="code-header">
-            <span class="code-lang">check it worked</span>
-            <button class="code-copy" data-target="code-verify">Copy</button>
-          </div>
-          <pre id="code-verify"><span class="id">python -c "import veloxquant_mlx; print(veloxquant_mlx.__version__)"</span></pre>
-        </div>
-        <div class="code-wrap fade-in">
-          <div class="code-header">
-            <span class="code-lang">for developers: install from source</span>
-            <button class="code-copy" data-target="code-src">Copy</button>
-          </div>
-          <pre id="code-src"><span class="id">git clone https://github.com/rajveer43/VeloxQuant-MLX
+          <div class="code-wrap">
+            <div class="code-header">
+              <span class="code-lang">for developers: install from source</span>
+              <button class="code-copy" data-target="code-src">Copy</button>
+            </div>
+            <pre id="code-src"><span class="id">git clone https://github.com/rajveer43/VeloxQuant-MLX
 cd VeloxQuant-MLX
 pip install -e ".[dev]"</span></pre>
+          </div>
+          <p style="margin-top:1.5rem;">
+            Prefer an editor integration? Get the
+            <a href="https://marketplace.visualstudio.com/items?itemName=veloxquant-mlx.veloxquant-vscode" target="_blank" rel="noopener">VeloxQuant VS Code extension</a>.
+          </p>
         </div>
-        <p style="margin-top:1.5rem;">
-          Prefer an editor integration? Get the
-          <a href="https://marketplace.visualstudio.com/items?itemName=veloxquant-mlx.veloxquant-vscode" target="_blank" rel="noopener">VeloxQuant VS Code extension</a>.
-        </p>
-      </div>
-      <div class="fade-in">
-        <ul class="req-list">
-          <li>Apple Silicon M1 or later (M2/M3/M4 recommended)</li>
-          <li>Python 3.11 or 3.12</li>
-          <li>Apple's MLX framework, version 0.18 or later</li>
-          <li>NumPy 1.26 or later</li>
-          <li>Matplotlib 3.8 or later (only needed for benchmark charts)</li>
-          <li>Free and open source — MIT license, free for personal and commercial use</li>
-        </ul>
+        <div>
+          <ul class="req-list">
+            <li>Apple Silicon M1 or later (M2/M3/M4/M5 recommended)</li>
+            <li>Python 3.11 or 3.12</li>
+            <li>Apple's MLX framework, version 0.18 or later</li>
+            <li>NumPy 1.26 or later</li>
+            <li>Matplotlib 3.8 or later (only needed for benchmark charts)</li>
+            <li>Free and open source — MIT license, free for personal and commercial use</li>
+          </ul>
 
-        <!-- Institutional trust signals, reframed in plain terms for a
-             consumer reader: what "MIT license" / "tests" / "maintainers"
-             actually buy them (can inspect the code, it's checked before
-             each release, it's not a one-person weekend project) plus
-             explicit privacy framing, which the page didn't state anywhere
-             before. Test count is `pytest --collect-only` at v0.49.4;
-             maintainer count is deliberately the literal number rather than
-             a vaguer "team". -->
-        <ul class="req-list req-list-trust">
-          <!-- Format is load-bearing: scripts/sync_release_badges.py rewrites
-               the literal "<n>/<n> tests passing" on every release. Any other
-               phrasing here silently goes stale. -->
-          <li><strong class="t-strong">2347/2347 tests passing</strong> — run on every commit</li>
-          <li><strong class="t-strong">CI</strong> — lint, unit and non-Metal suites on GitHub Actions</li>
-          <li><strong class="t-strong">2 maintainers</strong> — plus outside contributors</li>
-          <li><a href="https://doi.org/10.5281/zenodo.20647294" target="_blank" rel="noopener">Citable — DOI on Zenodo</a></li>
-        </ul>
+          <!-- Institutional trust signals, reframed in plain terms for a
+               consumer reader: what "MIT license" / "tests" / "maintainers"
+               actually buy them (can inspect the code, it's checked before
+               each release, it's not a one-person weekend project) plus
+               explicit privacy framing, which the page didn't state anywhere
+               before. Test count is `pytest --collect-only` at v0.49.4;
+               maintainer count is deliberately the literal number rather than
+               a vaguer "team". -->
+          <ul class="req-list req-list-trust">
+            <!-- Format is load-bearing: scripts/sync_release_badges.py rewrites
+                 the literal "<n>/<n> tests passing" on every release. Any other
+                 phrasing here silently goes stale. -->
+            <li><strong class="t-strong">2347/2347 tests passing</strong> — run on every commit</li>
+            <li><strong class="t-strong">CI</strong> — lint, unit and non-Metal suites on GitHub Actions</li>
+            <li><strong class="t-strong">2 maintainers</strong> — plus outside contributors</li>
+            <li><a href="https://doi.org/10.5281/zenodo.20647294" target="_blank" rel="noopener">Citable — DOI on Zenodo</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </section>

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -35,7 +35,7 @@
 
   <!-- ── NAVIGATION ── -->
   <nav id="navbar">
-    <a href="index.html#hero" class="nav-logo">VeloxQuant-MLX</a>
+    <a href="index.html#hero" class="nav-logo"><img src="assets/logo.svg" alt="" width="28" height="28" class="nav-logo-mark" />VeloxQuant-MLX</a>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
       <span></span><span></span><span></span>
     </button>


### PR DESCRIPTION
## Summary
- Simplified the hero: trimmed pills, replaced the boxed 8GB→1.33GB proof card with a plain sentence, removed the standalone memory-caveat disclaimer paragraph (now covered in the FAQ)
- Moved the detailed Q-Filters attention-correlation and perplexity tables off the landing page into a new `benchmarks.html`, linked from the nav
- Removed the "Raw benchmark data" section (search/filter table) that depended on a client-side fetch that was failing at runtime
- Added the product's real logo mark (sourced from the macOS app's icon design) to the nav across `index.html`, `playground.html`, and `benchmarks.html`

## Test plan
- [x] Validated HTML tag balance on all three touched/added pages (0 mismatches)
- [x] Manually click through index.html → benchmarks.html → playground.html nav links in a browser
- [x] Confirm logo renders correctly in both light and dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)