### PR TITLE
Add experimental row-owned streaming prefill attention kernel (research, negative result)

### DIFF
--- a/scripts/streaming_prefill_benchmark.py
+++ b/scripts/streaming_prefill_benchmark.py
@@ -1,0 +1,251 @@
+"""Benchmark harness: experimental streaming prefill vs flash_prefill vs MLX native.
+
+Compares the row-owned streaming kernel family (metal/_experimental_streaming_prefill.py)
+against:
+  - flash_prefill_attend       — the existing tiled simdgroup_matrix kernel (unmodified).
+  - mx.fast.scaled_dot_product_attention(mask="causal") — MLX's own tuned SDPA.
+
+across D in {32, 64, 128} and S in {64, 128, 256, 512, 1024, 2048, 4096, 8192},
+for both S_q == S_kv (full prefill) and one S_q < S_kv (cache-continuation)
+case per D. Uses the same timing methodology as scripts/flash_prefill_harness.py
+(``_bench``: warmup + N_ITER timed mx.eval() calls, median/p50/p95 reported) and
+the same error-metric helper (``_metrics``) for max/mean abs error, relative
+error, cosine similarity, and NaN/Inf flags vs a numpy fp32 reference.
+
+Usage:
+  python scripts/streaming_prefill_benchmark.py
+  python scripts/streaming_prefill_benchmark.py --n_iter 30 --skip-large
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+# See scripts/flash_prefill_harness.py's identical comment: insert the repo
+# root first so local edits under active development are what get imported,
+# not a frozen veloxquant_mlx copy that might be shadowing it in site-packages.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import mlx.core as mx
+import numpy as np
+
+from veloxquant_mlx.metal.kernels import flash_prefill_attend, streaming_prefill_attend
+
+N_WARMUP, N_ITER = 10, 30
+
+STREAMING_IMPLS = [
+    "streaming",
+    "streaming_block2",
+    "streaming_block4",
+    "streaming_block8",
+    "streaming_multirow",
+]
+
+ALL_KERNELS = ["flash_prefill", "mlx_native"] + STREAMING_IMPLS
+
+
+# ---------------------------------------------------------------------------
+# Reference + metrics (same convention as scripts/flash_prefill_harness.py)
+# ---------------------------------------------------------------------------
+
+
+def _reference_flash(q, k, v, scale):
+    S_q, S_kv = q.shape[2], k.shape[2]
+    scores = np.einsum("bhqd,bhsd->bhqs", q.astype(np.float32), k.astype(np.float32)) * scale
+    q_abs = (S_kv - S_q) + np.arange(S_q)
+    kv_pos = np.arange(S_kv)
+    mask = kv_pos[None, :] > q_abs[:, None]
+    scores = np.where(mask, -np.inf, scores)
+    row_has_any = np.isfinite(scores).any(axis=-1, keepdims=True)
+    scores = scores - np.where(row_has_any, scores.max(axis=-1, keepdims=True), 0.0)
+    w = np.where(np.isfinite(scores), np.exp(scores), 0.0)
+    denom = w.sum(axis=-1, keepdims=True)
+    w = np.where(denom > 0, w / np.where(denom > 0, denom, 1.0), 0.0)
+    return np.einsum("bhqs,bhsd->bhqd", w, v.astype(np.float32)).astype(np.float32)
+
+
+def _make_inputs(B, H, S_q, S_kv, D, seed=0):
+    rng = np.random.default_rng(seed)
+    q = rng.standard_normal((B, H, S_q, D)).astype(np.float16)
+    k = rng.standard_normal((B, H, S_kv, D)).astype(np.float16)
+    v = rng.standard_normal((B, H, S_kv, D)).astype(np.float16)
+    scale = np.array([1.0 / np.sqrt(D)], dtype=np.float32)
+    return q, k, v, scale
+
+
+def _metrics(got: np.ndarray, expected: np.ndarray) -> dict:
+    diff = got - expected
+    abs_err = np.abs(diff)
+    n_nan = int(np.isnan(got).sum())
+    n_inf = int(np.isinf(got).sum())
+    denom = np.linalg.norm(expected.reshape(-1))
+    rel_err = float(np.linalg.norm(diff.reshape(-1)) / denom) if denom > 0 else 0.0
+    return {
+        "max_abs_err": float(abs_err.max()) if abs_err.size else 0.0,
+        "mean_abs_err": float(abs_err.mean()) if abs_err.size else 0.0,
+        "rel_err": rel_err,
+        "n_nan": n_nan,
+        "n_inf": n_inf,
+    }
+
+
+def _bench(fn, n_warmup: int = N_WARMUP, n_iter: int = N_ITER) -> tuple[float, float, float]:
+    """Median/p50/p95 wall-clock seconds per call. mx.eval() forces GPU sync."""
+    for _ in range(n_warmup):
+        mx.eval(fn())
+    samples = []
+    for _ in range(n_iter):
+        t0 = time.perf_counter()
+        mx.eval(fn())
+        samples.append(time.perf_counter() - t0)
+    samples.sort()
+    n = len(samples)
+    median = samples[n // 2]
+    p95 = samples[min(n - 1, int(n * 0.95))]
+    return median, median, p95
+
+
+# ---------------------------------------------------------------------------
+# Kernel call wrappers
+# ---------------------------------------------------------------------------
+
+
+def _make_callable(kernel: str, q, k, v, scale_arr, scale_scalar):
+    if kernel == "flash_prefill":
+        return lambda: flash_prefill_attend(q, k, v, scale_arr)
+    if kernel == "mlx_native":
+        return lambda: mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=scale_scalar, mask="causal"
+        )
+    if kernel in STREAMING_IMPLS:
+        return lambda: streaming_prefill_attend(q, k, v, scale_arr, implementation=kernel)
+    raise ValueError(kernel)
+
+
+# ---------------------------------------------------------------------------
+# Main sweep
+# ---------------------------------------------------------------------------
+
+
+def run(n_iter: int, skip_large: bool) -> list[dict]:
+    Ds = [32, 64, 128]
+    S_values = [64, 128, 256, 512, 1024, 2048, 4096, 8192]
+    if skip_large:
+        S_values = [s for s in S_values if s <= 2048]
+
+    B, H = 1, 8
+    results: list[dict] = []
+
+    print(f"[bench] device=Apple M4 GPU  N_WARMUP={N_WARMUP} N_ITER={n_iter}")
+    print(f"[bench] kernels: {ALL_KERNELS}")
+    print()
+
+    for D in Ds:
+        # Shapes to test per D: full prefill (S_q==S_kv) for every S, plus
+        # exactly one cache-continuation (S_q<S_kv) case.
+        shapes = [(S, S, "full") for S in S_values]
+        shapes.append((max(1, S_values[len(S_values) // 2] // 4), S_values[len(S_values) // 2], "cache_cont"))
+
+        for S_q, S_kv, kind in shapes:
+            # Reduce iteration count for very large sequences to keep the
+            # sweep tractable — noted explicitly rather than silently.
+            eff_iter = n_iter if S_kv <= 2048 else max(5, n_iter // max(1, S_kv // 2048))
+
+            q_np, k_np, v_np, scale_np = _make_inputs(B, H, S_q, S_kv, D, seed=D + S_q + S_kv)
+            expected = _reference_flash(q_np, k_np, v_np, scale_np)
+
+            q = mx.array(q_np)
+            k = mx.array(k_np)
+            v = mx.array(v_np)
+            scale_arr = mx.array(scale_np, dtype=mx.float32)
+            scale_scalar = float(scale_np[0])
+            mx.eval(q, k, v, scale_arr)
+
+            row = {"D": D, "S_q": S_q, "S_kv": S_kv, "kind": kind, "B": B, "H": H}
+            flash_median = None
+            mlx_median = None
+
+            for kernel in ALL_KERNELS:
+                try:
+                    fn = _make_callable(kernel, q, k, v, scale_arr, scale_scalar)
+                    out = fn()
+                    mx.eval(out)
+                    got = np.array(out, dtype=np.float32)
+                    m = _metrics(got, expected)
+
+                    median, _, p95 = _bench(fn, N_WARMUP, eff_iter)
+                    tok_per_s = (B * H * S_q) / median if median > 0 else float("nan")
+
+                    row[kernel] = {
+                        "median_ms": median * 1000.0,
+                        "p95_ms": p95 * 1000.0,
+                        "tokens_per_s": tok_per_s,
+                        **m,
+                    }
+                    if kernel == "flash_prefill":
+                        flash_median = median
+                    if kernel == "mlx_native":
+                        mlx_median = median
+                except Exception as e:  # noqa: BLE001 — record failure, keep sweeping
+                    row[kernel] = {"error": str(e)}
+
+            for kernel in ALL_KERNELS:
+                entry = row.get(kernel, {})
+                if isinstance(entry, dict) and "median_ms" in entry:
+                    if flash_median:
+                        entry["speedup_vs_flash"] = flash_median / (entry["median_ms"] / 1000.0)
+                    if mlx_median:
+                        entry["speedup_vs_mlx"] = mlx_median / (entry["median_ms"] / 1000.0)
+
+            results.append(row)
+
+            print(f"=== D={D} S_q={S_q} S_kv={S_kv} ({kind}) ===")
+            print(
+                f"  {'kernel':<20} {'median(ms)':>11} {'p95(ms)':>9} {'tok/s':>12} "
+                f"{'vs_flash':>9} {'vs_mlx':>8} {'max_err':>10} {'mean_err':>10} {'nan/inf':>8}"
+            )
+            for kernel in ALL_KERNELS:
+                entry = row.get(kernel, {})
+                if "error" in entry:
+                    print(f"  {kernel:<20} ERROR: {entry['error'][:80]}")
+                    continue
+                vs_flash = entry.get("speedup_vs_flash")
+                vs_mlx = entry.get("speedup_vs_mlx")
+                print(
+                    f"  {kernel:<20} {entry['median_ms']:>11.4f} {entry['p95_ms']:>9.4f} "
+                    f"{entry['tokens_per_s']:>12.1f} "
+                    f"{(f'{vs_flash:.2f}x' if vs_flash else '-'):>9} "
+                    f"{(f'{vs_mlx:.2f}x' if vs_mlx else '-'):>8} "
+                    f"{entry['max_abs_err']:>10.3e} {entry['mean_abs_err']:>10.3e} "
+                    f"{entry['n_nan']}/{entry['n_inf']:>5}"
+                )
+            print()
+
+    return results
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n_iter", type=int, default=N_ITER)
+    ap.add_argument(
+        "--skip-large",
+        action="store_true",
+        help="Skip S in {4096, 8192} to keep the sweep fast.",
+    )
+    ap.add_argument("--out", type=str, default=None, help="Optional path to save JSON results.")
+    args = ap.parse_args()
+
+    results = run(args.n_iter, args.skip_large)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"Saved {len(results)} rows to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/veloxquant_mlx/metal/__init__.py
+++ b/veloxquant_mlx/metal/__init__.py
@@ -73,6 +73,8 @@ def __getattr__(name: str):
         "keyformer_fused_evict",
         "qfilters_fused_evict",
         "qfilters_score",
+        "flash_prefill_attend",
+        "streaming_prefill_attend",
     }
     if name in _turboquant_names:
         from . import kernels as _k
@@ -105,4 +107,6 @@ __all__ = [
     "keyformer_fused_evict",
     "qfilters_fused_evict",
     "qfilters_score",
+    "flash_prefill_attend",
+    "streaming_prefill_attend",
 ]

--- a/veloxquant_mlx/metal/_experimental_streaming_prefill.py
+++ b/veloxquant_mlx/metal/_experimental_streaming_prefill.py
@@ -1,0 +1,156 @@
+"""Row-owned streaming causal prefill attention — experimental alternative.
+
+From-scratch alternative architecture to ``flash_prefill_attend``
+(``_flash_prefill.py`` / ``flash_prefill.metal``), built to compare a
+genuinely different computational decomposition against the conventional
+tiled ``simdgroup_matrix`` FlashAttention-style kernel. See
+``metal/src/experimental_streaming_prefill_ARCHITECTURE.md`` for the full
+design rationale — in short: ownership is by QUERY ROW (one SIMD-group
+owns one query row for the whole kernel), each lane owns a fixed
+stride-32 slab of head-dims, K/V stream directly from device memory one
+(or a small block of) token(s) at a time, and there is zero threadgroup
+memory / zero barriers anywhere in this kernel family.
+
+This module is purely additive: it does not modify ``_flash_prefill.py``,
+``flash_prefill.metal``, or any existing export. ``flash_prefill_attend``
+remains the production kernel used elsewhere in the codebase.
+
+Public API:
+  - :func:`streaming_prefill_attend`
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+
+
+def _read_kernel_source(filename: str) -> str:
+    """Read a standalone .metal kernel source file from metal/src/."""
+    return (Path(__file__).parent / "src" / filename).read_text()
+
+
+_STREAMING_PREFILL_SRC = _read_kernel_source("experimental_streaming_prefill.metal")
+
+_cache: dict = {}
+
+# implementation name -> (kv_block, rows_per_threadgroup)
+_IMPLEMENTATIONS = {
+    "streaming": (1, 1),
+    "streaming_block2": (2, 1),
+    "streaming_block4": (4, 1),
+    "streaming_block8": (8, 1),
+    # multirow uses the block=1 single-row algorithm (per the architecture
+    # note's Step 8/kernel-family description) but dispatches 4 independent
+    # SIMD-groups per threadgroup purely for occupancy/dispatch granularity.
+    "streaming_multirow": (1, 4),
+}
+
+_MULTIROW_ROWS_PER_TG = 4
+
+
+def _stream_kernel(d: int, kv_block: int, rows_per_tg: int):
+    key = ("streaming_prefill_attend", d, kv_block, rows_per_tg)
+    if key not in _cache:
+        _cache[key] = mx.fast.metal_kernel(
+            name=f"stream_prefill_attend_d{d}_kb{kv_block}_rtg{rows_per_tg}",
+            input_names=["q", "k", "v", "scale"],
+            output_names=["out"],
+            source=_STREAMING_PREFILL_SRC,
+            ensure_row_contiguous=True,
+        )
+    return _cache[key]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def streaming_prefill_attend(
+    q: mx.array,  # [B, H, S_q, D]   fp16 — queries
+    k: mx.array,  # [B, H, S_kv, D]  fp16 — keys, plain (not compressed)
+    v: mx.array,  # [B, H, S_kv, D]  fp16 — values, plain (not compressed)
+    scale: mx.array,  # [1]              fp32 — softmax scale (1/sqrt(D))
+    implementation: str = "streaming",
+) -> mx.array:
+    """Row-owned streaming causal attention over plain fp16 K/V.
+
+    An experimental, from-scratch alternative to ``flash_prefill_attend``:
+    instead of tiled ``simdgroup_matrix`` matmuls staged through
+    threadgroup memory, one SIMD-group (32 lanes) owns one query row for
+    the whole kernel and streams K/V directly from device memory, with
+    the online-softmax update redundantly (but bit-identically) computed
+    in every lane. Zero threadgroup memory, zero barriers. See
+    ``metal/src/experimental_streaming_prefill_ARCHITECTURE.md``.
+
+    Always causal: queries align to the tail of the KV cache
+    (``q_abs = (S_kv - S_q) + q_pos``), matching ``flash_prefill_attend``'s
+    convention exactly, so the two kernels are directly comparable.
+
+    Args:
+        q, k, v: fp16 tensors, shapes as above.
+        scale: fp32 ``[1]`` softmax scale.
+        implementation: one of ``"streaming"`` (block=1 baseline),
+            ``"streaming_block2"``, ``"streaming_block4"``,
+            ``"streaming_block8"`` (KV-blocked variants — 2/4/8 KV tokens
+            per online-softmax update), or ``"streaming_multirow"`` (4
+            independent SIMD-groups per threadgroup, block=1 algorithm,
+            zero cross-SIMD-group communication).
+
+    Returns:
+        ``[B, H, S_q, D]`` fp16 attention output.
+    """
+    if implementation not in _IMPLEMENTATIONS:
+        raise ValueError(
+            f"streaming_prefill_attend: unknown implementation={implementation!r}; "
+            f"must be one of {sorted(_IMPLEMENTATIONS)}"
+        )
+    if q.ndim != 4:
+        raise ValueError(f"streaming_prefill_attend: q must be 4D, got {q.shape}")
+    B, H, S_q, D = q.shape
+    if D % 32 != 0:
+        raise ValueError(
+            f"streaming_prefill_attend: D={D} must be a multiple of 32 "
+            "(one head-dim slab per lane in the owning SIMD-group)"
+        )
+    if D > 128:
+        raise ValueError(
+            f"streaming_prefill_attend: D={D} exceeds the 128 limit "
+            "(only D in {32, 64, 128} is specialized)"
+        )
+    if k.shape[:2] != (B, H) or k.shape[3] != D:
+        raise ValueError(f"streaming_prefill_attend: k must be [B, H, S_kv, {D}], got {k.shape}")
+    S_kv = k.shape[2]
+    if v.shape != (B, H, S_kv, D):
+        raise ValueError(f"streaming_prefill_attend: v must be {(B, H, S_kv, D)}, got {v.shape}")
+
+    kv_block, rows_per_tg = _IMPLEMENTATIONS[implementation]
+
+    n_qblk = (S_q + rows_per_tg - 1) // rows_per_tg
+    n_tg = B * H * n_qblk
+
+    outputs = _stream_kernel(D, kv_block, rows_per_tg)(
+        inputs=[
+            q.astype(mx.float16),
+            k.astype(mx.float16),
+            v.astype(mx.float16),
+            scale.reshape(1).astype(mx.float32),
+        ],
+        template=[
+            ("MAX_D", D),
+            ("KV_BLOCK", kv_block),
+            ("ROWS_PER_TG", rows_per_tg),
+        ],
+        # MLX grid = total threads; one (32 x ROWS_PER_TG) threadgroup per
+        # (b, h, query-row-block).
+        grid=(n_tg * 32, rows_per_tg, 1),
+        threadgroup=(32, rows_per_tg, 1),
+        output_shapes=[(B, H, S_q, D)],
+        output_dtypes=[mx.float16],
+    )
+    return outputs[0]
+
+
+__all__ = ["streaming_prefill_attend"]

--- a/veloxquant_mlx/metal/kernels.py
+++ b/veloxquant_mlx/metal/kernels.py
@@ -18,6 +18,9 @@ Kernels are organized into focused submodules:
   _keyformer_evict — Fused Keyformer eviction: Gumbel-regularized argmin + evict + RoPE-remap
   _qfilters_evict — Fused Q-Filters eviction: projection scoring + block top-k compaction
   _crosskv_rope    — Cross-model KV transfer: fused source→target RoPE re-encode
+  _flash_prefill   — Plain-fp16 causal flash attention (tiled simdgroup_matrix)
+  _experimental_streaming_prefill — Row-owned streaming causal attention
+                     (experimental alternative decomposition to _flash_prefill)
 """
 
 from __future__ import annotations
@@ -31,6 +34,9 @@ from veloxquant_mlx.metal._comm_vq import (
 )
 from veloxquant_mlx.metal._crosskv_rope import (
     crosskv_rope_recode,
+)
+from veloxquant_mlx.metal._experimental_streaming_prefill import (
+    streaming_prefill_attend,
 )
 from veloxquant_mlx.metal._flash_prefill import (
     flash_prefill_attend,
@@ -112,6 +118,7 @@ __all__ = [
     "rabitq_pack_values",
     "rabitq_prefill_attend",
     "flash_prefill_attend",
+    "streaming_prefill_attend",
     "h2o_fused_evict",
     "keyformer_fused_evict",
     "qfilters_fused_evict",

--- a/veloxquant_mlx/metal/src/experimental_streaming_prefill.metal
+++ b/veloxquant_mlx/metal/src/experimental_streaming_prefill.metal
@@ -1,0 +1,171 @@
+// experimental_streaming_prefill.metal
+// Row-owned streaming causal prefill attention — see
+// experimental_streaming_prefill_ARCHITECTURE.md in this directory for the
+// full design rationale. Read as plain text at import time via
+// _read_kernel_source() in _experimental_streaming_prefill.py and
+// JIT-compiled by mx.fast.metal_kernel at call time (same pattern as
+// flash_prefill.metal — see that file's header comment).
+//
+// This is a genuinely different computational decomposition from
+// flash_prefill.metal: ownership is by QUERY ROW, not by matrix tile.
+// One SIMD-group (32 lanes) owns exactly one query row for the whole
+// kernel invocation; each lane owns a fixed, disjoint stride-32 slab of
+// head-dims (D/32 dims/lane). There is no simdgroup_matrix usage, no
+// threadgroup array staging K/V/scores/weights/output, and no
+// threadgroup_barrier / simdgroup_barrier anywhere in this file.
+//
+// Template parameters:
+//   MAX_D       — head dimension: 32, 64, or 128 (must be a multiple of 32).
+//   KV_BLOCK    — KV tokens processed per loop iteration before one
+//                 online-softmax update: 1, 2, 4, or 8.
+//   ROWS_PER_TG — SIMD-groups (independent query rows) per threadgroup:
+//                 1 for the single-row kernels, 4 for the "multirow"
+//                 kernel. Purely a dispatch-granularity knob — no data is
+//                 shared between SIMD-groups in the same threadgroup, so
+//                 no barrier is needed even when ROWS_PER_TG > 1.
+//
+// Grid:        (B * H * n_qblk * 32, ROWS_PER_TG, 1) — MLX grid = threads.
+// Threadgroup: (32, ROWS_PER_TG, 1).
+// n_qblk = ceil(S_q / ROWS_PER_TG); threadgroup tgx owns ROWS_PER_TG
+// consecutive query rows (one per SIMD-group) within one (b, h).
+//
+// Causal alignment: q_abs = (S_kv - S_q) + q_index; KV slot j is visible
+// iff j <= q_abs. The KV loop bound is `visible = min(S_kv, q_abs + 1)`
+// itself — future KV tokens are never loaded or computed, no masking.
+//
+// Precision: Q/K/V loaded fp16, widened to float for all arithmetic.
+// Output accumulator is float, cast to half only at the final write.
+// scale is pre-folded with log2(e) so the softmax inner loop uses
+// fast::exp2 instead of exp (matches flash_prefill.metal / MLX's steel
+// attention kernel).
+//
+// Note: the dims-per-lane loop index is named `dk` (not `k`) throughout —
+// `k` is the MLX-generated device-buffer pointer name for the Keys input
+// (from input_names=["q","k","v","scale"]), so reusing `k` as a loop
+// variable would shadow it and break every `k[...]` load.
+
+constexpr uint D             = uint(MAX_D);
+constexpr uint KB            = uint(KV_BLOCK);
+constexpr uint NSG           = uint(ROWS_PER_TG);
+constexpr uint DIMS_PER_LANE = D / 32u;
+constexpr float kLog2E       = 1.4426950408889634f;
+
+uint tgx  = threadgroup_position_in_grid.x;
+uint lane = thread_position_in_threadgroup.x;
+uint sg   = thread_position_in_threadgroup.y;
+
+uint H     = uint(q_shape[1]);
+uint S_q   = uint(q_shape[2]);
+uint S_kv  = uint(k_shape[2]);
+
+uint n_qblk = (S_q + NSG - 1u) / NSG;
+
+// Threadgroup tgx owns one (b, h) pair and one block of NSG consecutive
+// query rows: qblk = tgx % n_qblk, h = (tgx / n_qblk) % H, b = tgx / (n_qblk*H).
+uint qblk  = tgx % n_qblk;
+uint h_idx = (tgx / n_qblk) % H;
+uint b_idx = tgx / (n_qblk * H);
+
+uint g_row = qblk * NSG + sg;  // this SIMD-group's global query row index
+
+uint q_base  = ((b_idx * H + h_idx) * S_q) * D;
+uint kv_base = ((b_idx * H + h_idx) * S_kv) * D;
+
+// scale pre-folded with log2(e): softmax uses exp2 instead of exp.
+float sc = scale[0] * kLog2E;
+
+// Queries align to the tail of the KV cache (fused_sdpa.metal convention,
+// same as flash_prefill.metal).
+int q_align = int(S_kv) - int(S_q);
+
+// Per-lane owned output-dim accumulators (registers only — no
+// threadgroup memory). o[dk] holds owned dim `lane + dk*32`.
+float o[DIMS_PER_LANE];
+for (uint dk = 0; dk < DIMS_PER_LANE; ++dk) o[dk] = 0.0f;
+
+float m = -INFINITY;
+float l = 0.0f;
+
+if (g_row < S_q) {
+    int q_abs = q_align + int(g_row);
+    // Pre-load this lane's owned Q dims (widened to float) once — reused
+    // for every KV token's dot product.
+    float q_local[DIMS_PER_LANE];
+    for (uint dk = 0; dk < DIMS_PER_LANE; ++dk) {
+        q_local[dk] = float(q[q_base + g_row * D + (lane + dk * 32u)]);
+    }
+
+    if (q_abs >= 0) {
+        uint visible = uint(metal::min(int(S_kv) - 1, q_abs)) + 1u;
+
+        uint j0 = 0u;
+        // ---- Blocked main loop: KB independent KV tokens per iteration ----
+        for (; j0 + KB <= visible; j0 += KB) {
+            float scores[KB];
+            for (uint b = 0; b < KB; ++b) {
+                uint slot = j0 + b;
+                float local_dot = 0.0f;
+                for (uint dk = 0; dk < DIMS_PER_LANE; ++dk) {
+                    float kv = float(k[kv_base + slot * D + (lane + dk * 32u)]);
+                    local_dot += q_local[dk] * kv;
+                }
+                scores[b] = metal::simd_sum(local_dot) * sc;
+            }
+
+            // One online-softmax update over this KB-wide mini-block.
+            float block_max = scores[0];
+            for (uint b = 1; b < KB; ++b) block_max = metal::max(block_max, scores[b]);
+            float m_new = metal::max(m, block_max);
+            float alpha = metal::fast::exp2(m - m_new);
+
+            float p[KB];
+            float p_sum = 0.0f;
+            for (uint b = 0; b < KB; ++b) {
+                p[b] = metal::fast::exp2(scores[b] - m_new);
+                p_sum += p[b];
+            }
+
+            for (uint dk = 0; dk < DIMS_PER_LANE; ++dk) {
+                float acc = o[dk] * alpha;
+                for (uint b = 0; b < KB; ++b) {
+                    uint slot = j0 + b;
+                    float vv = float(v[kv_base + slot * D + (lane + dk * 32u)]);
+                    acc += p[b] * vv;
+                }
+                o[dk] = acc;
+            }
+
+            l = l * alpha + p_sum;
+            m = m_new;
+        }
+
+        // ---- Tail: remaining KV tokens (visible % KB != 0), one at a time ----
+        for (uint slot = j0; slot < visible; ++slot) {
+            float local_dot = 0.0f;
+            for (uint dk = 0; dk < DIMS_PER_LANE; ++dk) {
+                float kv = float(k[kv_base + slot * D + (lane + dk * 32u)]);
+                local_dot += q_local[dk] * kv;
+            }
+            float score = metal::simd_sum(local_dot) * sc;
+
+            float m_new = metal::max(m, score);
+            float alpha = metal::fast::exp2(m - m_new);
+            float p = metal::fast::exp2(score - m_new);
+
+            for (uint dk = 0; dk < DIMS_PER_LANE; ++dk) {
+                float vv = float(v[kv_base + slot * D + (lane + dk * 32u)]);
+                o[dk] = o[dk] * alpha + p * vv;
+            }
+
+            l = l * alpha + p;
+            m = m_new;
+        }
+    }
+
+    // ---- Write out (l == 0 only for the causally-unreachable case,
+    // guarded for safety/symmetry with flash_prefill.metal). ----
+    for (uint dk = 0; dk < DIMS_PER_LANE; ++dk) {
+        out[q_base + g_row * D + (lane + dk * 32u)] =
+            half(l > 0.0f ? o[dk] / l : 0.0f);
+    }
+}

--- a/veloxquant_mlx/metal/src/experimental_streaming_prefill_ARCHITECTURE.md
+++ b/veloxquant_mlx/metal/src/experimental_streaming_prefill_ARCHITECTURE.md
@@ -1,0 +1,160 @@
+# Architecture note: row-owned streaming causal prefill attention
+
+Status: design note, written before implementation (Step 2 of the research
+process). Companion kernel file: `experimental_streaming_prefill.metal`.
+
+## 1. What this is not
+
+`flash_prefill.metal` decomposes attention as a sequence of tiled matrix
+multiplications: a `BQ x BK` score tile computed via `simdgroup_half8x8`
+MAC fragments, staged through `q_tile` / `kv_tile` / `s_tile` / `w_tile` /
+`p_tile` / `out_tile` threadgroup arrays, with `threadgroup_barrier` /
+`simdgroup_barrier` round trips between each stage. Ownership is by
+**matrix tile**: a SIMD-group owns an 8-row slice of Q and cooperates with
+sibling SIMD-groups (via shared `kv_tile`) to consume a 16-wide KV chunk.
+
+None of that structure is reused here. No threadgroup array in this file
+plays the role of `q_tile`, `kv_tile`, `s_tile`, `w_tile`, `p_tile`, or
+`out_tile` under a different name, and there is no `simdgroup_matrix`
+usage at all in the primary kernel family.
+
+## 2. Ownership model
+
+Ownership is by **query row**, not by tile:
+
+- One SIMD-group (32 lanes) owns exactly one query row `Q_i` for the
+  entire kernel invocation.
+- Within that SIMD-group, each lane owns a fixed, disjoint subset of the
+  D head-dimensions — for both Q/K (dot-product) and V/O (output)
+  purposes. The same lane->dimension mapping is used for both, so a
+  lane's registers never need to be shuffled to a different lane's
+  dimension range.
+- K and V rows are streamed directly from device memory, one (or a small
+  block of) KV token(s) at a time. There is no shared on-chip staging of
+  K/V for reuse across SIMD-groups — each SIMD-group re-reads K/V
+  independently from `device` memory, relying on Apple Silicon's GPU L2
+  cache (K/V rows for nearby query rows are re-read shortly after one
+  another, and TBDR GPUs have relatively large L2s versus discrete
+  parts) rather than explicit threadgroup reuse.
+- The online-softmax state (`m`, `l`) is redundantly computed
+  **identically** in every lane of the SIMD-group (all lanes see the same
+  broadcast `score` from `simd_sum`, so all lanes' running `m`/`l` stay
+  bit-identical without any cross-lane broadcast). This trades a few
+  redundant scalar FLOPs per lane for the removal of one
+  `simd_shuffle`/lane-0-owns-state indirection — evaluated against the
+  alternative (lane 0 owns state, broadcasts `alpha`/`p`) in the
+  benchmarks; see the results section of the final report for which won.
+
+## 3. Lane -> dimension mapping
+
+For head dimension D, with 32 lanes per SIMD-group, each lane owns
+`D/32` dimensions (only defined for D that's a multiple of 32 in the
+primary family — D=128 -> 4/lane, D=64 handled by a half-populated
+SIMD-group mapping described below, D=32 -> 1/lane):
+
+- D=128: lane `l` owns `{l, l+32, l+64, l+96}` — four strided dims.
+- D=64: lane `l` owns `{l, l+32}` for `l < 32` — two strided dims (all 32
+  lanes active, stride-32 mapping, structurally the same shape as D=128
+  with 2 slabs instead of 4).
+- D=32: lane `l` owns `{l}` — one dimension, all 32 lanes active,
+  contiguous coalesced access.
+
+This keeps the **same stride-32 slab pattern** across all three
+specializations (`D/32` slabs of 32 contiguous dimensions each), so the
+per-KV-token load is always a sequence of 32-lane-coalesced loads:
+lane `l` reads dimension `l`, then `l+32`, then `l+64`, then `l+96` — each
+individual load is fully coalesced across the SIMD-group (consecutive
+lanes -> consecutive addresses), which is the memory-access goal called
+out in the spec, and it generalizes uniformly instead of special-casing
+D=64 with 16 active lanes.
+
+## 4. Per-KV-token inner loop (block=1 baseline)
+
+```text
+score_local = sum over owned dims d: float(Q[d]) * float(K_j[d])
+score = simd_sum(score_local) * scale * log2(e)      // all lanes get the full score
+
+m_new  = max(m, score)
+alpha  = exp2(m - m_new)
+p      = exp2(score - m_new)
+
+for each owned dim d:
+    o[d] = o[d] * alpha + p * float(V_j[d])
+
+l = l * alpha + p
+m = m_new
+```
+
+No threadgroup memory, no barrier, anywhere in this loop. `simd_sum` is
+the only cross-lane primitive, and it is a single SIMD-native reduction
+instruction on Apple GPUs (no shared-memory round trip).
+
+## 5. Causal skipping
+
+Each SIMD-group computes `q_abs = (S_kv - S_q) + q_index` once, and the KV
+loop runs `for j in 0 ..< min(S_kv, q_abs + 1)`. Future KV tokens are
+never loaded, never dot-producted, never masked — the loop bound itself
+is the mask. This is a structural consequence of row ownership: since a
+whole SIMD-group tracks one query row's causal frontier, the bound is a
+single scalar, not a per-element predicate.
+
+## 6. Kernel family
+
+1. **`stream_prefill_d{32,64,128}`** — one SIMD-group per query row,
+   block=1 (baseline, Step 3).
+2. **`stream_prefill_d{32,64,128}_block{2,4,8}`** — same row ownership,
+   but the KV loop is unrolled to compute `simd_sum` for 2/4/8 KV tokens
+   before doing one online-softmax update over that mini-block. This
+   amortizes the softmax-update overhead (a handful of scalar ops) over
+   more arithmetic per loop iteration, and gives the compiler more
+   independent `simd_sum` reductions to interleave/hide latency across
+   (Step 6-7).
+3. **`stream_prefill_multirow_d{32,64,128}`** — a threadgroup of 4
+   independent SIMD-groups, each running the exact block=1 (or best
+   block-size) algorithm above on its own query row. The threadgroup
+   dimension exists purely to change dispatch granularity (fewer, fatter
+   threadgroups -> better occupancy scheduling), not to share any data;
+   there is no barrier in this kernel because no SIMD-group ever reads
+   another's state (Step 8).
+
+All variants share the same lane/dimension ownership convention from
+Section 3 and the same causal loop-bound convention from Section 5.
+
+## 7. Precision
+
+- Q/K/V are loaded as fp16 (matching the existing kernel's input dtype)
+  and immediately widened to `float` for the dot product and softmax
+  arithmetic — same precision strategy as `flash_prefill.metal`, which
+  keeps the online-softmax accumulator in float even though tiles are
+  half.
+- Output accumulator `o[d]` is `float`, converted to `half` only at the
+  final write.
+- `scale` is pre-folded with `log2(e)` exactly as in `flash_prefill.metal`
+  so the softmax inner loop uses `exp2` instead of `exp` (cheaper on
+  Apple GPU ALUs, matches MLX's own steel attention kernel).
+
+## 8. What "no threadgroup memory" means precisely here
+
+The block=1 and block-N single-row kernels use **zero** `threadgroup`
+declarations and **zero** barriers. The `multirow` kernel also uses zero
+`threadgroup` declarations/barriers — grouping SIMD-groups into a
+threadgroup for dispatch purposes requires no shared memory at all, since
+nothing is shared.
+
+## 9. Expected tradeoffs (hypotheses to test, not conclusions)
+
+- Loss: no `simdgroup_matrix` (AMX-style matrix-unit) utilization at all
+  — every FLOP here is scalar ALU + `simd_sum`. At large D and large
+  compute-bound S ranges, this is expected to lose to the tiled kernel's
+  matrix-unit throughput.
+- Gain: zero threadgroup traffic/barriers, fully register-resident state,
+  minimal control overhead, and literally zero wasted work on causally
+  masked KV tokens (vs. the tiled kernel's block-level skip, which still
+  computes a few masked-but-loaded slots at the causal diagonal).
+- Cross-over: expected to depend on D (higher D = more matrix-unit
+  advantage for the tiled kernel, since arithmetic intensity per
+  `simd_sum` chain grows) and S (very small S may favor the streaming
+  kernel's lower fixed overhead / no threadgroup setup cost).
+
+This is exactly the hypothesis the benchmarking step must confirm or
+refute — no claim of a winner is made here.

--- a/veloxquant_mlx/tests/metal/test_experimental_streaming_prefill.py
+++ b/veloxquant_mlx/tests/metal/test_experimental_streaming_prefill.py
@@ -1,0 +1,278 @@
+"""Parity tests for the experimental row-owned streaming prefill kernel.
+
+Reference is standard causal self-attention in numpy float32: exact
+Q@K^T dot scores, causal mask aligned to the tail of the KV cache
+(``q_abs = (S_kv - S_q) + q_pos``, same convention as
+``flash_prefill_attend`` / ``rabitq_prefill_attend(causal=True)`` /
+``fused_sdpa.metal``), softmax, then matmul against V.
+
+Tolerance: ``atol=3e-2, rtol=3e-2`` — the same tolerance used by
+``test_flash_prefill.py``. Both kernels store Q/K/V as fp16 and widen to
+float for arithmetic (this kernel widens per-scalar in registers rather
+than through half 8x8 MAC fragments, so empirically it is *more* accurate
+than the tiled kernel — observed max abs error in exploratory runs was
+~1e-3, an order of magnitude under this bound — but the bound is kept at
+the existing kernel's 3e-2 for an apples-to-apples comparison and to
+leave headroom for fp16 storage-precision effects at longer sequences /
+larger D, rather than fitting the tolerance to a single measurement).
+
+Every implementation variant (``streaming``, ``streaming_block2``,
+``streaming_block4``, ``streaming_block8``, ``streaming_multirow``) is
+checked against the same reference and shape matrix.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import mlx.core as mx
+import pytest
+
+from veloxquant_mlx.metal import metal_available
+from veloxquant_mlx.metal.kernels import streaming_prefill_attend
+
+pytestmark = pytest.mark.skipif(
+    not metal_available(),
+    reason="Metal compute kernels not available on this build of mlx.",
+)
+
+_IMPLEMENTATIONS = [
+    "streaming",
+    "streaming_block2",
+    "streaming_block4",
+    "streaming_block8",
+    "streaming_multirow",
+]
+
+_ATOL, _RTOL = 3e-2, 3e-2
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation (numpy float32) — identical convention to
+# test_flash_prefill.py's _reference_flash.
+# ---------------------------------------------------------------------------
+
+
+def _reference_flash(q, k, v, scale):
+    S_q, S_kv = q.shape[2], k.shape[2]
+    scores = np.einsum("bhqd,bhsd->bhqs", q.astype(np.float32), k.astype(np.float32)) * scale
+    q_abs = (S_kv - S_q) + np.arange(S_q)
+    kv_pos = np.arange(S_kv)
+    mask = kv_pos[None, :] > q_abs[:, None]  # [S_q, S_kv]
+    scores = np.where(mask, -np.inf, scores)
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    w = np.exp(scores)
+    w = w / w.sum(axis=-1, keepdims=True)
+    return np.einsum("bhqs,bhsd->bhqd", w, v.astype(np.float32)).astype(np.float32)
+
+
+def _make_inputs(B, H, S_q, S_kv, D, seed=0):
+    rng = np.random.default_rng(seed)
+    q = rng.standard_normal((B, H, S_q, D)).astype(np.float16)
+    k = rng.standard_normal((B, H, S_kv, D)).astype(np.float16)
+    v = rng.standard_normal((B, H, S_kv, D)).astype(np.float16)
+    scale = np.array([1.0 / np.sqrt(D)], dtype=np.float32)
+    return q, k, v, scale
+
+
+def _run_kernel(q, k, v, scale, implementation):
+    out = streaming_prefill_attend(
+        mx.array(q), mx.array(k), mx.array(v), mx.array(scale), implementation=implementation
+    )
+    mx.eval(out)
+    return np.array(out, dtype=np.float32)
+
+
+def _assert_no_nan_inf(got: np.ndarray, name: str) -> None:
+    assert not np.isnan(got).any(), f"{name}: NaN in output"
+    assert not np.isinf(got).any(), f"{name}: Inf in output"
+
+
+# ---------------------------------------------------------------------------
+# Parity sweep across all implementations x D x representative S_q/S_kv
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("implementation", _IMPLEMENTATIONS)
+@pytest.mark.parametrize("D", [32, 64, 128])
+@pytest.mark.parametrize("S_q", [1, 8, 33, 256])
+@pytest.mark.parametrize("S_kv", [8, 33, 2048])
+@pytest.mark.parametrize("BH", [(1, 1), (2, 2)])
+def test_streaming_prefill_attend_parity(implementation, D, S_q, S_kv, BH):
+    if S_q > S_kv:
+        pytest.skip("causal alignment requires S_q <= S_kv")
+    B, H = BH
+    args = _make_inputs(B, H, S_q, S_kv, D, seed=D + S_q + S_kv + B * H)
+    expected = _reference_flash(*args)
+    got = _run_kernel(*args, implementation=implementation)
+    assert got.shape == (B, H, S_q, D)
+    _assert_no_nan_inf(got, implementation)
+    np.testing.assert_allclose(got, expected, atol=_ATOL, rtol=_RTOL)
+
+
+# ---------------------------------------------------------------------------
+# First / middle / last query token behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("implementation", _IMPLEMENTATIONS)
+@pytest.mark.parametrize("D", [32, 64, 128])
+def test_streaming_prefill_first_middle_last_token(implementation, D):
+    """S_q == S_kv self-attention: check the first row (sees only itself),
+    a middle row, and the last row (sees the full KV range) individually."""
+    B, H = 1, 2
+    args = _make_inputs(B, H, 65, 65, D, seed=500 + D)
+    expected = _reference_flash(*args)
+    got = _run_kernel(*args, implementation=implementation)
+    _assert_no_nan_inf(got, implementation)
+    for row, label in [(0, "first"), (32, "middle"), (64, "last")]:
+        np.testing.assert_allclose(
+            got[:, :, row, :], expected[:, :, row, :], atol=_ATOL, rtol=_RTOL,
+            err_msg=f"{implementation} D={D} {label} token (row={row}) mismatch",
+        )
+
+
+# ---------------------------------------------------------------------------
+# S_q == 1 (single new token — decode-shaped prefill call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("implementation", _IMPLEMENTATIONS)
+@pytest.mark.parametrize("D", [32, 64, 128])
+@pytest.mark.parametrize("S_kv", [1, 17, 500])
+def test_streaming_prefill_s_q_one(implementation, D, S_kv):
+    args = _make_inputs(1, 2, 1, S_kv, D, seed=600 + D + S_kv)
+    expected = _reference_flash(*args)
+    got = _run_kernel(*args, implementation=implementation)
+    assert got.shape == (1, 2, 1, D)
+    _assert_no_nan_inf(got, implementation)
+    np.testing.assert_allclose(got, expected, atol=_ATOL, rtol=_RTOL)
+
+
+# ---------------------------------------------------------------------------
+# S_q < S_kv: cache-continuation shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("implementation", _IMPLEMENTATIONS)
+@pytest.mark.parametrize("D", [32, 64, 128])
+def test_streaming_prefill_cache_continuation(implementation, D):
+    """S_kv > S_q: queries are new tokens appended after an existing
+    (uncompressed) prefix — the KV-cache-continuation shape."""
+    args = _make_inputs(1, 2, 16, 500, D, seed=700 + D)
+    expected = _reference_flash(*args)
+    got = _run_kernel(*args, implementation=implementation)
+    _assert_no_nan_inf(got, implementation)
+    np.testing.assert_allclose(got, expected, atol=_ATOL, rtol=_RTOL)
+
+
+# ---------------------------------------------------------------------------
+# Non-multiple-of-block-size sequence lengths (S=33, S=127) — exercises the
+# blocked variants' tail loop (visible % KV_BLOCK != 0) explicitly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("implementation", _IMPLEMENTATIONS)
+@pytest.mark.parametrize("D", [32, 64, 128])
+@pytest.mark.parametrize("S", [33, 127])
+def test_streaming_prefill_non_multiple_of_block(implementation, D, S):
+    args = _make_inputs(1, 3, S, S, D, seed=800 + D + S)
+    expected = _reference_flash(*args)
+    got = _run_kernel(*args, implementation=implementation)
+    _assert_no_nan_inf(got, implementation)
+    np.testing.assert_allclose(got, expected, atol=_ATOL, rtol=_RTOL)
+
+
+# ---------------------------------------------------------------------------
+# Non-multiple-of-ROWS_PER_TG query-block sizes (multirow uses 4 rows/tg)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("implementation", _IMPLEMENTATIONS)
+@pytest.mark.parametrize("S", [1, 5, 31, 33, 63, 65, 97])
+def test_streaming_prefill_query_block_partial(implementation, S):
+    """S_q not a multiple of 4 (ROWS_PER_TG for multirow): every valid row
+    must still be written correctly."""
+    D = 64
+    args = _make_inputs(1, 1, S, S, D, seed=900 + S)
+    expected = _reference_flash(*args)
+    got = _run_kernel(*args, implementation=implementation)
+    assert got.shape == (1, 1, S, D)
+    _assert_no_nan_inf(got, implementation)
+    np.testing.assert_allclose(got, expected, atol=_ATOL, rtol=_RTOL)
+
+
+# ---------------------------------------------------------------------------
+# Causal masking sanity: perturbing a future key must not change earlier
+# rows' output — proof the loop-bound-as-mask isn't accidentally attending
+# to slots past q_abs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("implementation", _IMPLEMENTATIONS)
+def test_streaming_prefill_causal_masks_future(implementation):
+    B, H, S, D = 1, 2, 40, 64
+    q, k, v, scale = _make_inputs(B, H, S, S, D, seed=21)
+    out1 = _run_kernel(q, k, v, scale, implementation)
+
+    k2, v2 = k.copy(), v.copy()
+    k2[:, :, -1, :] = 1000.0  # perturb the last (future-for-every-row-but-the-last) key
+    v2[:, :, -1, :] = 1000.0
+    out2 = _run_kernel(q, k2, v2, scale, implementation)
+
+    # Every row except the very last one must be unaffected.
+    np.testing.assert_allclose(out1[:, :, :-1, :], out2[:, :, :-1, :], atol=1e-3)
+    assert not np.allclose(out1[:, :, -1, :], out2[:, :, -1, :])
+
+
+# ---------------------------------------------------------------------------
+# Cross-implementation agreement: all variants must agree with each other
+# (not just with the numpy reference) to a tight tolerance, since they are
+# all computing the identical algorithm at different block granularities.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("D", [32, 64, 128])
+def test_streaming_prefill_variants_agree_with_each_other(D):
+    args = _make_inputs(2, 3, 77, 203, D, seed=1000 + D)
+    outs = {impl: _run_kernel(*args, implementation=impl) for impl in _IMPLEMENTATIONS}
+    baseline = outs["streaming"]
+    for impl, got in outs.items():
+        _assert_no_nan_inf(got, impl)
+        np.testing.assert_allclose(
+            got, baseline, atol=1e-3, rtol=1e-3,
+            err_msg=f"{impl} disagrees with block=1 baseline beyond fp arithmetic-order noise",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_prefill_rejects_bad_inputs():
+    q, k, v, scale = _make_inputs(1, 1, 8, 16, 64)
+    with pytest.raises(ValueError, match="multiple of 32"):
+        streaming_prefill_attend(
+            mx.array(np.zeros((1, 1, 8, 48), np.float16)),
+            mx.array(k),
+            mx.array(v),
+            mx.array(scale),
+        )
+    with pytest.raises(ValueError, match="v must be"):
+        streaming_prefill_attend(
+            mx.array(q),
+            mx.array(k),
+            mx.array(np.zeros((1, 1, 1, 64), np.float16)),
+            mx.array(scale),
+        )
+    with pytest.raises(ValueError, match="128 limit"):
+        streaming_prefill_attend(
+            mx.array(np.zeros((1, 1, 8, 256), np.float16)),
+            mx.array(np.zeros((1, 1, 16, 256), np.float16)),
+            mx.array(np.zeros((1, 1, 16, 256), np.float16)),
+            mx.array(scale),
+        )
+    with pytest.raises(ValueError, match="unknown implementation"):
+        streaming_prefill_attend(
+            mx.array(q), mx.array(k), mx.array(v), mx.array(scale), implementation="bogus"
+        )


### PR DESCRIPTION
Closes #281

## Summary
- New, independently-designed causal prefill attention kernel family (`experimental_streaming_prefill.metal`) exploring a row-owned streaming architecture: one SIMD-group per query row, register-resident online softmax, zero threadgroup memory, zero barriers, causal masking via loop bound instead of per-element masking.
- Variants: block=1 baseline, KV-blocked (block=2/4/8), and a 4-SIMD-group `multirow` dispatch-granularity variant.
- Benchmarked on Apple M4 GPU against the existing tiled `flash_prefill_attend` kernel and MLX's native `scaled_dot_product_attention` across D∈{32,64,128} and S∈{64..8192}.
- **Result: negative for production use.** The tiled kernel and MLX native SDPA both beat the streaming family outside a narrow D=32/small-S(≤256) niche where `streaming_block8` wins by 10-20%. `multirow` never wins any measured configuration.
- No production code path changes — `flash_prefill_attend` remains the default and is byte-for-byte unmodified (verified via diff). All changes are additive new files plus additive exports in `metal/kernels.py` / `metal/__init__.py`.

See `veloxquant_mlx/metal/src/experimental_streaming_prefill_ARCHITECTURE.md` for the full design rationale and #281 for the complete benchmark/correctness writeup.

## Test plan
- [x] `pytest veloxquant_mlx/tests/metal/test_experimental_streaming_prefill.py -v` — 419 passed, 90 skipped (skips are correctly-excluded `S_q > S_kv` cases)
- [x] Full existing metal suite (`veloxquant_mlx/tests/metal/`) — 872 passed, 114 skipped, no regressions
- [x] `scripts/streaming_prefill_benchmark.py` run against real M4 GPU hardware, results captured in #281
- [x] Confirmed `flash_prefill.metal` / `_flash_prefill.py` unchanged (empty diff vs master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)