### PR TITLE
fix(docs-site): disable Algolia contextualSearch — index has no facets

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -162,7 +162,13 @@ const config: Config = {
         appId: process.env.ALGOLIA_APP_ID!,
         apiKey: process.env.ALGOLIA_SEARCH_API_KEY!,
         indexName: 'veloxquant-mlx',
-        contextualSearch: true,
+        // contextualSearch requires facets (lang/docusaurus_tag) that only
+        // the official DocSearch crawler writes. This index is built by our
+        // own scripts/algolia-index.js, which doesn't set those facets, so
+        // contextualSearch's auto-applied filter matches zero records and
+        // every query silently returns no results. Leave it off until the
+        // indexer writes matching facets.
+        contextualSearch: false,
       },
     } : {}),
   } satisfies Preset.ThemeConfig,


### PR DESCRIPTION
## Summary
- Docs search returned "no results found" for every query on the live site, even after the Algolia index was populated via `scripts/algolia-index.js` (confirmed 1117 records indexed).
- Root cause: `contextualSearch: true` makes the DocSearch widget auto-apply a facet filter (typically `lang`/`docusaurus_tag`) scoped to the current page. Our custom indexer script writes plain records with no such facets, and the index has `attributesForFaceting: null` — so the widget's filter matches zero records on every query, regardless of the search term.
- Verified directly against the Algolia REST API with the search-only key: querying `vecinfer` returns real, correctly-highlighted hits — the index and data are fine, only the widget's contextual filter was broken.
- Fix: set `contextualSearch: false` so the widget queries the index without that filter.

## Test plan
- [x] `npm run build` in `docs-site/` completes with no errors
- [x] Confirmed via direct Algolia API query (search-only key) that indexed records exist and match real search terms
- [x] After deploy, verify the search modal on the live site returns results for terms like "vecinfer", "metal kernels", "rabitq"