### PR TITLE
docs: fix stale method count in package/citation metadata (41 → 43)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "VeloxQuant-MLX: Fast KV-Cache Quantization for Apple Silicon",
-  "description": "Fast KV-cache quantization for Apple Silicon (MLX) — 41 research-adapted compression methods, from TurboQuant and KIVI to A2ATS, with Metal kernels. Compresses the Key/Value cache of mlx_lm models up to 16x with near-lossless quality via a common three-line API.",
+  "description": "Fast KV-cache quantization for Apple Silicon (MLX) — 43 research-adapted compression methods, from TurboQuant and KIVI to A2ATS, with Metal kernels. Compresses the Key/Value cache of mlx_lm models up to 16x with near-lossless quality via a common three-line API.",
   "creators": [
     {
       "name": "Rathod, Rajveer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "VeloxQuant-MLX"
 version = "0.57.1"
-description = "Fast KV-cache quantization for Apple Silicon (MLX) — 41 research-adapted compression methods, from TurboQuant and KIVI to A2ATS, with Metal kernels"
+description = "Fast KV-cache quantization for Apple Silicon (MLX) — 43 research-adapted compression methods, from TurboQuant and KIVI to A2ATS, with Metal kernels"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
## Summary

`pyproject.toml`'s package description and `.zenodo.json`'s citation description both said "41 research-adapted compression methods." `README.md` consistently says 43 (twice), and its method library breakdown by family — 22 quantization + 6 low-rank/cross-layer + 15 eviction/merging — sums to 43, so it's the internally consistent, actively maintained count. This syncs both metadata files to match.

Note while investigating: the actual code registry (`veloxquant_mlx/cache/registry.py`'s `_FAMILY` dict) currently has 42 entries, and `rabitq`/`comm_vq` (mentioned in README's quickstart as selectable `method=` values) aren't present in that dict at all — worth a separate follow-up to reconcile the registry against the docs, out of scope for this metadata-only fix.

## Test plan

- [x] `python3 -c "import json; json.load(open('.zenodo.json'))"` — valid JSON
- [x] No code changes, metadata-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)