### PR TITLE
perf: warm KIVI Metal kernels at cache-build time

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -851,7 +851,11 @@ class KVCacheBuilder:
                 f"KVCacheBuilder: n_calib_tokens={cfg.n_calib_tokens} must be >= 1."
             )
 
-        return KVCacheFactory.create(cfg)
+        from veloxquant_mlx.metal._warmup import warmup_for_config
+
+        cache = KVCacheFactory.create(cfg)
+        warmup_for_config(cfg)
+        return cache
 
     @staticmethod
     def for_model(model, config: "KVCacheConfig") -> list:
@@ -951,8 +955,11 @@ class KVCacheBuilder:
         if config.method == "chunkkv" and config.chunkkv_reuse_layers > 1:
             return KVCacheBuilder._build_chunkkv(layers, args, config, _FallbackCache)
 
+        from veloxquant_mlx.metal._warmup import warmup_for_config
+
         caches = []
         attn_idx = 0  # index into b_spec, advances only for attention layers
+        warmed_keys: set = set()
         for i, layer in enumerate(layers):
             attn = getattr(layer, "self_attn", None) or getattr(layer, "attn", None)
             if attn is None:
@@ -979,6 +986,13 @@ class KVCacheBuilder:
                 seed=config.seed + i,
                 store=config.store,
             )
+            # Warm each distinct (head_dim, bit_width) combo once rather than
+            # per layer — most models use the same head_dim across layers, so
+            # this usually compiles a single kernel variant for the whole model.
+            warm_key = (hd, layer_b if not isinstance(layer_b, list) else tuple(layer_b))
+            if warm_key not in warmed_keys:
+                warmup_for_config(layer_cfg)
+                warmed_keys.add(warm_key)
             caches.append(KVCacheFactory.create(layer_cfg))
             attn_idx += 1
         return caches

--- a/veloxquant_mlx/metal/_warmup.py
+++ b/veloxquant_mlx/metal/_warmup.py
@@ -1,0 +1,85 @@
+"""Ahead-of-time Metal kernel warmup, keyed off ``KVCacheConfig``.
+
+Every Metal kernel in this package specializes at compile time on config-fixed
+constants (bit-width, head_dim, group_size, ...) via ``mx.fast.metal_kernel``
+templates/headers, then memoizes the compiled pipeline in a module-level dict
+(see ``_kivi_quant.py``, ``_bit_packing.py``, ``_scalar_quant.py``). That
+compile is lazy: it happens on the first real call, which for a serving
+workload means the first decode step of the first request pays a ~200-800ms
+shader-compile stall (see ``docs-site/docs/guides/metal-kernels.md``).
+
+``warmup_for_config`` runs that first call — with a throwaway, minimally
+shaped input — once, synchronously, at cache-build time (when the config's
+bit-width/head_dim/etc. are already fixed), so the compile cost lands during
+setup instead of mid-generation.
+
+This module only warms kernels with calling conventions fully derivable from
+``KVCacheConfig`` alone. Kernels whose shapes also depend on runtime
+artifacts (e.g. VecInfer's codebook-derived ``sub_dim``/``n_centroids``) are
+left to compile lazily on first real use, same as today.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import mlx.core as mx
+
+from veloxquant_mlx.metal import metal_available
+
+# method -> warmup callable(config) -> None. Best-effort: a warmer raising
+# never propagates past warmup_for_config (see below).
+_WARMERS: dict[str, Callable[[Any], None]] = {}
+
+
+def register_warmer(method: str, warmer: Callable[[Any], None]) -> None:
+    """Register a warmup hook for ``config.method == method``."""
+    _WARMERS[method] = warmer
+
+
+def _warm_kivi(config: Any) -> None:
+    from veloxquant_mlx.metal.kernels import kivi_group_quant_dequant
+
+    d = int(config.head_dim)
+    b = config.bit_width_inlier
+    if isinstance(b, list):
+        return
+    levels = (1 << int(b)) - 1
+    group_size = int(getattr(config, "kivi_group_size", 32))
+    dtype = config.dtype or mx.float16
+
+    # One threadgroup's worth of tokens is enough to compile both axis
+    # variants (keys group along tokens=-2, values group along channels=-1);
+    # the sequence length is never specialized on (see _kivi_quant.py), so
+    # any small S compiles the same pipeline the real traffic will reuse.
+    dummy = mx.zeros((1, 1, group_size, d), dtype=dtype)
+    for axis in (-2, -1):
+        kivi_group_quant_dequant(dummy, axis=axis, group_size=group_size, levels=levels)
+    mx.eval(dummy)
+
+
+register_warmer("kivi", _warm_kivi)
+register_warmer("kivi_sink", _warm_kivi)
+
+
+def warmup_for_config(config: Any) -> None:
+    """Best-effort ahead-of-time compile of this config's Metal kernels.
+
+    No-op if Metal is unavailable, the method has no registered warmer, or
+    the warmer itself raises (warmup is a latency optimization, never a
+    correctness requirement — a failed warmup just means the first real call
+    falls back to the normal lazy-compile path).
+    """
+    if not metal_available():
+        return
+    warmer = _WARMERS.get(getattr(config, "method", None))
+    if warmer is None:
+        return
+    try:
+        warmer(config)
+    except Exception:
+        pass
+
+
+__all__ = ["warmup_for_config", "register_warmer"]

--- a/veloxquant_mlx/tests/metal/test_warmup.py
+++ b/veloxquant_mlx/tests/metal/test_warmup.py
@@ -1,0 +1,97 @@
+"""Tests for ahead-of-time Metal kernel warmup (issue #250).
+
+``warmup_for_config`` exists purely to move a config's first-call shader
+compile from mid-generation (inside ``update_and_fetch``) to cache-build
+time. The tests here check that:
+
+  * warmup actually populates the same kernel cache a real call would use,
+    keyed identically (so it isn't compiling a variant that then goes
+    unused and gets recompiled anyway),
+  * ``KVCacheBuilder.build()`` / ``.for_model()`` trigger it automatically,
+  * it degrades to a silent no-op for unregistered methods, missing Metal,
+    or a warmer that raises — warmup is a latency optimization, never a
+    correctness gate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from veloxquant_mlx.cache.base import KVCacheBuilder, KVCacheConfig
+from veloxquant_mlx.cache.kivi_cache import KIVIKVCache
+from veloxquant_mlx.metal import _kivi_quant, metal_available
+from veloxquant_mlx.metal._warmup import register_warmer, warmup_for_config
+
+pytestmark = pytest.mark.skipif(
+    not metal_available(),
+    reason="Metal compute kernels not available on this build of mlx.",
+)
+
+
+def _make_fake_model(n_layers: int = 2, n_heads: int = 2, head_dim: int = 32) -> SimpleNamespace:
+    hidden_size = n_heads * head_dim
+    layers = [
+        SimpleNamespace(self_attn=SimpleNamespace(head_dim=head_dim)) for _ in range(n_layers)
+    ]
+    args = SimpleNamespace(hidden_size=hidden_size, num_attention_heads=n_heads)
+    return SimpleNamespace(layers=layers, args=args)
+
+
+def test_warmup_matches_real_call_cache_key():
+    _kivi_quant._cache.clear()
+    cfg = KVCacheConfig(method="kivi", head_dim=128, bit_width_inlier=2)
+    warmup_for_config(cfg)
+    warm_keys = set(_kivi_quant._cache.keys())
+    assert warm_keys, "warmup did not compile any KIVI kernel variant"
+
+    cache = KIVIKVCache(cfg)
+    x = mx.random.normal((1, 1, 32, 128)).astype(mx.float16)
+    cache._quant_dequant_along(x, axis=-2)
+    cache._quant_dequant_along(x, axis=-1)
+
+    assert set(_kivi_quant._cache.keys()) == warm_keys
+
+
+def test_warmup_noop_for_unregistered_method():
+    cfg = KVCacheConfig(method="turboquant_prod", head_dim=128, bit_width_inlier=2)
+    # Must not raise even though no warmer is registered for this method.
+    warmup_for_config(cfg)
+
+
+def test_warmup_swallows_warmer_exceptions():
+    def _broken(_config):
+        raise RuntimeError("boom")
+
+    register_warmer("kivi", _broken)
+    try:
+        cfg = KVCacheConfig(method="kivi", head_dim=128, bit_width_inlier=2)
+        warmup_for_config(cfg)  # must not propagate
+    finally:
+        from veloxquant_mlx.metal._warmup import _warm_kivi
+
+        register_warmer("kivi", _warm_kivi)
+
+
+def test_builder_build_warms_kivi_kernels():
+    _kivi_quant._cache.clear()
+    KVCacheBuilder().with_method("kivi").with_head_dim(64).with_bit_width(4).build()
+    assert ("kivi_group_quant", -2, 32, 15, 1e-08, 64, "half") in _kivi_quant._cache
+    assert ("kivi_group_quant", -1, 32, 15, 1e-08, 64, "half") in _kivi_quant._cache
+
+
+def test_for_model_warms_kivi_kernels_once_per_distinct_head_dim():
+    _kivi_quant._cache.clear()
+    model = _make_fake_model(n_layers=3, n_heads=2, head_dim=32)
+    config = KVCacheConfig(method="kivi", bit_width_inlier=2, seed=42)
+
+    caches = KVCacheBuilder.for_model(model, config)
+
+    assert len(caches) == 3
+    assert ("kivi_group_quant", -2, 32, 3, 1e-08, 32, "half") in _kivi_quant._cache
+    assert ("kivi_group_quant", -1, 32, 3, 1e-08, 32, "half") in _kivi_quant._cache
+    # All three layers share head_dim=32, so warmup should compile each
+    # variant exactly once rather than once per layer.
+    assert len(_kivi_quant._cache) == 2


### PR DESCRIPTION
Fixes #250.

## Summary

- Metal kernels in this repo already specialize at compile time on config-fixed constants (bit-width, head_dim, ...) via `mx.fast.metal_kernel` templates, memoized per-variant — but that compile is lazy, happening on the *first real call*. In a serving workload that means the first decode step of the first request pays a ~200-800ms shader-compile stall.
- `KVCacheConfig` already fixes bit-width/head_dim/etc. at build time, before any generation traffic exists, so this moves that first call to `KVCacheBuilder.build()` / `.for_model()` time instead.
- New `veloxquant_mlx/metal/_warmup.py`: a small registry (`register_warmer` / `warmup_for_config`) that replays a throwaway call through a config's kernel(s) so the JIT compile happens during setup. Best-effort — no Metal, an unregistered method, or a warmer exception are all silent no-ops; this is a pure latency optimization, never a correctness gate.
- Wired into `KVCacheBuilder.build()` (warms right after construction) and `.for_model()` (warms once per distinct `(head_dim, bit_width)` combo across layers, not once per layer, since most models share head_dim across all layers).

## Scope note

Issue #250 names `int2/int4/int8`, head-dim, and layout specialization broadly. Investigation found:
- The exact kernels the issue names (`turboquant_bit_pack`/`turboquant_scalar_quantize`/`turboquant_hadamard_quantize`) are implemented, tested, and benchmarked — but have **zero production callers** today. `TurboQuantKVCache` uses a pure-numpy `BitPackBuffer` path instead. Warming dead code would be inert, so this PR doesn't touch them; wiring `TurboQuantKVCache` onto the Metal path is a separate, larger change.
- KIVI's fused group-quant kernel *is* load-bearing (it's the cache's hot `update_and_fetch` path) and has calling conventions fully derivable from `KVCacheConfig` alone, so it's the target here.
- VecInfer/H2O/Keyformer/QFilters kernels also have production callers, but their shapes depend on runtime-loaded codebooks (`sub_dim`, `n_centroids`), not just config — faithful warmup for those needs more care and is left for follow-up.

## Test plan

- [x] New `veloxquant_mlx/tests/metal/test_warmup.py`: warmup produces the exact same kernel-cache key a real call would use; `for_model` dedups warmup by `(head_dim, bit_width)` across layers; no-op behavior for unregistered methods and warmer exceptions.
- [x] Full suite: 2388 passed, 4 skipped (unchanged skip count).
- [x] `ruff check` clean on new/changed files.