### PR TITLE
feat: hardware-aware automatic KV quantization configuration (#253)

### DIFF
--- a/.github/workflows/non-metal-unit.yml
+++ b/.github/workflows/non-metal-unit.yml
@@ -22,3 +22,7 @@ jobs:
         run: >
           python -m pytest tests/non_metal/test_mac_recommender.py -q
           --noconftest --import-mode=importlib -c /dev/null -o addopts=
+      - name: Run auto KV-config selector unit tests (no MLX)
+        run: >
+          python -m pytest tests/non_metal/test_auto_kv_config.py -q
+          --noconftest --import-mode=importlib -c /dev/null -o addopts=

--- a/README.md
+++ b/README.md
@@ -371,6 +371,11 @@ python benchmark_scripts/run_outlier_ratequant.py # RateQuant mixed-precision
 # Which method should I use on my Mac? (new in 0.42.0)
 python -m veloxquant_mlx recommend \
     --chip M4 --ram-gb 16 --model-class 7B --goal everyday
+
+# Auto-select method/bit-width/group-size/packing from workload + hardware,
+# no goal to pick (new in #253)
+python -m veloxquant_mlx autoconfig \
+    --seq-len 32768 --head-dim 128 --n-layers 32 --n-kv-heads 8 --ram-gb 16
 ```
 
 The recommender is accounting-aware. It reports the key compression ratio and also tells you when resident RAM savings are unlikely, rather than quoting a ratio that won't show up in RSS:
@@ -397,6 +402,8 @@ warnings:
 ```
 
 Goals: `everyday`, `max_key_accounting`, `max_context`, `best_quality`, `constant_memory`. Add `--json` for machine-readable output, or `--seq-len` / `--n-layers` / `--n-kv-heads` / `--head-dim` to match a specific model. Also available in the browser via the [Compression Lab](https://veloxquant-mlx.netlify.app/playground.html).
+
+`veloxquant autoconfig` goes a step further: instead of picking from a fixed list of goals, it derives bit-width, group size, and packing strategy directly from context length and available memory — short contexts get higher precision (`kivi` at 4-bit), long ones get aggressive compression (`turboquant_rvq` at 1-bit), and memory pressure that no bit-width can satisfy falls back to a bounded-memory method (`streaming_llm`) instead of quietly running out of RAM. See `veloxquant_mlx/tools/auto_kv_config.py`.
 
 Load precomputed artifacts to skip re-computation at runtime:
 

--- a/tests/non_metal/test_auto_kv_config.py
+++ b/tests/non_metal/test_auto_kv_config.py
@@ -1,0 +1,169 @@
+"""Unit tests for the hardware-aware auto KV-config selector (no MLX required).
+
+Lives outside veloxquant_mlx/tests/ on purpose — see
+docs/CI_AND_TESTING.md#two-test-directories-and-why.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo-root tests/ so pytest does not import veloxquant_mlx/__init__.py (needs mlx).
+_MOD_PATH = Path(__file__).resolve().parents[2] / "veloxquant_mlx" / "tools" / "auto_kv_config.py"
+_SPEC = importlib.util.spec_from_file_location("auto_kv_config", _MOD_PATH)
+assert _SPEC and _SPEC.loader
+_mod = importlib.util.module_from_spec(_SPEC)
+sys.modules["auto_kv_config"] = _mod
+_SPEC.loader.exec_module(_mod)
+
+WorkloadProfile = _mod.WorkloadProfile
+HardwareProfile = _mod.HardwareProfile
+select_kv_config = _mod.select_kv_config
+estimate_kv_fp16_gb = _mod.estimate_kv_fp16_gb
+to_kv_cache_config = _mod.to_kv_cache_config
+
+
+def test_estimate_kv_fp16_gb_mistral_like():
+    # 2 * 32 * 8 * 128 * 2048 * 2 bytes = 256 MiB = 0.25 GiB
+    gb = estimate_kv_fp16_gb(WorkloadProfile(seq_len=2048, head_dim=128, n_layers=32, n_kv_heads=8))
+    assert abs(gb - 0.25) < 1e-6
+
+
+def test_short_context_prefers_higher_precision_kivi():
+    r = select_kv_config(
+        WorkloadProfile(seq_len=2048, head_dim=128, n_layers=32, n_kv_heads=8),
+        HardwareProfile(ram_gb=64),
+    )
+    assert r.context_regime == "short"
+    assert r.method == "kivi"
+    assert r.bit_width == 4
+    assert r.knobs["kivi_group_size"] == r.group_size
+
+
+def test_long_context_prefers_aggressive_compression():
+    r = select_kv_config(
+        WorkloadProfile(seq_len=65536, head_dim=128, n_layers=32, n_kv_heads=8),
+        HardwareProfile(ram_gb=64),
+    )
+    assert r.context_regime == "long"
+    assert r.method == "turboquant_rvq"
+    assert r.bit_width == 1
+
+
+def test_large_head_dim_gets_a_coarser_group_size():
+    small = select_kv_config(
+        WorkloadProfile(seq_len=2048, head_dim=64, n_layers=32, n_kv_heads=8),
+        HardwareProfile(ram_gb=64),
+    )
+    large = select_kv_config(
+        WorkloadProfile(seq_len=2048, head_dim=256, n_layers=32, n_kv_heads=8),
+        HardwareProfile(ram_gb=64),
+    )
+    assert small.group_size <= 64
+    assert large.group_size <= 256
+    # head_dim=256 admits the full preferred group size (64 | 256); a
+    # smaller head_dim that still divides evenly should not get *more*
+    # than the same preferred cap.
+    assert large.group_size == 64
+
+
+def test_group_size_always_divides_head_dim():
+    for head_dim in (48, 96, 100, 127, 130, 192, 384):
+        r = select_kv_config(
+            WorkloadProfile(seq_len=2048, head_dim=head_dim, n_layers=32, n_kv_heads=8),
+            HardwareProfile(ram_gb=64),
+        )
+        assert head_dim % r.group_size == 0, (head_dim, r.group_size)
+
+
+def test_memory_pressure_lowers_bit_width():
+    workload = WorkloadProfile(seq_len=4096, head_dim=128, n_layers=80, n_kv_heads=8)
+
+    # Plenty of RAM: short context keeps the 4-bit default.
+    roomy = select_kv_config(workload, HardwareProfile(ram_gb=256))
+    assert roomy.bit_width == 4
+    assert roomy.memory_pressure_ratio <= 1.0
+
+    # Same workload, tiny machine: pressure forces bit-width down and
+    # method switches off kivi (kivi is reserved for the no-pressure path).
+    tight = select_kv_config(workload, HardwareProfile(ram_gb=8))
+    assert tight.bit_width < roomy.bit_width
+    assert tight.memory_pressure_ratio > 1.0
+    assert any("pressure" in w.lower() for w in tight.warnings)
+
+
+def test_extreme_pressure_falls_back_to_streaming_llm():
+    r = select_kv_config(
+        WorkloadProfile(seq_len=200000, head_dim=128, n_layers=80, n_kv_heads=8),
+        HardwareProfile(ram_gb=8),
+    )
+    assert r.method == "streaming_llm"
+    assert r.knobs["stream_window_size"] > 0
+    assert any("streaming_llm" in w for w in r.warnings)
+
+
+def test_no_metal_hardware_selects_pure_mlx_packing():
+    r = select_kv_config(
+        WorkloadProfile(seq_len=2048, head_dim=128),
+        HardwareProfile(ram_gb=32, metal_available=False),
+    )
+    assert r.packing_strategy == "pure_mlx"
+
+
+def test_metal_available_or_unknown_selects_metal_auto():
+    for metal_available in (True, None):
+        r = select_kv_config(
+            WorkloadProfile(seq_len=2048, head_dim=128),
+            HardwareProfile(ram_gb=32, metal_available=metal_available),
+        )
+        assert r.packing_strategy == "metal_auto"
+
+
+def test_invalid_seq_len_raises():
+    with pytest.raises(ValueError):
+        select_kv_config(WorkloadProfile(seq_len=0, head_dim=128))
+
+
+def test_invalid_head_dim_raises():
+    with pytest.raises(ValueError):
+        select_kv_config(WorkloadProfile(seq_len=2048, head_dim=0))
+
+
+def test_result_to_dict_roundtrip():
+    r = select_kv_config(WorkloadProfile(seq_len=2048, head_dim=128))
+    d = r.to_dict()
+    assert d["method"] == r.method
+    assert d["knobs"] == r.knobs
+
+
+def test_to_kv_cache_config_maps_knobs_and_packing():
+    workload = WorkloadProfile(seq_len=2048, head_dim=128)
+    result = select_kv_config(workload, HardwareProfile(ram_gb=64, metal_available=False))
+
+    class _FakeKVCacheConfig(dict):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
+    fake_base_module = type(sys)("veloxquant_mlx.cache.base")
+    fake_base_module.KVCacheConfig = _FakeKVCacheConfig
+    fake_cache_module = type(sys)("veloxquant_mlx.cache")
+    fake_pkg = type(sys)("veloxquant_mlx")
+    sys.modules["veloxquant_mlx"] = fake_pkg
+    sys.modules["veloxquant_mlx.cache"] = fake_cache_module
+    sys.modules["veloxquant_mlx.cache.base"] = fake_base_module
+    try:
+        cfg = to_kv_cache_config(result, workload)
+    finally:
+        del sys.modules["veloxquant_mlx"]
+        del sys.modules["veloxquant_mlx.cache"]
+        del sys.modules["veloxquant_mlx.cache.base"]
+
+    assert cfg["method"] == result.method
+    assert cfg["head_dim"] == workload.head_dim
+    assert cfg["use_metal_kernels"] is False
+    for k, v in result.knobs.items():
+        assert cfg[k] == v

--- a/veloxquant_mlx/__main__.py
+++ b/veloxquant_mlx/__main__.py
@@ -7,7 +7,7 @@ import sys
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: veloxquant {precompute|benchmark|recommend|methods|serve|panel}")
+        print("Usage: veloxquant {precompute|benchmark|recommend|autoconfig|methods|serve|panel}")
         sys.exit(1)
 
     command = sys.argv[1]
@@ -26,6 +26,10 @@ def main() -> None:
         from veloxquant_mlx.cli.recommend import main as _main
 
         _main()
+    elif command == "autoconfig":
+        from veloxquant_mlx.cli.autoconfig import main as _main
+
+        _main()
     elif command == "methods":
         from veloxquant_mlx.cli.methods import main as _main
 
@@ -41,7 +45,7 @@ def main() -> None:
     else:
         print(
             f"Unknown command: {command!r}. "
-            "Choices: precompute, benchmark, recommend, methods, serve, panel"
+            "Choices: precompute, benchmark, recommend, autoconfig, methods, serve, panel"
         )
         sys.exit(1)
 

--- a/veloxquant_mlx/cli/autoconfig.py
+++ b/veloxquant_mlx/cli/autoconfig.py
@@ -1,0 +1,95 @@
+"""CLI: automatically pick a KV-cache quantization config for a workload + machine (#253)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from veloxquant_mlx.tools.auto_kv_config import (
+    HardwareProfile,
+    WorkloadProfile,
+    select_kv_config,
+)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="veloxquant autoconfig",
+        description=(
+            "Automatically select a KV-cache quantization method, bit-width, group size, "
+            "and packing strategy from workload and hardware characteristics -- no manual "
+            "goal selection required (unlike `veloxquant recommend`)."
+        ),
+    )
+    parser.add_argument(
+        "--seq-len", type=int, default=4096, help="Expected max context length in tokens"
+    )
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--n-layers", type=int, default=32)
+    parser.add_argument("--n-kv-heads", type=int, default=8)
+    parser.add_argument("--ram-gb", type=float, default=16.0, help="Total unified memory in GB")
+    parser.add_argument(
+        "--memory-budget-gb",
+        type=float,
+        default=None,
+        help=(
+            "GB actually available for the KV cache; default derives a conservative "
+            "estimate from --ram-gb"
+        ),
+    )
+    parser.add_argument(
+        "--no-metal",
+        action="store_true",
+        help="Assume Metal kernel acceleration is unavailable",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    workload = WorkloadProfile(
+        seq_len=args.seq_len,
+        head_dim=args.head_dim,
+        n_layers=args.n_layers,
+        n_kv_heads=args.n_kv_heads,
+    )
+    hardware = HardwareProfile(
+        ram_gb=args.ram_gb,
+        memory_budget_gb=args.memory_budget_gb,
+        metal_available=not args.no_metal,
+    )
+    result = select_kv_config(workload, hardware)
+
+    if args.json:
+        payload = {
+            "workload": {
+                "seq_len": workload.seq_len,
+                "head_dim": workload.head_dim,
+                "n_layers": workload.n_layers,
+                "n_kv_heads": workload.n_kv_heads,
+            },
+            "hardware": {
+                "ram_gb": hardware.ram_gb,
+                "memory_budget_gb": hardware.resolved_budget_gb(),
+                "metal_available": hardware.metal_available,
+            },
+            "result": result.to_dict(),
+        }
+        print(json.dumps(payload, indent=2))
+        return
+
+    print("VeloxQuant-MLX automatic KV-cache configuration")
+    print(f"  seq_len={workload.seq_len}  head_dim={workload.head_dim}  ram={hardware.ram_gb} GB")
+    print(f"  context_regime={result.context_regime}")
+    print(f"  method={result.method}  bit_width={result.bit_width}  group_size={result.group_size}")
+    print(f"  packing_strategy={result.packing_strategy}")
+    print(f"  knobs={result.knobs}")
+    print(f"  kv_fp16_gb≈{result.kv_fp16_gb}  memory_pressure≈{result.memory_pressure_ratio}x")
+    print(f"  rationale: {result.rationale}")
+    if result.warnings:
+        print("  warnings:")
+        for w in result.warnings:
+            print(f"    - {w}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/veloxquant_mlx/tests/tools/__init__.py
+++ b/veloxquant_mlx/tests/tools/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/veloxquant_mlx/tests/tools/test_auto_kv_config_integration.py
+++ b/veloxquant_mlx/tests/tools/test_auto_kv_config_integration.py
@@ -1,0 +1,91 @@
+"""Integration coverage for the auto KV-config selector (#253) against real caches.
+
+Pure-heuristic behaviour of ``select_kv_config`` is covered without MLX in
+``tests/non_metal/test_auto_kv_config.py``; this file only checks that
+``to_kv_cache_config()`` produces a ``KVCacheConfig`` that
+``KVCacheFactory`` actually accepts and can round-trip real tensors
+through, for each method the selector can choose.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx_lm.models.cache import KVCache as _MLXKVCache
+
+from veloxquant_mlx.cache.base import KVCacheFactory
+from veloxquant_mlx.tools.auto_kv_config import (
+    HardwareProfile,
+    WorkloadProfile,
+    select_kv_config,
+    to_kv_cache_config,
+)
+
+
+def _kv(B, H, S, D, seed=0):
+    rng = np.random.default_rng(seed)
+    k = mx.array(rng.standard_normal((B, H, S, D)).astype(np.float16))
+    v = mx.array(rng.standard_normal((B, H, S, D)).astype(np.float16))
+    return k, v
+
+
+@pytest.mark.parametrize(
+    "workload,hardware",
+    [
+        (
+            WorkloadProfile(seq_len=2048, head_dim=128, n_layers=32, n_kv_heads=8),
+            HardwareProfile(ram_gb=64),
+        ),  # short context -> kivi
+        (
+            WorkloadProfile(seq_len=65536, head_dim=128, n_layers=32, n_kv_heads=8),
+            HardwareProfile(ram_gb=64),
+        ),  # long context -> turboquant_rvq
+        (
+            WorkloadProfile(seq_len=200000, head_dim=128, n_layers=80, n_kv_heads=8),
+            HardwareProfile(ram_gb=8),
+        ),  # extreme pressure -> streaming_llm
+    ],
+)
+def test_auto_selected_config_builds_and_round_trips(workload, hardware) -> None:
+    result = select_kv_config(workload, hardware)
+    config = to_kv_cache_config(result, workload)
+
+    assert config.method == result.method
+    assert config.head_dim == workload.head_dim
+
+    cache = KVCacheFactory.create(config)
+    assert isinstance(cache, _MLXKVCache)
+
+    k, v = _kv(1, workload.n_kv_heads, 16, workload.head_dim)
+    ko, vo = cache.update_and_fetch(k, v)
+    mx.eval(ko, vo)
+    assert ko.shape == (1, workload.n_kv_heads, 16, workload.head_dim)
+    assert ko.dtype == mx.float16
+
+
+def test_short_context_pure_mlx_packing_still_builds() -> None:
+    workload = WorkloadProfile(seq_len=2048, head_dim=128, n_layers=32, n_kv_heads=8)
+    result = select_kv_config(workload, HardwareProfile(ram_gb=64, metal_available=False))
+    config = to_kv_cache_config(result, workload)
+
+    assert config.use_metal_kernels is False
+    cache = KVCacheFactory.create(config)
+
+    k, v = _kv(1, workload.n_kv_heads, 8, workload.head_dim)
+    ko, vo = cache.update_and_fetch(k, v)
+    mx.eval(ko, vo)
+    assert ko.shape == (1, workload.n_kv_heads, 8, workload.head_dim)
+
+
+@pytest.mark.parametrize("head_dim", [48, 96, 100, 192, 384])
+def test_odd_head_dims_produce_buildable_configs(head_dim: int) -> None:
+    workload = WorkloadProfile(seq_len=1024, head_dim=head_dim, n_layers=16, n_kv_heads=4)
+    result = select_kv_config(workload, HardwareProfile(ram_gb=32))
+    config = to_kv_cache_config(result, workload)
+
+    cache = KVCacheFactory.create(config)
+    k, v = _kv(1, workload.n_kv_heads, 8, head_dim)
+    ko, vo = cache.update_and_fetch(k, v)
+    mx.eval(ko, vo)
+    assert ko.shape == (1, workload.n_kv_heads, 8, head_dim)

--- a/veloxquant_mlx/tools/auto_kv_config.py
+++ b/veloxquant_mlx/tools/auto_kv_config.py
@@ -1,0 +1,331 @@
+"""Hardware-aware automatic KV-cache quantization configuration (#253).
+
+A single compression configuration is unlikely to be optimal for every
+model, head dimension, sequence length, and hardware configuration. This
+module picks a quantization method, bit-width, group size, and packing
+strategy directly from a description of the workload (expected context
+length, head dimension) and the machine it runs on (unified memory, Metal
+availability) — no manually-chosen "goal" required, unlike
+:mod:`veloxquant_mlx.tools.mac_recommender`, which recommends a method
+from a user-picked goal (max compression, best quality, ...) for a given
+Mac chip/RAM combination.
+
+Pure heuristics, no MLX required at import time (mirrors
+``mac_recommender.py``) — only :func:`to_kv_cache_config` needs MLX
+installed, since it constructs a real
+:class:`~veloxquant_mlx.cache.base.KVCacheConfig`.
+
+Deliberately restricted to methods that need no calibration pass
+(``kivi``, ``turboquant_rvq``, ``streaming_llm``), so the recommendation
+is usable immediately with no setup step the caller has to remember to
+run first.
+
+Example::
+
+    from veloxquant_mlx.tools.auto_kv_config import (
+        HardwareProfile,
+        WorkloadProfile,
+        select_kv_config,
+    )
+
+    result = select_kv_config(
+        WorkloadProfile(seq_len=32768, head_dim=128, n_layers=32, n_kv_heads=8),
+        HardwareProfile(ram_gb=16),
+    )
+    print(result.method, result.bit_width, result.knobs)
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal, Optional
+
+ContextRegime = Literal["short", "medium", "long"]
+PackingStrategy = Literal["metal_auto", "pure_mlx"]
+
+# Context-length thresholds (tokens) separating the three regimes the issue
+# calls out: "short context -> higher precision", "long context -> aggressive
+# compression".
+SHORT_CONTEXT_TOKENS: int = 4096
+LONG_CONTEXT_TOKENS: int = 32768
+
+# Base inlier bit-width per context regime, before any memory-pressure
+# adjustment. Both candidate methods (kivi, turboquant_rvq) accept any
+# bit_width_inlier >= 1.
+_BASE_BITS: dict[ContextRegime, int] = {"short": 4, "medium": 2, "long": 1}
+MIN_BIT_WIDTH: int = 1
+
+# Preferred group size per regime (tokens per min/max quantization group),
+# clamped down to a divisor of head_dim by _select_group_size. Large head
+# dimensions can afford coarser (cheaper) groups; the issue's "large head
+# dim -> specialized block size" is handled by deriving the actual group
+# size from head_dim rather than using this value unclamped.
+_PREFERRED_GROUP_SIZE: dict[ContextRegime, int] = {"short": 64, "medium": 32, "long": 32}
+
+# Memory-pressure ratios (estimated fp16 KV size / memory budget) at which
+# the selector escalates compression.
+PRESSURE_LOWER_BITS: float = 1.0
+PRESSURE_FORCE_MIN_BITS: float = 4.0
+PRESSURE_FORCE_EVICTION: float = 16.0
+
+
+@dataclass(frozen=True)
+class WorkloadProfile:
+    """Describes the inference workload the cache will serve.
+
+    Attributes:
+        seq_len: Expected/typical maximum context length in tokens.
+        head_dim: Attention head dimension.
+        n_layers: Number of transformer layers.
+        n_kv_heads: Number of KV heads (post-GQA/MQA grouping).
+    """
+
+    seq_len: int = 4096
+    head_dim: int = 128
+    n_layers: int = 32
+    n_kv_heads: int = 8
+
+
+@dataclass(frozen=True)
+class HardwareProfile:
+    """Describes the machine the cache will run on.
+
+    Attributes:
+        ram_gb: Total unified memory in GB.
+        memory_budget_gb: GB actually available for the KV cache once
+            weights, activations, and OS overhead are accounted for.
+            ``None`` derives a conservative estimate from ``ram_gb``.
+        metal_available: Whether Metal kernel acceleration can be used.
+            ``True``/``None`` are treated the same ("may be available,
+            detect at runtime"); only an explicit ``False`` disables it,
+            matching ``KVCacheConfig.use_metal_kernels``'s own
+            auto-detect-with-silent-fallback default.
+    """
+
+    ram_gb: float = 16.0
+    memory_budget_gb: Optional[float] = None
+    metal_available: Optional[bool] = True
+
+    def resolved_budget_gb(self) -> float:
+        if self.memory_budget_gb is not None:
+            return self.memory_budget_gb
+        # Conservative: assume weights, activations, and OS overhead claim
+        # the rest, leaving a fraction of unified memory for the KV cache.
+        return max(self.ram_gb * 0.15, 1.0)
+
+
+@dataclass(frozen=True)
+class AutoConfigResult:
+    """A selected configuration plus the reasoning behind it."""
+
+    method: str
+    bit_width: int
+    group_size: Optional[int]
+    packing_strategy: PackingStrategy
+    context_regime: ContextRegime
+    knobs: dict[str, Any]
+    kv_fp16_gb: float
+    memory_pressure_ratio: float
+    rationale: str
+    warnings: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def estimate_kv_fp16_gb(workload: WorkloadProfile) -> float:
+    """Full K+V fp16 cache size in GB at ``workload.seq_len``."""
+    bytes_ = 2 * workload.n_layers * workload.n_kv_heads * workload.head_dim * workload.seq_len * 2
+    return bytes_ / (1024**3)
+
+
+def _context_regime(seq_len: int) -> ContextRegime:
+    if seq_len <= SHORT_CONTEXT_TOKENS:
+        return "short"
+    if seq_len >= LONG_CONTEXT_TOKENS:
+        return "long"
+    return "medium"
+
+
+def _select_group_size(head_dim: int, preferred: int) -> int:
+    """Largest divisor of ``head_dim`` no larger than ``preferred``.
+
+    Group-wise quantization (e.g. KIVI's min/max groups) needs group_size
+    to divide head_dim evenly. Picking the largest such divisor keeps
+    groups as coarse (cheap) as head_dim allows. Falls back to smaller
+    divisors only for awkward head_dim values; group_size=1 (per-channel)
+    always divides head_dim and so is always reachable.
+    """
+    if head_dim <= 0:
+        raise ValueError(f"head_dim must be positive, got {head_dim}")
+    preferred = max(1, min(preferred, head_dim))
+    for candidate in range(preferred, 0, -1):
+        if head_dim % candidate == 0:
+            return candidate
+    return 1  # unreachable: candidate=1 always divides head_dim
+
+
+def select_kv_config(
+    workload: WorkloadProfile,
+    hardware: Optional[HardwareProfile] = None,
+) -> AutoConfigResult:
+    """Pick a KV-cache quantization configuration for a workload + machine.
+
+    Implements the issue's rules directly:
+
+    * short context -> higher precision (higher bit-width)
+    * long context -> aggressive compression (lower bit-width)
+    * large head dim -> specialized (coarser) group size
+    * memory pressure -> lower-bit KV, escalating to a bounded-memory
+      eviction method when no bit-width fits the budget
+
+    Args:
+        workload: Expected context length, head dimension, layer/head counts.
+        hardware: Target machine's memory and Metal availability. Defaults
+            to a generic 16 GB Apple Silicon machine.
+
+    Returns:
+        The selected method, knobs, and the reasoning behind them.
+
+    Raises:
+        ValueError: If ``seq_len`` or ``head_dim`` is not positive.
+    """
+    hardware = hardware or HardwareProfile()
+    if workload.seq_len < 1:
+        raise ValueError(f"seq_len must be >= 1, got {workload.seq_len}")
+    if workload.head_dim < 1:
+        raise ValueError(f"head_dim must be >= 1, got {workload.head_dim}")
+
+    regime = _context_regime(workload.seq_len)
+    kv_fp16_gb = estimate_kv_fp16_gb(workload)
+    budget_gb = hardware.resolved_budget_gb()
+    pressure = kv_fp16_gb / budget_gb if budget_gb > 0 else float("inf")
+
+    warnings: list[str] = []
+    packing: PackingStrategy = "metal_auto" if hardware.metal_available is not False else "pure_mlx"
+
+    if pressure > PRESSURE_FORCE_EVICTION:
+        method, bit_width, group_size, knobs, rationale = _select_eviction_fallback(
+            workload, kv_fp16_gb, budget_gb, pressure, warnings
+        )
+    else:
+        method, bit_width, group_size, knobs, rationale = _select_quantized(
+            workload, regime, pressure, packing, warnings
+        )
+
+    return AutoConfigResult(
+        method=method,
+        bit_width=bit_width,
+        group_size=group_size,
+        packing_strategy=packing,
+        context_regime=regime,
+        knobs=knobs,
+        kv_fp16_gb=round(kv_fp16_gb, 4),
+        memory_pressure_ratio=round(pressure, 4),
+        rationale=rationale,
+        warnings=warnings,
+    )
+
+
+def _select_eviction_fallback(
+    workload: WorkloadProfile,
+    kv_fp16_gb: float,
+    budget_gb: float,
+    pressure: float,
+    warnings: list[str],
+) -> tuple[str, int, Optional[int], dict[str, Any], str]:
+    """No bit-width survives this budget; bound memory outright instead.
+
+    An eviction cache's memory footprint depends only on its window size,
+    not on context length, so it is the only family that stops growing
+    once ``seq_len`` outstrips even the most aggressive quantized method.
+    """
+    bytes_per_token = 2 * workload.n_layers * workload.n_kv_heads * workload.head_dim * 2
+    budget_bytes = budget_gb * (1024**3)
+    window = max(int(budget_bytes / bytes_per_token), 64) if bytes_per_token > 0 else 512
+
+    warnings.append(
+        f"Estimated fp16 KV cache ({kv_fp16_gb:.2f} GB at seq_len={workload.seq_len}) is "
+        f"{pressure:.1f}x the available budget ({budget_gb:.2f} GB); no bit-width alone fits "
+        f"this context. Falling back to streaming_llm, which bounds memory to a fixed window "
+        f"({window} tokens) instead of growing with context length. Expect the model to lose "
+        "track of anything outside the sink + window."
+    )
+    rationale = (
+        f"Memory pressure ({pressure:.1f}x budget) forces a bounded-memory method regardless "
+        "of context regime."
+    )
+    knobs = {"stream_n_sink": 4, "stream_window_size": window}
+    # fp16-resident inside the window: no per-element quantization applies.
+    return "streaming_llm", 16, None, knobs, rationale
+
+
+def _select_quantized(
+    workload: WorkloadProfile,
+    regime: ContextRegime,
+    pressure: float,
+    packing: PackingStrategy,
+    warnings: list[str],
+) -> tuple[str, int, Optional[int], dict[str, Any], str]:
+    bit_width = _BASE_BITS[regime]
+    if pressure > PRESSURE_FORCE_MIN_BITS:
+        bit_width = MIN_BIT_WIDTH
+    elif pressure > PRESSURE_LOWER_BITS:
+        bit_width = min(bit_width, 2)
+
+    if bit_width < _BASE_BITS[regime]:
+        warnings.append(
+            f"Memory pressure ({pressure:.1f}x budget) lowered bit-width from "
+            f"{_BASE_BITS[regime]} ({regime}-context default) to {bit_width}."
+        )
+
+    preferred_group = _PREFERRED_GROUP_SIZE[regime]
+    group_size = _select_group_size(workload.head_dim, preferred_group)
+    if workload.head_dim % preferred_group != 0:
+        warnings.append(
+            f"head_dim={workload.head_dim} does not divide evenly by the preferred group size "
+            f"({preferred_group}); using {group_size} instead."
+        )
+
+    # KIVI's tuning-free min/max quantization is the accuracy-first pick
+    # for short/medium contexts with no memory pressure. Long contexts (or
+    # any memory pressure) move to turboquant_rvq: residual vector
+    # quantization gives better inner-product fidelity at low bit-widths
+    # and is the library's own serving default (see cache/registry.py's
+    # DEFAULT_SERVE_METHOD).
+    if regime == "long" or pressure > PRESSURE_LOWER_BITS:
+        method = "turboquant_rvq"
+        knobs: dict[str, Any] = {"bit_width_inlier": bit_width, "seed": 42}
+    else:
+        method = "kivi"
+        knobs = {"bit_width_inlier": bit_width, "kivi_group_size": group_size}
+
+    rationale = (
+        f"{regime}-context regime ({workload.seq_len} tokens) at {pressure:.2f}x memory "
+        f"pressure -> {method} at {bit_width}-bit"
+        + (f", group_size={group_size}" if method == "kivi" else "")
+        + f"; packing={packing}."
+    )
+    return method, bit_width, group_size, knobs, rationale
+
+
+def to_kv_cache_config(result: AutoConfigResult, workload: WorkloadProfile) -> Any:
+    """Build a real ``KVCacheConfig`` from a selection result.
+
+    Imported lazily so this module stays importable without MLX installed
+    (see module docstring) — only calling this function requires MLX.
+
+    Args:
+        result: Output of :func:`select_kv_config`.
+        workload: The same profile passed to :func:`select_kv_config`.
+
+    Returns:
+        A ``veloxquant_mlx.cache.base.KVCacheConfig`` ready for
+        ``KVCacheFactory.create()`` or ``KVCacheBuilder.for_model()``.
+    """
+    from veloxquant_mlx.cache.base import KVCacheConfig
+
+    kwargs: dict[str, Any] = {"method": result.method, "head_dim": workload.head_dim}
+    kwargs.update(result.knobs)
+    kwargs["use_metal_kernels"] = None if result.packing_strategy == "metal_auto" else False
+    return KVCacheConfig(**kwargs)


### PR DESCRIPTION
Add a lightweight, calibration-free config selector that picks a KV-cache
quantization method, bit-width, group size, and packing strategy directly
from workload (context length, head dimension) and hardware (unified
memory, Metal availability) characteristics, so callers don't have to
hand-tune every KVCacheConfig field themselves.

- veloxquant_mlx/tools/auto_kv_config.py: pure-heuristic selector
  (WorkloadProfile, HardwareProfile, select_kv_config, to_kv_cache_config).
  Short contexts get higher precision (kivi, 4-bit), long contexts get
  aggressive compression (turboquant_rvq, 1-bit), large head dims get a
  coarser group size, and memory pressure lowers bit-width or falls back
  to a bounded-memory eviction method (streaming_llm) when no bit-width
  fits the budget. No MLX import at module scope, mirroring
  tools/mac_recommender.py.
- veloxquant_mlx/cli/autoconfig.py + __main__.py: `veloxquant autoconfig`
  CLI entry point.
- tests/non_metal/test_auto_kv_config.py: pure-Python unit tests (wired
  into non-metal-unit.yml, no MLX required).
- veloxquant_mlx/tests/tools/test_auto_kv_config_integration.py: builds
  real KVCacheFactory caches from the selector's output and round-trips
  tensors through update_and_fetch for every method it can choose.