### PR TITLE
perf: fuse RVQ quantize and bit-pack into a single Metal kernel

### DIFF
--- a/veloxquant_mlx/cache/turboquant_rvq_cache.py
+++ b/veloxquant_mlx/cache/turboquant_rvq_cache.py
@@ -48,9 +48,13 @@ import mlx.core as mx
 from mlx_lm.models.cache import KVCache as _MLXKVCache
 from mlx_lm.models.cache import create_attention_mask
 
+from veloxquant_mlx.metal import metal_available
 from veloxquant_mlx.quantizers.turboquant_rvq import TurboQuantRVQ
 
 _WORD_BITS = 32
+# rvq_quant_pack's threadgroup-per-vector kernel needs a power-of-two D that
+# fits a whole vector's coordinates in one Metal threadgroup (<= 1024).
+_MAX_FUSED_D = 1024
 
 
 def _pack_indices(idx: Any, bits: int) -> Any:
@@ -177,6 +181,17 @@ class TurboQuantRVQKVCache(_MLXKVCache):
         self._key_bytes_compressed = 0
         self._key_bytes_fp16 = 0
 
+        # Fused quantize+pack kernel (#251) needs a power-of-two head_dim
+        # that fits one Metal threadgroup; degrade to the MLX quantize +
+        # separate _pack_indices path otherwise. Bit-identical either way
+        # (see TurboQuantRVQ.encode_pack), so this is a pure perf knob.
+        self._use_metal_pack: bool = (
+            metal_available()
+            and self._head_dim > 0
+            and (self._head_dim & (self._head_dim - 1)) == 0
+            and self._head_dim <= _MAX_FUSED_D
+        )
+
     def _grow(self, B: int, H: int, num_steps: int) -> None:
         prev = self.offset
         needs_grow = self._packed1 is None or (prev + num_steps) > self._packed1.shape[2]
@@ -212,12 +227,26 @@ class TurboQuantRVQKVCache(_MLXKVCache):
         safe = mx.maximum(norms, mx.array(1e-4, dtype=kdtype))
         k_unit = (k_flat / safe).astype(mx.float16)
 
-        ev = self._quantizer.encode(k_unit)
-        idx1 = ev.indices  # (B*H*S, D) uint8
-        idx2 = ev.signs.astype(mx.uint8)  # (B*H*S, D) uint8, stage-2 codebook indices
+        if self._use_metal_pack:
+            try:
+                p1_flat, p2_flat = self._quantizer.encode_pack(k_unit)
+                p1 = p1_flat.reshape(B, H, S, self._n_words)
+                p2 = p2_flat.reshape(B, H, S, self._n_words)
+            except Exception:
+                # Kernel-side failure (compile error, driver issue): degrade
+                # to the MLX path rather than taking down generation, and
+                # latch off so later calls don't re-pay the failure.
+                self._use_metal_pack = False
+                p1 = p2 = None
+        else:
+            p1 = p2 = None
 
-        p1 = _pack_indices(idx1, self._bits).reshape(B, H, S, self._n_words)
-        p2 = _pack_indices(idx2, self._bits).reshape(B, H, S, self._n_words)
+        if p1 is None:
+            ev = self._quantizer.encode(k_unit)
+            idx1 = ev.indices  # (B*H*S, D) uint8
+            idx2 = ev.signs.astype(mx.uint8)  # (B*H*S, D) uint8, stage-2 codebook indices
+            p1 = _pack_indices(idx1, self._bits).reshape(B, H, S, self._n_words)
+            p2 = _pack_indices(idx2, self._bits).reshape(B, H, S, self._n_words)
         norms_bhs1 = norms.reshape(B, H, S, 1)
 
         self.offset += S

--- a/veloxquant_mlx/codebooks/scalar_codebook.py
+++ b/veloxquant_mlx/codebooks/scalar_codebook.py
@@ -117,5 +117,14 @@ class ScalarCodebook(Codebook):
         """Return centroid array as MLX fp16 array."""
         return self._centroids_mx
 
+    def boundaries_mx(self) -> Any:
+        """Return sorted Voronoi boundaries (midpoints) as MLX fp16 array.
+
+        Shape ``(k - 1,)`` — the same array :meth:`quantize` compares
+        against. Exposed for callers (e.g. fused Metal kernels) that need
+        to replicate ``quantize``'s boundary-count semantics outside MLX.
+        """
+        return self._boundaries_mx
+
     def __repr__(self) -> str:
         return f"ScalarCodebook(k={self._k}, b={self._b})"

--- a/veloxquant_mlx/metal/_rvq_quant_pack.py
+++ b/veloxquant_mlx/metal/_rvq_quant_pack.py
@@ -1,0 +1,148 @@
+"""Fused TurboQuantRVQ quantize+pack Metal kernel (#251).
+
+``TurboQuantRVQKVCache.update_and_fetch`` currently runs the two-stage RVQ
+codebook quantize (stage-1 nearest-centroid, dequantize, residual, stage-2
+nearest-centroid) as MLX broadcast-compare ops, then bit-packs each stage's
+uint8 index array into uint32 words via a *separate* MLX dispatch
+(``_pack_indices`` in ``veloxquant_mlx/cache/turboquant_rvq_cache.py``):
+
+    rotated y -> quantize1 -> dequantize1 -> residual -> quantize2
+              -> [idx1 uint8 buffer] -> pack -> [packed1 uint32]
+              -> [idx2 uint8 buffer] -> pack -> [packed2 uint32]
+
+Every arrow after the rotation is arithmetically a single streaming pass per
+coordinate, but the MLX path materializes two full-size ``(N, D)`` uint8
+index intermediates before packing them. This module fuses stage-1 quantize,
+stage-2 (residual) quantize, and both bit-packs into one Metal dispatch that
+writes directly to the two packed uint32 streams — no intermediate index
+buffers, no separate pack dispatch.
+
+Bit-exactness with the MLX path (``ScalarCodebook.quantize`` +
+``_pack_indices``):
+
+* ``ScalarCodebook.quantize`` computes ``idx = sum(y > boundary_k)`` over
+  sorted Voronoi boundaries (a "boundary-count" quantizer, not a naive
+  argmin) — this kernel reduces the identical ``>`` comparisons in the same
+  order, so ties resolve identically.
+* ``_pack_indices`` packs ``ELEMS_PER_WORD = 32 // bits`` consecutive
+  coordinates into one ``uint32``, LSB-first, zero-padding any partial
+  trailing word — this kernel's packing loop matches that exactly.
+
+Public API:
+  - :func:`rvq_quant_pack`
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+
+_WORD_BITS = 32
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
+
+_cache: dict = {}
+
+# ===========================================================================
+# Metal source — fused stage-1 + stage-2 RVQ quantize, packed to uint32
+# ===========================================================================
+# Grid:        (N * D, 1, 1) — MLX grid = total threads.
+# Threadgroup: (D, 1, 1)     — one threadgroup per rotated vector, D <= 1024.
+#
+# BITS and MAX_D are compile-time #defines/templates: BITS controls the
+# packing width (matching TurboQuantRVQKVCache's single bit_width_inlier used
+# for both RVQ stages), MAX_D sizes the threadgroup index-staging buffers.
+
+_RVQ_QUANT_PACK_SRC = _read_kernel_source("rvq_quant_pack.metal")
+
+
+def _quant_pack_kernel(d: int, bits: int):
+    key = ("rvq_quant_pack", d, bits)
+    if key not in _cache:
+        _cache[key] = mx.fast.metal_kernel(
+            name=f"rvq_quant_pack_d{d}_b{bits}",
+            input_names=["rotated", "centroids1", "boundaries1", "boundaries2"],
+            output_names=["packed1", "packed2"],
+            header=f"#define MAX_D {d}\n#define BITS {bits}u\n",
+            source=_RVQ_QUANT_PACK_SRC,
+            ensure_row_contiguous=True,
+        )
+    return _cache[key]
+
+
+def rvq_quant_pack(
+    rotated: mx.array,
+    centroids1: mx.array,
+    boundaries1: mx.array,
+    boundaries2: mx.array,
+    bits: int,
+) -> tuple[mx.array, mx.array]:
+    """Fused two-stage RVQ quantize, packed directly into uint32 words.
+
+    Args:
+        rotated:     ``[N, D]`` fp16/fp32 rotated key vectors (post-Hadamard
+                     or post-QR rotation — the ``y`` that would otherwise go
+                     into ``ScalarCodebook.quantize``). D must be a power of
+                     two, <= 1024 (Metal threadgroup-size limit).
+        centroids1:  ``[2**bits]`` fp32/fp16 stage-1 sorted centroids.
+        boundaries1: ``[2**bits - 1]`` fp32/fp16 stage-1 sorted Voronoi
+                     boundaries (midpoints between consecutive centroids).
+        boundaries2: ``[2**bits - 1]`` fp32/fp16 stage-2 (Laplacian
+                     residual) sorted Voronoi boundaries.
+        bits:        Bits per stage (1-4). Total packed storage is
+                     ``2 * bits`` bits/coordinate, split across two streams.
+
+    Returns:
+        Tuple ``(packed1, packed2)``, each ``[N, ceil(D / (32 // bits))]``
+        uint32 — bit-identical to
+        ``_pack_indices(codebook1.quantize(rotated), bits)`` and
+        ``_pack_indices(codebook2.quantize(rotated - y_hat1), bits)``
+        respectively.
+    """
+    if rotated.ndim != 2:
+        raise ValueError(f"rvq_quant_pack: rotated must be 2D [N, D], got {rotated.shape}")
+    N, D = rotated.shape
+    if D & (D - 1) != 0:
+        raise ValueError(f"rvq_quant_pack: D={D} must be a power of two")
+    if D > 1024:
+        raise ValueError(f"rvq_quant_pack: D={D} exceeds the 1024 threadgroup-size limit")
+    if not (1 <= bits <= 4):
+        raise ValueError(f"rvq_quant_pack: bits must be 1-4, got {bits}")
+    n_levels = 1 << bits
+    if centroids1.size != n_levels:
+        raise ValueError(
+            f"rvq_quant_pack: expected {n_levels} stage-1 centroids for bits={bits}, "
+            f"got {centroids1.size}"
+        )
+    if boundaries1.size != n_levels - 1 or boundaries2.size != n_levels - 1:
+        raise ValueError(
+            f"rvq_quant_pack: expected {n_levels - 1} boundaries per stage for bits={bits}, "
+            f"got {boundaries1.size} (stage 1), {boundaries2.size} (stage 2)"
+        )
+
+    el_per_word = _WORD_BITS // bits
+    n_words = -(-D // el_per_word)  # ceil div
+
+    kernel = _quant_pack_kernel(D, bits)
+    outputs = kernel(
+        inputs=[
+            rotated.astype(mx.float16),
+            centroids1.astype(mx.float32),
+            boundaries1.astype(mx.float32),
+            boundaries2.astype(mx.float32),
+        ],
+        # MLX grid = total threads; D threads per threadgroup, one per vector.
+        grid=(N * D, 1, 1),
+        threadgroup=(D, 1, 1),
+        output_shapes=[(N, n_words), (N, n_words)],
+        output_dtypes=[mx.uint32, mx.uint32],
+    )
+    return outputs[0], outputs[1]
+
+
+__all__ = ["rvq_quant_pack"]

--- a/veloxquant_mlx/metal/kernels.py
+++ b/veloxquant_mlx/metal/kernels.py
@@ -8,6 +8,7 @@ Kernels are organized into focused submodules:
   _kivi_quant    — Fused KIVI asymmetric group quantize+dequantize round-trip
   _qjl           — QJL encode and inner product
   _rvq_attend    — Fused RVQ decode + attention
+  _rvq_quant_pack — Fused RVQ stage-1+stage-2 quantize, packed to uint32 (#251)
   _comm_vq       — CommVQ RoPE-commutative decode
   _rabitq        — RaBitQ packed Hamming scoring
   _rabitq_attend — Fused RaBitQ asymmetric attention (1-bit K + 4-bit V)
@@ -66,6 +67,9 @@ from veloxquant_mlx.metal._rabitq_values import (
 from veloxquant_mlx.metal._rvq_attend import (
     turboquant_fused_rvq_decode_attend,
 )
+from veloxquant_mlx.metal._rvq_quant_pack import (
+    rvq_quant_pack,
+)
 from veloxquant_mlx.metal._scalar_attend import (
     scalar_fused_decode_attend,
 )
@@ -97,6 +101,7 @@ __all__ = [
     "qjl_encode",
     "qjl_inner_product",
     "turboquant_fused_rvq_decode_attend",
+    "rvq_quant_pack",
     "comm_vq_decode_metal",
     "rabitq_hamming_score",
     "rabitq_fused_attend",

--- a/veloxquant_mlx/metal/src/rvq_quant_pack.metal
+++ b/veloxquant_mlx/metal/src/rvq_quant_pack.metal
@@ -1,0 +1,84 @@
+// rvq_quant_pack.metal
+// Extracted from veloxquant_mlx/metal/_rvq_quant_pack.py (_RVQ_QUANT_PACK_SRC) — see that
+// file's docstring for the algorithm, memory-layout, and threadgroup strategy
+// explanation. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call time;
+// it is NOT separately compiled (see issue #64).
+//
+// Fused TurboQuantRVQ stage-1 + stage-2 quantize, packed directly into uint32
+// words — replaces {codebook1.quantize, codebook1.dequantize, codebook2.quantize,
+// _pack_indices, _pack_indices} (five MLX dispatches, two full-size uint8 index
+// intermediates) with one dispatch and zero intermediate index buffers (#251).
+//
+// Grid:        (N * D, 1, 1) — one thread per (vector, coordinate).
+// Threadgroup: (D, 1, 1)     — one threadgroup per rotated vector `y`.
+//
+// Per thread:
+//   1. idx1 = count(y > boundaries1[k])   for k in [0, K1-1)   -- stage-1 code
+//      (boundary-count quantize: identical to ScalarCodebook.quantize's
+//      broadcast-compare-and-sum, so output matches the MLX path bit-for-bit
+//      on ties as well, since both reduce the same `>` comparisons in the
+//      same left-to-right order over sorted boundaries.)
+//   2. y_hat1 = centroids1[idx1]
+//   3. r1 = y - y_hat1
+//   4. idx2 = count(r1 > boundaries2[k])  for k in [0, K2-1)   -- stage-2 code
+//   5. Each lane's (idx1, idx2) is a BITS-bit code. Lanes cooperatively pack
+//      ELEMS_PER_WORD = 32 / BITS consecutive lanes' codes into one uint32,
+//      LSB-first — the same layout as _pack_indices/mx.quantize. Packing
+//      reads threadgroup memory (each lane's own idx1/idx2, staged there),
+//      so no cross-lane shuffle is needed: lane `w * ELEMS_PER_WORD` writes
+//      word `w` by looping its ELEMS_PER_WORD group.
+//
+// D is not required to be a multiple of ELEMS_PER_WORD; out-of-range lanes
+// within the final word contribute zero bits (matching _pack_indices's
+// zero-padding of the trailing partial word).
+
+    threadgroup uint8_t idx1_buf[MAX_D];
+    threadgroup uint8_t idx2_buf[MAX_D];
+
+    uint n    = threadgroup_position_in_grid.x;
+    uint lane = thread_position_in_threadgroup.x;
+    uint D    = uint(MAX_D);
+
+    constexpr uint K1 = (1u << BITS) - 1u;  // stage-1 boundary count
+    constexpr uint K2 = (1u << BITS) - 1u;  // stage-2 boundary count
+
+    float y = float(rotated[n * D + lane]);
+
+    uint idx1 = 0u;
+    for (uint k = 0; k < K1; ++k) {
+        idx1 += uint(y > float(boundaries1[k]));
+    }
+    float y_hat1 = float(centroids1[idx1]);
+    float r1 = y - y_hat1;
+
+    uint idx2 = 0u;
+    for (uint k = 0; k < K2; ++k) {
+        idx2 += uint(r1 > float(boundaries2[k]));
+    }
+
+    idx1_buf[lane] = uint8_t(idx1);
+    idx2_buf[lane] = uint8_t(idx2);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    constexpr uint ELEMS_PER_WORD = 32u / BITS;
+    constexpr uint MASK           = (1u << BITS) - 1u;
+
+    // Each word's first lane packs its ELEMS_PER_WORD-wide group. Surplus
+    // lanes (D not a multiple of ELEMS_PER_WORD, or lane belongs to a
+    // partial trailing group) are simply idle here.
+    if (lane % ELEMS_PER_WORD == 0u) {
+        uint word_idx = lane / ELEMS_PER_WORD;
+        uint w1 = 0u;
+        uint w2 = 0u;
+        for (uint j = 0; j < ELEMS_PER_WORD; ++j) {
+            uint d = lane + j;
+            if (d < D) {
+                w1 |= (uint(idx1_buf[d]) & MASK) << (j * BITS);
+                w2 |= (uint(idx2_buf[d]) & MASK) << (j * BITS);
+            }
+        }
+        uint n_words = (D + ELEMS_PER_WORD - 1u) / ELEMS_PER_WORD;
+        packed1[n * n_words + word_idx] = w1;
+        packed2[n * n_words + word_idx] = w2;
+    }

--- a/veloxquant_mlx/quantizers/turboquant_rvq.py
+++ b/veloxquant_mlx/quantizers/turboquant_rvq.py
@@ -153,6 +153,37 @@ class TurboQuantRVQ(Quantizer):
             signs=idx2_int8,
         )
 
+    def encode_pack(self, x: Any) -> tuple[Any, Any]:
+        """Encode and bit-pack in one fused Metal dispatch (#251).
+
+        Equivalent to bit-packing :meth:`encode`'s ``indices``/``signs``
+        streams separately, but skips materializing either uint8 index
+        array: stage-1 quantize, dequantize, residual, stage-2 quantize,
+        and both bit-packs run in a single kernel over the rotated input.
+
+        Args:
+            x: Array of shape (batch, d), fp16.
+
+        Returns:
+            Tuple ``(packed1, packed2)``, each
+            ``(batch, ceil(d / (32 // b)))`` uint32 — bit-identical to
+            ``_pack_indices(idx1, b)``/``_pack_indices(idx2, b)`` for the
+            ``idx1``/``idx2`` that :meth:`encode` would have produced.
+        """
+        from veloxquant_mlx.metal.kernels import rvq_quant_pack
+
+        if x.ndim == 1:
+            x = x[None]
+
+        y = self._rotation.apply(x)  # (batch, d)
+        return rvq_quant_pack(
+            y,
+            self._codebook1.centroids_mx(),
+            self._codebook1.boundaries_mx(),
+            self._codebook2.boundaries_mx(),
+            self._b,
+        )
+
     def decode(self, ev: EncodedVector) -> Any:
         """Reconstruct x_hat = unrotate(y_hat1 + y_hat2)."""
         import mlx.core as mx

--- a/veloxquant_mlx/tests/metal/test_rvq_quant_pack.py
+++ b/veloxquant_mlx/tests/metal/test_rvq_quant_pack.py
@@ -1,0 +1,231 @@
+"""Parity + benchmark tests for the fused RVQ quantize+pack kernel (#251).
+
+``TurboQuantRVQKVCache.update_and_fetch`` previously ran stage-1 quantize,
+dequantize, residual, stage-2 quantize as MLX ops, then bit-packed each
+stage's uint8 index array via a *separate* ``_pack_indices`` MLX dispatch --
+five MLX kernel launches and two full-size ``(N, D)`` uint8 intermediates
+per flush. ``rvq_quant_pack`` fuses all of that (post-rotation) into one
+Metal dispatch with no intermediate index buffers.
+
+Must reproduce ``_pack_indices(ScalarCodebook.quantize(...), bits)``
+**bit-for-bit**, not merely within tolerance -- see
+:meth:`TurboQuantRVQ.encode_pack`'s docstring for why (same bit-exactness
+bar as the KIVI fused kernel, #164).
+"""
+
+from __future__ import annotations
+
+import time
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from veloxquant_mlx.cache.turboquant_rvq_cache import _pack_indices
+from veloxquant_mlx.metal import metal_available
+from veloxquant_mlx.metal.kernels import rvq_quant_pack
+from veloxquant_mlx.quantizers.turboquant_rvq import TurboQuantRVQ
+
+pytestmark = pytest.mark.skipif(
+    not metal_available(),
+    reason="Metal compute kernels not available on this build of mlx.",
+)
+
+
+def _reference_pack(quantizer: TurboQuantRVQ, x: mx.array, bits: int):
+    ev = quantizer.encode(x)
+    p1 = _pack_indices(ev.indices, bits)
+    p2 = _pack_indices(ev.signs.astype(mx.uint8), bits)
+    return p1, p2
+
+
+# ---------------------------------------------------------------------------
+# Parity vs the MLX reference path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("D", [8, 16, 32, 64, 128, 256])
+@pytest.mark.parametrize("bits", [1, 2, 3, 4])
+@pytest.mark.parametrize("N", [1, 5, 33])
+def test_rvq_quant_pack_bit_exact(D, bits, N):
+    q = TurboQuantRVQ(d=D, b=bits, seed=D + bits + N, use_hadamard=True)
+    rng = np.random.default_rng(D * 100 + bits * 10 + N)
+    x = mx.array(rng.standard_normal((N, D)).astype(np.float16))
+
+    p1_ref, p2_ref = _reference_pack(q, x, bits)
+    p1_got, p2_got = q.encode_pack(x)
+    mx.eval(p1_ref, p2_ref, p1_got, p2_got)
+
+    assert p1_got.shape == p1_ref.shape
+    assert p2_got.shape == p2_ref.shape
+    assert p1_got.dtype == mx.uint32
+    np.testing.assert_array_equal(np.array(p1_got), np.array(p1_ref))
+    np.testing.assert_array_equal(np.array(p2_got), np.array(p2_ref))
+
+
+def test_rvq_quant_pack_direct_kernel_entry_point():
+    """Exercise rvq_quant_pack() directly (not via TurboQuantRVQ.encode_pack)."""
+    D, bits, N = 128, 2, 17
+    q = TurboQuantRVQ(d=D, b=bits, seed=0, use_hadamard=True)
+    rng = np.random.default_rng(0)
+    x = mx.array(rng.standard_normal((N, D)).astype(np.float16))
+
+    p1_ref, p2_ref = _reference_pack(q, x, bits)
+
+    y = q._rotation.apply(x)
+    p1_got, p2_got = rvq_quant_pack(
+        y,
+        q._codebook1.centroids_mx(),
+        q._codebook1.boundaries_mx(),
+        q._codebook2.boundaries_mx(),
+        bits,
+    )
+    mx.eval(p1_ref, p2_ref, p1_got, p2_got)
+    np.testing.assert_array_equal(np.array(p1_got), np.array(p1_ref))
+    np.testing.assert_array_equal(np.array(p2_got), np.array(p2_ref))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: cache update_and_fetch takes the fused path and dequantizes
+# correctly (round-trip through the real EncodedVector-based decode).
+# ---------------------------------------------------------------------------
+
+
+def test_rvq_cache_fused_path_matches_mlx_path():
+    from veloxquant_mlx import KVCacheConfig, KVCacheFactory
+
+    cfg = KVCacheConfig(method="turboquant_rvq", head_dim=128, bit_width_inlier=2, seed=0)
+    c_fused = KVCacheFactory.create(cfg)
+    c_mlx = KVCacheFactory.create(cfg)
+    c_mlx._use_metal_pack = False
+    assert c_fused._use_metal_pack is True
+
+    rng = np.random.default_rng(5)
+    keys = mx.array(rng.standard_normal((1, 4, 40, 128)).astype(np.float16))
+    vals = mx.array(rng.standard_normal((1, 4, 40, 128)).astype(np.float16))
+
+    k_fused, v_fused = c_fused.update_and_fetch(keys, vals)
+    k_mlx, v_mlx = c_mlx.update_and_fetch(keys, vals)
+    mx.eval(k_fused, v_fused, k_mlx, v_mlx)
+
+    np.testing.assert_array_equal(np.array(k_fused), np.array(k_mlx))
+    np.testing.assert_array_equal(np.array(v_fused), np.array(v_mlx))
+    assert c_fused.compressed_key_bytes == c_mlx.compressed_key_bytes
+
+
+def test_rvq_quant_pack_rejects_bad_shapes():
+    D, bits = 128, 2
+    q = TurboQuantRVQ(d=D, b=bits, seed=0, use_hadamard=True)
+    y = mx.zeros((4, D), dtype=mx.float16)
+
+    with pytest.raises(ValueError, match="must be 2D"):
+        rvq_quant_pack(
+            y[None],
+            q._codebook1.centroids_mx(),
+            q._codebook1.boundaries_mx(),
+            q._codebook2.boundaries_mx(),
+            bits,
+        )
+    with pytest.raises(ValueError, match="power of two"):
+        bad_y = mx.zeros((4, 24), dtype=mx.float16)
+        rvq_quant_pack(
+            bad_y,
+            mx.zeros(4, dtype=mx.float32),
+            mx.zeros(3, dtype=mx.float32),
+            mx.zeros(3, dtype=mx.float32),
+            bits,
+        )
+    with pytest.raises(ValueError, match="bits must be"):
+        rvq_quant_pack(
+            y,
+            q._codebook1.centroids_mx(),
+            q._codebook1.boundaries_mx(),
+            q._codebook2.boundaries_mx(),
+            5,
+        )
+    with pytest.raises(ValueError, match="centroids"):
+        rvq_quant_pack(
+            y,
+            mx.zeros(3, dtype=mx.float32),
+            q._codebook1.boundaries_mx(),
+            q._codebook2.boundaries_mx(),
+            bits,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark: fused kernel latency vs the multi-stage MLX pipeline.
+# ---------------------------------------------------------------------------
+
+
+def test_rvq_quant_pack_benchmark(capsys):
+    """Latency, effective bandwidth, and speedup vs the multi-stage MLX path.
+
+    Follows the interleaved-sampling methodology of
+    ``test_kivi_quant.py::test_kivi_quant_benchmark``: a rotating pool of
+    distinct inputs (so MLX cannot reuse work across calls) and interleaved
+    A/B sampling (so thermal drift lands evenly on both paths), reporting
+    medians.
+    """
+    D, bits = 128, 2
+    q = TurboQuantRVQ(d=D, b=bits, seed=0, use_hadamard=True)
+    rng = np.random.default_rng(0)
+    rows = []
+
+    for N in (64, 1024, 8192):
+        pool = [mx.array(rng.standard_normal((N, D)).astype(np.float16)) for _ in range(10)]
+        mx.eval(*pool)
+
+        def _mlx_path(i, _pool=pool):
+            x = _pool[i % len(_pool)]
+            return _reference_pack(q, x, bits)
+
+        def _fused(i, _pool=pool):
+            return q.encode_pack(_pool[i % len(_pool)])
+
+        for i in range(20):  # warm + compile, outside all timing
+            mx.eval(*_mlx_path(i))
+            mx.eval(*_fused(i))
+        mx.synchronize()
+
+        def _sample(fn, off, iters=30):
+            mx.synchronize()
+            t0 = time.perf_counter()
+            for i in range(iters):
+                mx.eval(*fn(i + off))
+            mx.synchronize()
+            return (time.perf_counter() - t0) / iters * 1e3
+
+        s_mlx, s_fused = [], []
+        for rep in range(7):
+            s_mlx.append(_sample(_mlx_path, rep * 5))
+            s_fused.append(_sample(_fused, rep * 5))
+
+        ms_mlx = float(np.median(s_mlx))
+        ms_fused = float(np.median(s_fused))
+        # Effective bandwidth: fp32 rotated input read once, two uint32
+        # packed streams written; the MLX path additionally round-trips two
+        # full uint8 (N, D) index buffers through global memory.
+        n_words = -(-D // (32 // bits))
+        fused_bytes = N * D * 4 + 2 * N * n_words * 4
+        mlx_bytes = fused_bytes + 2 * N * D  # + two uint8 index intermediates
+        gbps_fused = fused_bytes / (ms_fused * 1e-3) / 1e9
+        gbps_mlx = mlx_bytes / (ms_mlx * 1e-3) / 1e9
+        rows.append((N, ms_mlx, ms_fused, gbps_mlx, gbps_fused))
+
+    with capsys.disabled():
+        print(f"\n# RVQ quantize+pack  |  D={D} bits={bits}  |  MLX {mx.__version__}")
+        print("| N | MLX ms | Fused ms | speedup | MLX GB/s | Fused GB/s |")
+        print("|---|--------|----------|---------|----------|------------|")
+        for N, ms_mlx, ms_fused, gbps_mlx, gbps_fused in rows:
+            print(
+                f"| {N} | {ms_mlx:.4f} | {ms_fused:.4f} | {ms_mlx / ms_fused:.2f}x "
+                f"| {gbps_mlx:.2f} | {gbps_fused:.2f} |"
+            )
+        print(
+            "\nMedians of interleaved samples over a rotating input pool (avoids\n"
+            "flattering either path with repeated-input reuse). GB/s is nominal\n"
+            "traffic (input read once + packed streams written), not a hardware\n"
+            "counter; the MLX column additionally charges the two full-size\n"
+            "uint8 index intermediates the fused kernel never materializes."
+        )


### PR DESCRIPTION
## Summary

Closes #251.

- `TurboQuantRVQKVCache.update_and_fetch` previously ran stage-1 quantize, dequantize, residual, stage-2 quantize as separate MLX ops, then bit-packed each stage's uint8 index array into uint32 words via a *separate* `_pack_indices` MLX dispatch — five MLX kernel launches and two full-size `(N, D)` uint8 index intermediates per flush.
- Adds `rvq_quant_pack` (`veloxquant_mlx/metal/src/rvq_quant_pack.metal` + `veloxquant_mlx/metal/_rvq_quant_pack.py`): a single Metal dispatch, one threadgroup per rotated vector, that runs both codebook stages' boundary-count quantize and packs both index streams directly into `uint32` words — no intermediate index buffers.
- Wired in as `TurboQuantRVQ.encode_pack()`, called from the cache with a Metal-availability + power-of-two-head_dim fallback to the existing MLX path (mirrors `KIVIKVCache`'s `_use_metal` latch-off-on-failure pattern). Bit-identical either way, so enabling/disabling the kernel can never change a cached value.
- Adds `ScalarCodebook.boundaries_mx()` accessor needed to pass Voronoi boundaries into the kernel.

## Verification

- Parity: `rvq_quant_pack` output matches `_pack_indices(ScalarCodebook.quantize(...), bits)` **bit-for-bit** across `D ∈ {8,16,32,64,128,256}`, `bits ∈ {1,2,3,4}`, multiple batch sizes and seeds (72 parametrized cases).
- End-to-end: `TurboQuantRVQKVCache.update_and_fetch` with the fused path produces identical dequantized keys/values and identical byte accounting as the MLX path.
- Full existing suite (2464 tests) still passes.

## Benchmark (kernel latency + effective bandwidth vs the multi-stage MLX path, D=128, bits=2, interleaved rotating-input-pool sampling)

| N | MLX ms | Fused ms | speedup | MLX GB/s | Fused GB/s |
|---|--------|----------|---------|----------|------------|
| 64 | 0.259 | 0.177 | 1.47x | 0.21 | 0.21 |
| 1024 | 0.353 | 0.236 | 1.49x | 2.42 | 2.50 |
| 8192 | 1.538 | 0.621 | 2.48x | 4.43 | 7.60 |

Speedup grows with block size, as expected — the fusion removes memory-traffic-bound intermediates, so the win scales with bytes moved (same shape as the KIVI fused-kernel results in #164/#250).

## Test plan

- [x] `pytest veloxquant_mlx/tests/metal/test_rvq_quant_pack.py -q` — parity, direct-entry-point, cache end-to-end, input-validation, and benchmark tests all pass
- [x] `pytest veloxquant_mlx/tests/cache/test_turboquant_rvq_cache.py -q` — existing cache tests unaffected
- [x] `pytest veloxquant_mlx/tests/ -q` — full suite (2464 passed, 4 skipped, unrelated)
- [x] `ruff check` clean on all new/changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)