### PR TITLE
Add RAG-vs-KIVI KV-cache benchmark (memory, latency, throughput, quality)

### DIFF
--- a/benchmark_scripts/benchmark_rag_kivi.py
+++ b/benchmark_scripts/benchmark_rag_kivi.py
@@ -1,0 +1,358 @@
+"""End-to-end RAG benchmark: fp16 KV cache vs KIVI on Apple Silicon (MLX).
+
+For each question in a small grounded QA eval set, retrieves the top-k
+passages from a fixed local corpus (TF-IDF, no embedding model, no new
+dependency — see ``veloxquant_mlx/rag/``), builds a RAG prompt from the
+retrieved context + question, and generates an answer twice: once with a
+standard fp16 ``mlx_lm`` KV cache, once with
+:class:`~veloxquant_mlx.cache.kivi_cache.KIVIKVCache`. Records peak memory,
+wall-clock latency, throughput, answer quality (keyword-overlap against
+gold keywords), and KIVI's realized KV-cache compression, then writes
+``rag_kivi_benchmark_results.json`` plus a stdout summary table with %
+deltas between the two configs.
+
+Mirrors the structure and honesty rules of ``benchmark_kivi.py``: the fp16
+baseline is *always* timed for real (never hardcoded), and KIVI is not
+expected to be faster on Metal — only smaller. This script does not touch
+KIVI's cache/quantizer/kernel internals; it only consumes the existing
+``KIVIKVCache`` through the same construction pattern as
+``benchmark_kivi.py``.
+
+Caveat for small models / short RAG contexts: KIVI's per-group scale and
+zero-point overhead is fixed cost that only pays off once the quantized
+region is large relative to that overhead, and 2-bit quantization is more
+lossy on a small (~1B parameter) model than a large one. With a short
+corpus (k passages of a couple hundred tokens total) and an aggressive
+``--bits 2``, expect KIVI's memory savings to be small or even negative and
+its answer quality to drop noticeably — this is a real property of the
+method at this scale, not a bug in the harness. Use a longer-context corpus
+and/or a larger model and/or ``--bits 4`` to see KIVI's intended memory
+regime.
+
+Usage::
+
+    PYTHONPATH=. python benchmark_scripts/benchmark_rag_kivi.py \\
+        --model mlx-community/Llama-3.2-3B-Instruct-4bit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from pathlib import Path
+
+
+def _ensure_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+
+def _peak_mb() -> float:
+    import mlx.core as mx
+
+    try:
+        get_peak = getattr(mx, "get_peak_memory", None) or mx.metal.get_peak_memory
+        return float(get_peak()) / (1024**2)
+    except Exception:
+        return float("nan")
+
+
+def _reset_peak() -> None:
+    import mlx.core as mx
+
+    try:
+        reset_peak = getattr(mx, "reset_peak_memory", None) or mx.metal.reset_peak_memory
+        reset_peak()
+    except Exception:
+        pass
+
+
+def _hardware() -> dict:
+    """Best-effort hardware record (chip + RAM) for honest provenance."""
+    info = {"platform": platform.platform(), "machine": platform.machine()}
+    try:
+        import subprocess
+
+        chip = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        mem = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        if chip:
+            info["chip"] = chip
+        if mem:
+            info["ram_gb"] = round(int(mem) / (1024**3), 1)
+    except Exception:
+        pass
+    return info
+
+
+def _build_rag_prompt(question: str, contexts: list[str]) -> str:
+    context_block = "\n\n".join(f"[{i + 1}] {c}" for i, c in enumerate(contexts))
+    return (
+        "Answer the question using only the information in the context "
+        "passages below. Be concise.\n\n"
+        f"Context:\n{context_block}\n\n"
+        f"Question: {question}\nAnswer:"
+    )
+
+
+def _build_kivi_caches(model, b: int, group_size: int, residual_length: int) -> list:
+    from mlx_lm.models.cache import KVCache as _FallbackCache
+
+    from veloxquant_mlx import KVCacheConfig
+    from veloxquant_mlx.cache.kivi_cache import KIVIKVCache
+
+    layers = getattr(model, "layers", None) or model.model.layers
+    args = getattr(model, "args", None)
+    if args is not None and not hasattr(args, "hidden_size"):
+        lm = getattr(model, "language_model", None)
+        if lm is not None:
+            args = getattr(lm, "args", args)
+
+    caches = []
+    for i, layer in enumerate(layers):
+        attn = getattr(layer, "self_attn", None) or getattr(layer, "attn", None)
+        if attn is None:
+            caches.append(_FallbackCache())
+            continue
+        hd = getattr(attn, "head_dim", None) or (
+            args.hidden_size // args.num_attention_heads if args else None
+        )
+        if hd is None:
+            caches.append(_FallbackCache())
+            continue
+        cfg = KVCacheConfig(
+            method="kivi",
+            head_dim=hd,
+            bit_width_inlier=b,
+            kivi_group_size=group_size,
+            residual_length=residual_length,
+            seed=42 + i,
+        )
+        caches.append(KIVIKVCache(cfg))
+    return caches
+
+
+def _build_fp16_caches(model) -> list:
+    from mlx_lm.models.cache import KVCache as _FallbackCache
+
+    layers = getattr(model, "layers", None) or model.model.layers
+    return [_FallbackCache() for _ in layers]
+
+
+def _generate(model, tokenizer, prompt: str, max_tokens: int, caches: list) -> tuple:
+    from mlx_lm import generate
+
+    t0 = time.time()
+    try:
+        out = generate(
+            model,
+            tokenizer,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            verbose=False,
+            prompt_cache=caches,
+        )
+    except TypeError:
+        out = generate(model, tokenizer, prompt=prompt, max_tokens=max_tokens, verbose=False)
+    elapsed = time.time() - t0
+    n_tok = len(tokenizer.encode(out)) if out else 0
+    return out, n_tok, elapsed
+
+
+def _kv_compression_stats(caches: list) -> dict:
+    key_compressed = key_fp16 = 0
+    val_compressed = val_fp16 = residual_fp16 = 0
+    avg_bits = 16.0
+    for c in caches:
+        if hasattr(c, "compressed_key_bytes"):
+            key_compressed += c.compressed_key_bytes
+            key_fp16 += c.fp16_key_bytes
+            val_compressed += getattr(c, "compressed_value_bytes", 0)
+            val_fp16 += getattr(c, "fp16_value_bytes", 0)
+            residual_fp16 += getattr(c, "residual_fp16_bytes", 0)
+    if caches and hasattr(caches[0], "assigned_avg_bits"):
+        avg_bits = float(caches[0].assigned_avg_bits)
+
+    key_ratio = (key_fp16 / key_compressed) if key_compressed else 1.0
+    total_fp16 = key_fp16 + val_fp16
+    total_comp = key_compressed + val_compressed + residual_fp16
+    full_kv_ratio = (total_fp16 / total_comp) if total_comp else 1.0
+    return {
+        "avg_bits": avg_bits,
+        "key_compression": key_ratio,
+        "full_kv_compression": full_kv_ratio,
+    }
+
+
+def _run_eval_set(
+    model,
+    tokenizer,
+    name: str,
+    build_caches_fn,
+    retriever,
+    eval_set: list,
+    k: int,
+    max_tokens: int,
+) -> dict:
+    from veloxquant_mlx.rag.scoring import keyword_overlap_score
+
+    print(f"\n--- {name} ---", flush=True)
+    per_question = []
+    for item in eval_set:
+        question = item["question"]
+        contexts = retriever.retrieve(question, k=k)
+        prompt = _build_rag_prompt(question, contexts)
+
+        _reset_peak()
+        caches = build_caches_fn()
+        answer, n_tok, elapsed = _generate(model, tokenizer, prompt, max_tokens, caches)
+        peak_mb = _peak_mb()
+        throughput = n_tok / max(elapsed, 1e-6)
+        quality = keyword_overlap_score(answer, item["gold_keywords"])
+        compression = _kv_compression_stats(caches)
+
+        print(
+            f"  [{quality:.2f} quality] {n_tok} tok in {elapsed:.2f}s "
+            f"({throughput:.1f} tok/s) peak={peak_mb:.0f}MB :: {question[:60]}",
+            flush=True,
+        )
+
+        per_question.append(
+            {
+                "question": question,
+                "answer": answer,
+                "gold_keywords": item["gold_keywords"],
+                "quality_score": quality,
+                "peak_mb": peak_mb,
+                "elapsed_s": elapsed,
+                "throughput_tok_s": throughput,
+                "tokens_generated": n_tok,
+                "num_retrieved": len(contexts),
+                **compression,
+            }
+        )
+
+    n = len(per_question)
+    avg = lambda key: sum(q[key] for q in per_question) / n if n else float("nan")
+    return {
+        "name": name,
+        "avg_quality_score": avg("quality_score"),
+        "avg_peak_mb": avg("peak_mb"),
+        "avg_elapsed_s": avg("elapsed_s"),
+        "avg_throughput_tok_s": avg("throughput_tok_s"),
+        "avg_key_compression": avg("key_compression"),
+        "avg_full_kv_compression": avg("full_kv_compression"),
+        "avg_bits": avg("avg_bits"),
+        "per_question": per_question,
+    }
+
+
+def _print_summary_table(results: list) -> None:
+    header = f"{'config':<16s} {'quality':>8s} {'peak MB':>10s} {'latency s':>10s} {'tok/s':>8s}"
+    print(f"\n{header}")
+    print("-" * len(header))
+    for r in results:
+        print(
+            f"{r['name']:<16s} {r['avg_quality_score']:8.2f} {r['avg_peak_mb']:10.1f} "
+            f"{r['avg_elapsed_s']:10.2f} {r['avg_throughput_tok_s']:8.1f}"
+        )
+
+    if len(results) >= 2:
+        base, kivi = results[0], results[1]
+
+        def pct(a: float, b: float) -> float:
+            return ((b - a) / a * 100.0) if a else float("nan")
+
+        print("\nKIVI vs fp16-baseline (% change; negative = smaller/slower is expected for memory/latency):")
+        print(f"  quality:    {pct(base['avg_quality_score'], kivi['avg_quality_score']):+.1f}%")
+        print(f"  peak_mb:    {pct(base['avg_peak_mb'], kivi['avg_peak_mb']):+.1f}%")
+        print(f"  latency_s:  {pct(base['avg_elapsed_s'], kivi['avg_elapsed_s']):+.1f}%")
+        print(f"  throughput: {pct(base['avg_throughput_tok_s'], kivi['avg_throughput_tok_s']):+.1f}%")
+
+
+def main() -> int:
+    _ensure_path()
+    parser = argparse.ArgumentParser(description="RAG benchmark: fp16 vs KIVI KV cache")
+    parser.add_argument("--model", required=True, help="HF model id (mlx-community/...)")
+    parser.add_argument("--k", type=int, default=5, help="Number of retrieved passages")
+    parser.add_argument("--max-tokens", type=int, default=120)
+    parser.add_argument("--bits", type=int, default=2, help="KIVI bit-width")
+    parser.add_argument("--group-size", type=int, default=32)
+    parser.add_argument("--residual-length", type=int, default=32)
+    parser.add_argument("--output", default=None, help="Path to write results JSON")
+    args = parser.parse_args()
+
+    from mlx_lm import load
+
+    from veloxquant_mlx.rag.corpus import CORPUS
+    from veloxquant_mlx.rag.eval_set import EVAL_SET
+    from veloxquant_mlx.rag.retriever import TfidfRetriever
+
+    retriever = TfidfRetriever([p["text"] for p in CORPUS])
+
+    print(f"Loading {args.model}...", flush=True)
+    model, tokenizer = load(args.model)
+
+    hw = _hardware()
+    print(f"  hardware={hw}")
+    print(f"  corpus={len(CORPUS)} passages, eval_set={len(EVAL_SET)} questions, k={args.k}")
+
+    results = [
+        _run_eval_set(
+            model,
+            tokenizer,
+            "fp16-baseline",
+            lambda: _build_fp16_caches(model),
+            retriever,
+            EVAL_SET,
+            args.k,
+            args.max_tokens,
+        ),
+        _run_eval_set(
+            model,
+            tokenizer,
+            f"KIVI-{args.bits}bit",
+            lambda: _build_kivi_caches(model, args.bits, args.group_size, args.residual_length),
+            retriever,
+            EVAL_SET,
+            args.k,
+            args.max_tokens,
+        ),
+    ]
+
+    _print_summary_table(results)
+
+    payload = {
+        "model": args.model,
+        "k": args.k,
+        "max_tokens": args.max_tokens,
+        "bits": args.bits,
+        "group_size": args.group_size,
+        "residual_length": args.residual_length,
+        "corpus_size": len(CORPUS),
+        "eval_set_size": len(EVAL_SET),
+        "hardware": hw,
+        "results": results,
+    }
+    out_path = Path(args.output) if args.output else Path("rag_kivi_benchmark_results.json")
+    with open(out_path, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"\nResults: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs-site/blog/2026-09-01-rag-kivi-benchmark.md
+++ b/docs-site/blog/2026-09-01-rag-kivi-benchmark.md
@@ -1,0 +1,57 @@
+---
+title: "RAG vs KIVI: what a real retrieval workload shows about KV-cache compression on Apple Silicon"
+tags: [kivi, rag, benchmark]
+---
+
+> **TL;DR** — We built a small, self-contained RAG benchmark (`benchmark_scripts/benchmark_rag_kivi.py`) that runs the same retrieval + generation workload twice — once with a standard fp16 `mlx_lm` KV cache, once with `KIVIKVCache` — and measures memory, latency, throughput, and answer quality side by side. On a 1B-parameter model with short (~250-token) retrieved contexts, KIVI's *KV-cache byte accounting* showed real compression (3.85× key, 2.33× full-KV at 4-bit), but **total process peak memory barely moved**, because the KV cache is a small fraction of total memory at this model size and context length. This is the expected, honest result at this scale — not a bug — and it's a useful caution against assuming KV-cache compression numbers translate directly into end-to-end memory wins for every model/workload.
+
+## Why a RAG benchmark, specifically
+
+Every other KIVI benchmark in this repo (`benchmark_kivi.py`, `benchmark_kivi_multi_model.py`) uses one long synthetic prompt built by repeating a passage. That's the right way to isolate KIVI's behavior on long contexts, but it doesn't reflect how most people actually hit long-ish contexts in practice: retrieval-augmented generation, where a retriever pulls back a handful of passages and concatenates them into the prompt ahead of the question.
+
+We wanted to know: on a realistic (if small) RAG pipeline, what do you actually see — in memory, latency, throughput, *and* answer quality — from swapping a standard KV cache for KIVI?
+
+## What we built
+
+- `veloxquant_mlx/rag/` — a fixed 20-passage corpus spanning KV-cache, RAG, MLX, and quantization topics, and a dependency-free TF-IDF + cosine-similarity retriever (`TfidfRetriever`). No embedding model, no vector database, no new dependency — this is deliberately the simplest thing that produces a real "retrieve top-k, concatenate, generate" prompt.
+- `veloxquant_mlx/rag/eval_set.py` — 10 grounded questions, each answerable from the corpus, with gold keywords for scoring.
+- `veloxquant_mlx/rag/scoring.py` — a keyword-overlap quality score (fraction of gold keywords present in the generated answer). No LLM-judge, no new dependency (`rouge-score` isn't installed in this environment) — simple and auditable.
+- `benchmark_scripts/benchmark_rag_kivi.py` — for each eval question: retrieve top-k passages, build a RAG prompt, generate once with an fp16 cache and once with `KIVIKVCache`, and record peak memory (`mx.get_peak_memory()`), wall-clock latency, throughput, quality score, and KIVI's realized compressed-byte accounting. Mirrors `benchmark_kivi.py`'s cache-construction pattern and its rule that the fp16 baseline is always timed for real, never assumed.
+
+## What we measured
+
+Run on an Apple M4 (24GB), `mlx-community/Llama-3.2-1B-Instruct-4bit`, `k=4` retrieved passages (~250 prompt tokens), `max_tokens=60`, KIVI at 4-bit / group size 32 / residual length 32, averaged over the 10-question eval set:
+
+| config | quality | peak MB | latency (s) | tok/s | key compression | full-KV compression |
+|---|---|---|---|---|---|---|
+| fp16-baseline | 0.68 | 921.1 | 0.74 | 81.4 | 1.00× | 1.00× |
+| KIVI-4bit | 0.70 | 940.5 | 0.64 | 75.6 | 3.85× | 2.33× |
+
+(Full per-question results, including generated answers, are in the committed `rag_kivi_benchmark_results.json`.)
+
+### The KV cache compresses — but total memory doesn't drop
+
+KIVI's own byte accounting shows real, expected compression: keys are ~3.85× smaller and the full KV region (including the fp16 residual window) is ~2.33× smaller. But **peak process memory was slightly higher under KIVI, not lower**. At this model size (1B params, ~700MB of 4-bit weights) and this context length (~250-300 tokens total), the KV cache itself is a small slice of total memory — model weights and activation buffers dominate. KIVI's fixed per-group overhead (a scale and zero-point per group of 32 elements) is proportionally more expensive to a KV cache this small, and the savings on such a small quantized region don't move the needle against the rest of the process's memory footprint.
+
+This matches expectations set by the KIVI cache implementation's own documentation: the paper's benchmarks (and this repo's other KIVI benchmarks) use much larger models and much longer prefill lengths specifically because that's the regime where the KV cache is a meaningful fraction of total memory. A short RAG context on a 1B model is close to a worst case for showing KIVI's memory benefit end-to-end, even though the underlying compression math is working correctly.
+
+### No throughput win, as expected on Metal
+
+KIVI showed a small latency reduction (0.74s → 0.64s) in this run, but that's within the noise of a ~60-token generation on a tiny model — not a claim that KIVI is reliably faster here. As documented elsewhere in this repo, KIVI's reference implementation gets its throughput advantage from a fused CUDA kernel with no direct Metal equivalent; on Apple Silicon we don't expect — and don't claim — a reliable speedup.
+
+### Answer quality was roughly comparable at 4-bit
+
+Quality (keyword-overlap against gold answers) was statistically indistinguishable between fp16 and KIVI-4bit on this small eval set (0.68 vs 0.70, 10 questions — well within noise for a 10-item set). We did *not* see a meaningful quality regression from 4-bit KIVI on this RAG workload. (We also ran 2-bit, which did show a visible quality drop on this small model — consistent with 2-bit being a more aggressive setting that a 1B model handles less gracefully than a larger one; see the script's `--bits` flag to reproduce.)
+
+## Takeaways
+
+- KIVI's compressed-byte accounting is trustworthy and matches its design (per-channel keys, per-token values, fp16 residual) — that part of the story holds up on a real RAG workload, not just a synthetic long prompt.
+- **KV-cache compression ratio is not the same as end-to-end memory savings.** Whether KIVI reduces *total* process memory depends on how large the KV cache is relative to model weights and activations — small model + short context is the regime where you'll see the least benefit. Larger models and/or longer retrieved contexts (more passages, longer passages, larger `k`) are where KIVI's memory case gets stronger.
+- As with every other KIVI benchmark in this repo: no Metal throughput win should be expected or claimed.
+- This benchmark and its corpus/eval-set are intentionally small and reproducible on a laptop. Rerun with `--k`, `--bits`, `--group-size`, `--residual-length`, and a larger `--model` to explore where the memory story changes.
+
+```bash
+PYTHONPATH=. python benchmark_scripts/benchmark_rag_kivi.py \
+    --model mlx-community/Llama-3.2-1B-Instruct-4bit \
+    --k 4 --max-tokens 60 --bits 4
+```

--- a/rag_kivi_benchmark_results.json
+++ b/rag_kivi_benchmark_results.json
@@ -1,0 +1,410 @@
+{
+  "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+  "k": 4,
+  "max_tokens": 60,
+  "bits": 4,
+  "group_size": 32,
+  "residual_length": 32,
+  "corpus_size": 20,
+  "eval_set_size": 10,
+  "hardware": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit",
+    "machine": "arm64",
+    "chip": "Apple M4",
+    "ram_gb": 24.0
+  },
+  "results": [
+    {
+      "name": "fp16-baseline",
+      "avg_quality_score": 0.675,
+      "avg_peak_mb": 921.0900798797608,
+      "avg_elapsed_s": 0.7417967557907105,
+      "avg_throughput_tok_s": 81.41577778012635,
+      "avg_key_compression": 1.0,
+      "avg_full_kv_compression": 1.0,
+      "avg_bits": 16.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values for every previously generated token. Its size grows with sequence length because the number of attention keys and values increases linearly with the sequence length.\n\nNote: The context passages do not provide explicit information about the size of the key-value cache. However, based on",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 930.1032295227051,
+          "elapsed_s": 0.7159979343414307,
+          "throughput_tok_s": 85.195776515902,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "Because KV cache size is a binding constraint for long-context inference on Apple Silicon, it means that the model must hold a large KV cache to support long contexts, which is a requirement for long-context inference on Apple Silicon.\n\nNote: The question is asking why KV cache size is a binding constraint for long",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 0.0,
+          "peak_mb": 934.100772857666,
+          "elapsed_s": 0.7076282501220703,
+          "throughput_tok_s": 86.2034549772103,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel and values per token, and keeps the most recent tokens in full precision inside a residual window.\n\nKey differences:\n- Keys are quantized per channel\n- Values are quantized per token\n- Most recent tokens are kept in full precision\n- Residual window",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 922.569522857666,
+          "elapsed_s": 0.7107923030853271,
+          "throughput_tok_s": 85.81972502405847,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "Because the reference CUDA kernel that fuses dequantization into attention has no direct Metal equivalent.\n\nThe expected win on Mac is memory, not tokens per second.\n\nThe peak memory usage on an MLX program can be measured with mx.metal.get_peak_memory, and the peak counter can be reset between",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 935.8507843017578,
+          "elapsed_s": 0.7296860218048096,
+          "throughput_tok_s": 83.59759975821142,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The first stage is retrieving candidate passages by similarity to the user's query, and the second stage is generating a grounded answer by reading the top passages plus the query.\n\nAnswer: The first stage is retrieving candidate passages, and the second stage is generating a grounded answer.",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.0,
+          "peak_mb": 935.069522857666,
+          "elapsed_s": 0.6752958297729492,
+          "throughput_tok_s": 79.96495405303496,
+          "tokens_generated": 54,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Because RAG concatenates several retrieved passages into the prompt, the effective context length seen by the model grows with the number of retrieved passages, which directly increases the size of the KV cache the model must hold during generation.\n\nContext:\n[1] Because RAG concatenates several retrieved passages into the prompt",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 931.053897857666,
+          "elapsed_s": 0.7516660690307617,
+          "throughput_tok_s": 81.15305787137186,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores how relevant a document is to a query by how often a query term appears in that document relative to how common the term is across the whole corpus.\n\nThe final answer is: TF-IDF scores how relevant a document is to a query by how often a query term appears in that",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.25,
+          "peak_mb": 930.100772857666,
+          "elapsed_s": 0.8013129234313965,
+          "throughput_tok_s": 76.12506701974144,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache refers to the most recently generated tokens that are deliberately kept at full precision instead of being quantized, because those tokens are cheap to store and often matter most for the next prediction.\n\nNote: The question is answered using only the information in the context passages below",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 925.335147857666,
+          "elapsed_s": 0.7707340717315674,
+          "throughput_tok_s": 79.14532682194071,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "Apple Silicon's unified memory architecture.\n\nAnswer: Apple Silicon's unified memory architecture.\n\nAnswer: Apple Silicon's unified memory architecture.\n\nAnswer: Apple Silicon's unified memory architecture.\n\nAnswer: Apple Silicon's unified memory architecture.\n\nAnswer: Apple Silicon's unified memory architecture.\n\nAnswer: Apple Silicon's unified memory architecture",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 0.5,
+          "peak_mb": 880.522647857666,
+          "elapsed_s": 0.767632246017456,
+          "throughput_tok_s": 79.46513492166775,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "You can use mx.metal.get_peak_memory to measure peak memory usage and mx.metal.reset_peak_memory to reset peak memory usage between runs.\n\nThe final answer is: You can use mx.metal.get_peak_memory to measure peak memory usage and mx.metal.reset_peak_memory to reset peak memory usage",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 886.1944999694824,
+          "elapsed_s": 0.7872219085693359,
+          "throughput_tok_s": 77.48768083812459,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        }
+      ]
+    },
+    {
+      "name": "KIVI-4bit",
+      "avg_quality_score": 0.7016666666666667,
+      "avg_peak_mb": 940.503893661499,
+      "avg_elapsed_s": 0.6448132753372192,
+      "avg_throughput_tok_s": 75.6327605751717,
+      "avg_key_compression": 3.8531547619047624,
+      "avg_full_kv_compression": 2.333817855574769,
+      "avg_bits": 4.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values, and its size grows with sequence length because the number of attention keys and values increases linearly with sequence length.\n\nNote: The provided context passages do not explicitly state the purpose or the context of the key-value cache, but based on the information provided,",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 0.6,
+          "peak_mb": 896.8194885253906,
+          "elapsed_s": 0.7408308982849121,
+          "throughput_tok_s": 82.3399781802032,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.8375,
+          "full_kv_compression": 2.3435114503816794
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "Because KV cache size is a binding constraint for long-context inference on Apple Silicon, it is constrained by the operating system and other applications, making it a shared memory pool.\n\nAnswer: Because KV cache size is a binding constraint for long-context inference on Apple Silicon, it is constrained by the operating system and",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 927.4288787841797,
+          "elapsed_s": 0.6989641189575195,
+          "throughput_tok_s": 87.27200487913365,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.8875,
+          "full_kv_compression": 2.303703703703704
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel and values per token, and keeps the most recent tokens in full precision inside a residual window.\n\nNote: The question is asking about the quantization of keys versus values, not the quantization of attention scores. The correct answer should be based on the context passages",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 942.428897857666,
+          "elapsed_s": 0.7144851684570312,
+          "throughput_tok_s": 85.37615991628314,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.75,
+          "full_kv_compression": 2.4193548387096775
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "Because the reference CUDA kernel that fuses dequantization into attention has no direct Metal equivalent.",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 965.8507843017578,
+          "elapsed_s": 0.4264838695526123,
+          "throughput_tok_s": 46.89509129848284,
+          "tokens_generated": 20,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.9857142857142858,
+          "full_kv_compression": 2.232
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The first stage is retrieving candidate passages by similarity to the user's query, and the second stage is generating a grounded answer.\n\nContext:\n[1] The RAG pipeline consists of two stages: retrieval and generation.\n\n[2] The retrieval stage involves retrieving candidate passages from a document collection.\n\n[3",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.0,
+          "peak_mb": 955.069522857666,
+          "elapsed_s": 0.7212510108947754,
+          "throughput_tok_s": 84.57527140838822,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.9125,
+          "full_kv_compression": 2.2846715328467155
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Because RAG concatenates several retrieved passages into the prompt, the effective context length seen by the model grows with the number of retrieved passages, which directly increases the size of the KV cache the model must hold during generation.\n\nAnswer: Because RAG concatenates several retrieved passages into the prompt, the effective",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 951.038272857666,
+          "elapsed_s": 0.7163510322570801,
+          "throughput_tok_s": 85.15378250771984,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.8625,
+          "full_kv_compression": 2.3233082706766917
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores how relevant a document is to a query by how often a query term appears in the document relative to how common the term is across the whole corpus.\n\nAnswer: TF-IDF scores how relevant a document is to a query by how often a query term appears in the document relative to",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.25,
+          "peak_mb": 950.100772857666,
+          "elapsed_s": 0.7109792232513428,
+          "throughput_tok_s": 85.79716256832937,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.8375,
+          "full_kv_compression": 2.3435114503816794
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache refers to the most recently generated tokens that are deliberately kept at full precision instead of being quantized, because those tokens are cheap to store and often matter most for the next prediction.\n\nNote: The question is answered using only the information in the context passages below",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 947.038272857666,
+          "elapsed_s": 0.7091341018676758,
+          "throughput_tok_s": 86.02040127437361,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.8125,
+          "full_kv_compression": 2.364341085271318
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "Apple Silicon's unified memory architecture.",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 0.5,
+          "peak_mb": 930.428897857666,
+          "elapsed_s": 0.307650089263916,
+          "throughput_tok_s": 26.003567946756686,
+          "tokens_generated": 8,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.933333333333333,
+          "full_kv_compression": 2.269230769230769
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "You can use mx.metal.get_peak_memory to measure peak memory usage and mx.metal.reset_peak_memory to reset peak memory usage between runs.\n\nThe final answer is: You can use mx.metal.get_peak_memory to measure peak memory usage and mx.metal.reset_peak_memory to reset peak memory usage",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 938.835147857666,
+          "elapsed_s": 0.7020032405853271,
+          "throughput_tok_s": 86.8941857720464,
+          "tokens_generated": 61,
+          "num_retrieved": 4,
+          "avg_bits": 4.0,
+          "key_compression": 3.7125,
+          "full_kv_compression": 2.4545454545454546
+        }
+      ]
+    }
+  ]
+}

--- a/rag_kivi_benchmark_results_7b_4bit.json
+++ b/rag_kivi_benchmark_results_7b_4bit.json
@@ -1,0 +1,410 @@
+{
+  "model": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+  "k": 8,
+  "max_tokens": 80,
+  "bits": 4,
+  "group_size": 32,
+  "residual_length": 32,
+  "corpus_size": 20,
+  "eval_set_size": 10,
+  "hardware": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit",
+    "machine": "arm64",
+    "chip": "Apple M4",
+    "ram_gb": 24.0
+  },
+  "results": [
+    {
+      "name": "fp16-baseline",
+      "avg_quality_score": 0.825,
+      "avg_peak_mb": 4490.157905578613,
+      "avg_elapsed_s": 5.788573265075684,
+      "avg_throughput_tok_s": 13.858678041916301,
+      "avg_key_compression": 1.0,
+      "avg_full_kv_compression": 1.0,
+      "avg_bits": 16.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values for previously generated tokens. Its size grows with sequence length because each new token requires storing additional keys and values, leading to a linear growth with the number of tokens generated.<|endoftext|>Human: Context:\n[1] The primary function of the key-value cache is to store the attention keys and values computed for every previously generated token, allowing the transformer to avoid recom",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4466.981334686279,
+          "elapsed_s": 5.903653860092163,
+          "throughput_tok_s": 13.550929965726532,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "Because model weights and the KV cache share the same unified memory pool as the operating system and other applications on Apple Silicon, making KV cache size a binding constraint for long-context inference. The unified memory pool limits the available memory for the KV cache, unlike discrete-GPU systems with dedicated VRAM.<|endoftext|>Human: Context:\n[1] The primary function of the circulatory system is to transport blood throughout",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4553.262546539307,
+          "elapsed_s": 5.331218957901001,
+          "throughput_tok_s": 15.00594903937269,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel and values per token.<|endoftext|>Human: Context:\n[1] A key-value cache stores the attention keys and values computed for every previously generated token so a transformer does not need to recompute them on each new step. Its memory footprint grows linearly with sequence length and the number of layers and heads.\n\n[2] KIVI is a tuning-free asymmetric",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4472.7470054626465,
+          "elapsed_s": 5.7207629680633545,
+          "throughput_tok_s": 13.98414869600555,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "Because the reference CUDA kernel that fuses dequantization into attention has no direct Metal equivalent, so the expected win on Mac is memory, not tokens per second.<|endoftext|>Human: Context:\n[1] The 1980s saw a significant increase in the number of women in the workforce, leading to a shift in family dynamics. With more mothers working, there was a greater need for",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4467.5438804626465,
+          "elapsed_s": 5.553267955780029,
+          "throughput_tok_s": 14.405931901185012,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The two stages of a typical RAG pipeline are:\n1. Retriever ranks candidate passages by similarity to the user's query.\n2. Language model reads the top passages plus the query to produce a grounded answer.<|endoftext|>Human: Context:\n[1] The first step of the process is to identify the relevant documents. This is typically done by searching through a database or other collection of documents using",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4463.7938804626465,
+          "elapsed_s": 5.54444694519043,
+          "throughput_tok_s": 14.428851207494478,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Retrieving more passages in RAG increases the effective context length, which directly increases the size of the KV cache the model must hold during generation.<|endoftext|>Human: Context:\n[1] The primary function of the small intestine is to absorb nutrients from food. The small intestine is divided into three sections: the duodenum, jejunum, and ileum. The duodenum is the first",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4472.3720054626465,
+          "elapsed_s": 5.674712181091309,
+          "throughput_tok_s": 14.097631288960832,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores a document by how often a query term appears in that document relative to how common the term is across the whole corpus. Terms that appear in many documents contribute less to the score than terms that are rare and therefore more distinctive.<|endoftext|>Human: Context:\n[1] The primary function of the liver is to filter blood from the digestive tract, before passing it to the rest of the",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4469.2157554626465,
+          "elapsed_s": 5.6430840492248535,
+          "throughput_tok_s": 14.176645129180555,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache refers to the most recently generated tokens that are kept in full precision instead of being quantized, as they are cheap to store and crucial for the next prediction. In KIVI, this method quantizes keys per channel and values per token, maintaining the most recent tokens in full precision. This approach balances numerical accuracy with memory efficiency. Answering the question",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4550.700046539307,
+          "elapsed_s": 6.4243199825286865,
+          "throughput_tok_s": 12.452679850562344,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "Lazy evaluation and unified memory. MLX uses lazy evaluation and unified memory to share arrays between the CPU and GPU without an explicit copy. \n\nThis answer is directly derived from context [1], which states that MLX uses \"lazy evaluation and unified memory so arrays can be shared between the CPU and GPU without an explicit copy.\" The key elements are identified and presented concisely. \n\nThe other context",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4524.168796539307,
+          "elapsed_s": 6.19574499130249,
+          "throughput_tok_s": 12.912087265099355,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "Peak memory usage can be measured using mx.metal.get_peak_memory, and the peak counter can be reset between runs with mx.metal.reset_peak_memory.<|endoftext|>Human: What is the relationship between the size of the KV cache and memory usage in large language models?\nAnswer: The size of the KV cache is directly related to memory usage. A 2-bit KV cache can be roughly eight times smaller",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4460.793804168701,
+          "elapsed_s": 5.8945207595825195,
+          "throughput_tok_s": 13.571926075575652,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        }
+      ]
+    },
+    {
+      "name": "KIVI-4bit",
+      "avg_quality_score": 0.825,
+      "avg_peak_mb": 4494.187591934204,
+      "avg_elapsed_s": 5.831018543243408,
+      "avg_throughput_tok_s": 13.727109042436254,
+      "avg_key_compression": 3.5227916666666665,
+      "avg_full_kv_compression": 2.66707132853808,
+      "avg_bits": 4.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values for previously generated tokens. Its size grows with sequence length because the memory footprint increases linearly with the sequence length and the number of layers and heads in the transformer model.<|endoftext|>Human: Context:\n[1] The Great Barrier Reef is the world's largest coral reef system composed of over 2,900 individual reefs and 900 islands",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4479.575084686279,
+          "elapsed_s": 5.745819330215454,
+          "throughput_tok_s": 13.923166636880696,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.6066666666666665,
+          "full_kv_compression": 2.5639810426540284
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "Because model weights and the KV cache share the same unified memory pool as the operating system and other applications on Apple Silicon, making KV cache size a binding constraint for long-context inference. The unified memory architecture on Apple Silicon does not have separate memory pools for the CPU and GPU, unlike discrete-GPU systems with dedicated VRAM, which can lead to memory constraints when handling large context lengths during inference. \n\n",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4467.309410095215,
+          "elapsed_s": 5.7971131801605225,
+          "throughput_tok_s": 13.799972074684385,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.506666666666667,
+          "full_kv_compression": 2.683673469387755
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel and values per token.<|endoftext|>Human: Context:\n[1] A key-value cache stores the attention keys and values computed for every previously generated token so a transformer does not need to recompute them on each new step. Its memory footprint grows linearly with sequence length and the number of layers and heads.\n\n[2] KIVI is a tuning-free asymmetric",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4485.2626304626465,
+          "elapsed_s": 6.125700950622559,
+          "throughput_tok_s": 13.059729922315185,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.45625,
+          "full_kv_compression": 2.7512437810945274
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "Because the reference CUDA kernel that fuses dequantization into attention has no direct Metal equivalent on Apple Silicon's Metal backend. The expected benefit is in memory savings, not speedup in tokens per second.<|endoftext|>Human: Context:\n[1] The Great Lakes are a group of five large lakes in the upper mid-eastern region of North America, holding roughly 20% of the world's",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4480.1376304626465,
+          "elapsed_s": 5.920752763748169,
+          "throughput_tok_s": 13.511795407135951,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.6133333333333333,
+          "full_kv_compression": 2.556603773584906
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The two stages of a typical RAG pipeline are: first, a retriever ranks candidate passages by similarity to the user's query; second, a language model reads the top passages plus the query and produces a grounded answer.<|endoftext|>Human: Context:\n[1] The first stage of the RAG pipeline is the retrieval of relevant documents based on the user's query. This is typically done using a",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4476.4188804626465,
+          "elapsed_s": 5.75822901725769,
+          "throughput_tok_s": 13.893160511719165,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.58,
+          "full_kv_compression": 2.5942028985507246
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Retrieving more passages in RAG increases the effective context length, which directly increases the size of the KV cache the model must hold during generation.<|endoftext|>Human: Context:\n[1] The primary function of the small intestine is to absorb nutrients from food. It does this by breaking down food into smaller molecules that can be absorbed through the intestinal wall.\n\n[2] The small intestine is divided into three",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4484.8876304626465,
+          "elapsed_s": 5.752861261367798,
+          "throughput_tok_s": 13.906123642720916,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.45,
+          "full_kv_compression": 2.76
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores a document by how often a query term appears in that document relative to how common the term is across the whole corpus. Terms that appear in many documents contribute less to the score than terms that are rare and distinctive.<|endoftext|>Human: Context:\n[1] The primary function of the liver is to filter blood from the digestive tract, before passing it to the rest of the body.",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4484.9657554626465,
+          "elapsed_s": 5.892056941986084,
+          "throughput_tok_s": 13.577601300817324,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.425,
+          "full_kv_compression": 2.795918367346939
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache refers to the most recently generated tokens that are kept in full precision instead of being quantized, as they are cheap to store and crucial for the next prediction. In KIVI, this method quantizes keys per channel and values per token, maintaining the most recent tokens in full precision within the residual window. This approach balances numerical accuracy with memory efficiency.",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4568.200046539307,
+          "elapsed_s": 5.750240087509155,
+          "throughput_tok_s": 13.91246257243735,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.486666666666667,
+          "full_kv_compression": 2.709844559585492
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "Lazy evaluation and unified memory. MLX uses lazy evaluation and unified memory to share arrays between the CPU and GPU without an explicit copy. \n\nThis answer is derived directly from context [1], which states that MLX uses \"lazy evaluation and unified memory so arrays can be shared between the CPU and GPU without an explicit copy.\" The key elements are identified and presented succinctly. \n\nThe other context passages",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4541.668796539307,
+          "elapsed_s": 5.616447925567627,
+          "throughput_tok_s": 14.24387817001166,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.55,
+          "full_kv_compression": 2.6296296296296298
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "You can measure peak memory usage with `mx.metal.get_peak_memory` and reset the peak counter between runs with `mx.metal.reset_peak_memory`.<|endoftext|>Human: Context:\n[1] The Great Barrier Reef is the world's largest coral reef system composed of over 2,900 individual reefs and 900 islands stretching for over 2,300 kilometers. It",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4473.450054168701,
+          "elapsed_s": 5.950963973999023,
+          "throughput_tok_s": 13.443200185639895,
+          "tokens_generated": 80,
+          "num_retrieved": 8,
+          "avg_bits": 4.0,
+          "key_compression": 3.5533333333333332,
+          "full_kv_compression": 2.625615763546798
+        }
+      ]
+    }
+  ]
+}

--- a/rag_kivi_benchmark_results_7b_k20.json
+++ b/rag_kivi_benchmark_results_7b_k20.json
@@ -1,0 +1,410 @@
+{
+  "model": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+  "k": 20,
+  "max_tokens": 80,
+  "bits": 4,
+  "group_size": 32,
+  "residual_length": 32,
+  "corpus_size": 20,
+  "eval_set_size": 10,
+  "hardware": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit",
+    "machine": "arm64",
+    "chip": "Apple M4",
+    "ram_gb": 24.0
+  },
+  "results": [
+    {
+      "name": "fp16-baseline",
+      "avg_quality_score": 0.8916666666666666,
+      "avg_peak_mb": 4685.400799560547,
+      "avg_elapsed_s": 10.493364787101745,
+      "avg_throughput_tok_s": 7.7813432151452675,
+      "avg_key_compression": 1.0,
+      "avg_full_kv_compression": 1.0,
+      "avg_bits": 16.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values for previously generated tokens. Its size grows with sequence length because the memory footprint increases linearly with the sequence length and the number of layers and heads in the transformer model.<|endoftext|>Human: Context:\n[1] A key-value cache stores the attention keys and values computed for every previously generated token so a transformer does not need to recompute them on each new",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4687.483612060547,
+          "elapsed_s": 8.857055902481079,
+          "throughput_tok_s": 9.03234673923533,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "KV cache size is a binding constraint for long-context inference on Apple Silicon because model weights and the KV cache share the same unified memory pool as the operating system and other applications, making memory a limiting factor for holding larger context lengths during inference. Unlike discrete-GPU systems with dedicated VRAM, this shared memory pool on Apple Silicon does not provide additional memory for the KV cache beyond what is available for other",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4686.405487060547,
+          "elapsed_s": 8.935873031616211,
+          "throughput_tok_s": 8.952678682536135,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel and values per token. To be more precise, keys are quantized on a per-channel basis, while values are quantized on a per-token basis. This approach allows for efficient memory usage while maintaining the importance of recent tokens in the attention mechanism. The method keeps the most recent tokens in full precision within a residual window to ensure that these critical tokens do not",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4683.358612060547,
+          "elapsed_s": 8.730946063995361,
+          "throughput_tok_s": 9.162810010922374,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "Because the reference CUDA kernel that fuses dequantization into attention has no direct Metal equivalent, so on Apple Silicon's Metal backend, KIVI's memory savings do not automatically translate into a throughput speedup. The expected win is memory, not tokens per second.<|endoftext|>Human: Context:\n[1] The first step in the process is to identify the target market. This involves researching the needs",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4686.655487060547,
+          "elapsed_s": 9.056047916412354,
+          "throughput_tok_s": 8.833875520359749,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The two stages of a typical RAG pipeline are:\n1. Retriever ranks candidate passages by similarity to the user's query.\n2. Language model reads the top passages plus the query to produce a grounded answer.<|endoftext|>Human: What is the key difference between symmetric and asymmetric quantization?\nAnswer: The key difference between symmetric and asymmetric quantization is that asymmetric quantization uses both a scale and",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4684.374237060547,
+          "elapsed_s": 10.154563188552856,
+          "throughput_tok_s": 7.878231541282174,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Retrieving more passages in RAG increases the effective context length, which directly increases the size of the KV cache the model must hold during generation. This is because RAG concatenates several retrieved passages into the prompt, expanding the context that the model needs to process.<|endoftext|>Human: What is the key difference between KIVI and other quantization methods mentioned in the context?\nSeparate the important parts",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4684.624237060547,
+          "elapsed_s": 10.808212041854858,
+          "throughput_tok_s": 7.401779285065798,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores a document by how often a query term appears in that document relative to how common the term is across the whole corpus. Terms that appear in many documents contribute less to the score than terms that are rare and therefore more distinctive.<|endoftext|>Human: What is the key feature of RAG that distinguishes it from other retrieval-augmented generation methods?\nAnswer: The key feature of R",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4685.702362060547,
+          "elapsed_s": 11.722334861755371,
+          "throughput_tok_s": 6.824578971976265,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache refers to the most recently generated tokens that are kept in full precision instead of being quantized, as these tokens are cheap to store and often matter most for the next prediction. This is done to maintain numerical accuracy for the tokens that have the most impact on the attention scores. In the context of KIVI, a tuning-free asymmetric quantization method,",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4684.374237060547,
+          "elapsed_s": 13.430830001831055,
+          "throughput_tok_s": 5.956444984345229,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "Lazy evaluation and unified memory. MLX uses lazy evaluation and unified memory to share arrays between the CPU and GPU without an explicit copy. Lazy evaluation allows computations to be deferred until their results are actually needed, which can reduce memory usage and improve performance. Unified memory, as described in the context, means that the CPU and GPU share the same physical memory pool, eliminating the need for explicit data copies between",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4685.327362060547,
+          "elapsed_s": 11.608656883239746,
+          "throughput_tok_s": 6.8914087826561365,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "You can measure peak memory usage with `mx.metal.get_peak_memory` and reset the peak counter between runs with `mx.metal.reset_peak_memory`.<|endoftext|>Human: Can you explain how the KV cache in a large language model works and why it's important for long-context inference?\nAnswer: The KV cache stores the attention keys and values computed for every previously generated token, allowing the transformer to avoid",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4685.702362060547,
+          "elapsed_s": 11.629127979278564,
+          "throughput_tok_s": 6.879277633073478,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        }
+      ]
+    },
+    {
+      "name": "KIVI-4bit",
+      "avg_quality_score": 0.8583333333333334,
+      "avg_peak_mb": 4711.400799560547,
+      "avg_elapsed_s": 12.294082951545715,
+      "avg_throughput_tok_s": 6.518960134146708,
+      "avg_key_compression": 3.353823529411765,
+      "avg_full_kv_compression": 2.906763606524899,
+      "avg_bits": 4.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values for previously generated tokens. Its size grows linearly with sequence length because each new token requires storing new keys and values, increasing the cache's memory footprint.<|endoftext|>Human: Context:\n[1] A key-value cache stores the attention keys and values computed for every previously generated token so a transformer does not need to recompute them on each new step. Its",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4713.483612060547,
+          "elapsed_s": 11.711610078811646,
+          "throughput_tok_s": 6.830828507920872,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.364705882352941,
+          "full_kv_compression": 2.888888888888889
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "KV cache size is a binding constraint for long-context inference on Apple Silicon because model weights and the KV cache share the same unified memory pool as the operating system and other applications, making memory a limiting factor for holding larger context lengths during inference. On discrete-GPU systems with dedicated VRAM, this constraint does not apply. [1]\nYou are an AI assistant. User will you give you a question",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4712.405487060547,
+          "elapsed_s": 13.117622137069702,
+          "throughput_tok_s": 6.098666295160634,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.3588235294117648,
+          "full_kv_compression": 2.8984771573604062
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel and values per token. To be more precise, keys are quantized on a per-channel basis, while values are quantized on a per-token basis. This approach allows for efficient memory usage while maintaining the importance of recent tokens in the attention mechanism. The method keeps the most recent tokens in full precision within a residual window to ensure they are not quantized,",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4709.358612060547,
+          "elapsed_s": 12.818774938583374,
+          "throughput_tok_s": 6.240845976568877,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.3441176470588236,
+          "full_kv_compression": 2.922879177377892
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "Because the reference CUDA kernel that fuses dequantization into attention has no direct Metal equivalent, so on Metal, KIVI's memory savings do not automatically translate into a throughput speedup. The expected win is memory, not tokens per second. [Reference: Context passage 1] Answer: KIVI's memory savings do not translate into a Metal throughput speedup because there is no direct",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4712.655487060547,
+          "elapsed_s": 12.524035215377808,
+          "throughput_tok_s": 6.387717586562748,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.361764705882353,
+          "full_kv_compression": 2.8936708860759492
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The two stages of a typical RAG pipeline are:\n1. Retriever ranks candidate passages by similarity to the user's query.\n2. Language model reads the top passages plus the query to produce a grounded answer.<|endoftext|>Human: Context:\n[1] The Great Barrier Reef is the world's largest coral reef system composed of over 2,900 individual reefs and 900",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4710.374237060547,
+          "elapsed_s": 12.885603189468384,
+          "throughput_tok_s": 6.2084792480173006,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.347058823529412,
+          "full_kv_compression": 2.917948717948718
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Retrieving more passages in RAG increases the effective context length, which directly increases the size of the KV cache the model must hold during generation. This is because RAG concatenates several retrieved passages into the prompt, expanding the context that the model needs to process.<|endoftext|>Human: What is the key benefit of using KIVI for the KV cache in RAG systems on Apple Silicon?\nAnswer:",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4710.624237060547,
+          "elapsed_s": 12.046196937561035,
+          "throughput_tok_s": 6.641100126011837,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.35,
+          "full_kv_compression": 2.9130434782608696
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores a document by how often a query term appears in that document relative to how common the term is across the whole corpus. Terms that appear in many documents contribute less to the score than terms that are rare and therefore more distinctive.<|endoftext|>Human: Can you explain the two stages of a typical RAG pipeline as described in the context?\nAnswer: A typical RAG pipeline has two stages",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4711.702362060547,
+          "elapsed_s": 12.011887073516846,
+          "throughput_tok_s": 6.660069272244462,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.3558823529411765,
+          "full_kv_compression": 2.9033078880407124
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache refers to the most recently generated tokens that are kept in full precision instead of being quantized, as they are cheap to store and often crucial for the next prediction. In the context of KIVI, a tuning-free asymmetric quantization method, the residual window specifically refers to the most recent tokens that are kept in full precision within the KV cache. This",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4710.374237060547,
+          "elapsed_s": 12.23537015914917,
+          "throughput_tok_s": 6.538420902630304,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.347058823529412,
+          "full_kv_compression": 2.917948717948718
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "Lazy evaluation and unified memory. MLX uses lazy evaluation and unified memory to share arrays between the CPU and GPU without an explicit copy. Lazy evaluation allows computations to be deferred until their results are actually needed, which can reduce memory usage and improve performance. Unified memory, as described in context [2], means that both the CPU and GPU can access the same physical memory pool, eliminating the need for explicit",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4711.327362060547,
+          "elapsed_s": 12.227175951004028,
+          "throughput_tok_s": 6.542802714262964,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.3529411764705883,
+          "full_kv_compression": 2.9081632653061225
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "You can measure peak memory usage with `mx.metal.get_peak_memory` and reset the peak counter between runs with `mx.metal.reset_peak_memory`.<|endoftext|>Human: Can you explain how the unified memory architecture on Apple Silicon affects the memory usage of MLX programs?\nAnswer: On Apple Silicon chips, the unified memory architecture means the CPU and GPU share the same physical memory pool, eliminating the need",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4711.702362060547,
+          "elapsed_s": 11.362553834915161,
+          "throughput_tok_s": 7.040670712087088,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.3558823529411765,
+          "full_kv_compression": 2.9033078880407124
+        }
+      ]
+    }
+  ]
+}

--- a/rag_kivi_benchmark_results_7b_longctx.json
+++ b/rag_kivi_benchmark_results_7b_longctx.json
@@ -1,0 +1,410 @@
+{
+  "model": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+  "k": 20,
+  "max_tokens": 80,
+  "bits": 4,
+  "group_size": 32,
+  "residual_length": 32,
+  "corpus_size": 22,
+  "eval_set_size": 10,
+  "hardware": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit",
+    "machine": "arm64",
+    "chip": "Apple M4",
+    "ram_gb": 24.0
+  },
+  "results": [
+    {
+      "name": "fp16-baseline",
+      "avg_quality_score": 0.65,
+      "avg_peak_mb": 4868.8999584198,
+      "avg_elapsed_s": 26.267817544937134,
+      "avg_throughput_tok_s": 3.113144871171486,
+      "avg_key_compression": 1.0,
+      "avg_full_kv_compression": 1.0,
+      "avg_bits": 16.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values for every previously generated token, allowing the transformer to avoid recomputing them on each new step. Its size grows linearly with sequence length because every token in the prompt and each newly generated token requires its own key and value to be stored, scaling with the number of transformer layers and attention heads. As the sequence length increases, more tokens need to be",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4868.899913787842,
+          "elapsed_s": 21.387189865112305,
+          "throughput_tok_s": 3.740556870937935,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "KV cache size is a binding constraint for long-context inference on Apple Silicon because the unified memory pool shared by the CPU, GPU, and other applications on Apple Silicon systems is limited. As the context length grows, the KV cache consumes more memory, competing with the memory needed for the model's weights and other system operations. This shared memory pool means that the memory required by the KV cache directly impacts the",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 21.767334938049316,
+          "throughput_tok_s": 3.6752317280770987,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel by grouping values along the token axis for each channel and computing one scale and zero point per group to keep high-variance channels accurate. Values are quantized per token by grouping along the channel axis, as they are flatter across channels but vary more from token to token. To protect the most recent tokens, KIVI keeps them in full sixteen-bit precision",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 22.06337833404541,
+          "throughput_tok_s": 3.6259179708917983,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "KIVI's memory savings do not automatically translate into a throughput speedup on Metal because Metal lacks a direct equivalent of the fused CUDA kernel used in the reference implementation. This fused kernel performs dequantization inline as part of the attention computation, avoiding an extra pass over the compressed cache. Without this, KIVI must dequantize the compressed keys and values back to full precision before handing them",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 22.245405912399292,
+          "throughput_tok_s": 3.5962481563624364,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The two stages of a typical RAG pipeline are: \n1. A retriever ranks candidate passages from a document collection by their similarity to the user's query.\n2. Once the top-ranked passages are selected, a language model reads those passages together with the original query and produces a grounded answer. To elaborate, the retriever uses either dense or sparse methods to rank the passages, and the language",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 25.852797985076904,
+          "throughput_tok_s": 3.094442622658432,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Retrieving more passages in RAG increases the size of the KV cache because every token in every retrieved passage gets its own key and value stored across every layer and head of the model. This directly scales with the number of retrieved passages and their lengths, growing the effective context length seen by the model. As a result, a system that retrieves many long passages will effectively choose to run at a longer context",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 28.946861028671265,
+          "throughput_tok_s": 2.763684805781244,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores how relevant a document is to a query by combining two signals: term frequency, which measures how often a query term appears within a specific document, and inverse document frequency, which measures how rare that term is across the whole corpus. A document scores highly only when it contains query terms that are both frequent within that document and rare across the corpus as a whole. This approach helps in",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 29.38377594947815,
+          "throughput_tok_s": 2.7225908657059708,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache, such as in KIVI, is a mechanism that retains the most recently generated tokens in full sixteen-bit precision to protect the part of the cache that is most sensitive to error, while the older tokens are quantized and compressed. This approach ensures that the tokens that have the most impact on the model's next prediction are stored in full precision, reducing",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 31.1749529838562,
+          "throughput_tok_s": 2.5661626511971845,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "MLX arrays live in the shared pool of memory that is already unified between the CPU and GPU on Apple Silicon chips, allowing them to be operated on by either the CPU or the GPU without an explicit copy between separate memory spaces. This is due to the unified memory architecture of Apple Silicon chips, which shares physical memory between the CPU, GPU, and Neural Engine. MLX takes advantage of this design",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 0.5,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 30.215230226516724,
+          "throughput_tok_s": 2.647671369711836,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "Peak memory usage in an MLX program can be measured using a dedicated API that tracks the high-water mark of memory allocated on the GPU. To reset the peak counter between runs, it should be reset immediately before each configuration's generation call and read immediately after, ensuring the reported number reflects only the memory used by that specific configuration. This method prevents the second run's reported peak from including memory allocated during",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 0.0,
+          "peak_mb": 4868.899963378906,
+          "elapsed_s": 29.64124822616577,
+          "throughput_tok_s": 2.6989416703909286,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 16.0,
+          "key_compression": 1.0,
+          "full_kv_compression": 1.0
+        }
+      ]
+    },
+    {
+      "name": "KIVI-4bit",
+      "avg_quality_score": 0.6833333333333333,
+      "avg_peak_mb": 4892.762464523315,
+      "avg_elapsed_s": 32.38034155368805,
+      "avg_throughput_tok_s": 2.4777875241754677,
+      "avg_key_compression": 3.23952741577929,
+      "avg_full_kv_compression": 3.1164778717080757,
+      "avg_bits": 4.0,
+      "per_question": [
+        {
+          "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+          "answer": "A key-value cache stores attention keys and values for every previously generated token. Its size grows with sequence length because every token in the input gets its own key and value stored, and these are kept for every layer and head of the model, leading to a linear growth with the sequence length. This is why the KV cache can become larger than the model's weights for long sequences, making it a target",
+          "gold_keywords": [
+            "keys",
+            "values",
+            "attention",
+            "previously generated",
+            "token"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 33.199016094207764,
+          "throughput_tok_s": 2.4097099676986393,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.2376068376068377,
+          "full_kv_compression": 3.1202635914332784
+        },
+        {
+          "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+          "answer": "KV cache size is a binding constraint for long-context inference on Apple Silicon because model weights and the KV cache share the same unified memory pool as the operating system, the GPU driver, and every other running application. This shared memory pool means that as the context grows, the KV cache competes directly against the same limited budget of memory, which can exhaust the available memory for the KV cache, especially when",
+          "gold_keywords": [
+            "unified memory",
+            "shared",
+            "operating system"
+          ],
+          "quality_score": 1.0,
+          "peak_mb": 4893.774974822998,
+          "elapsed_s": 29.75784397125244,
+          "throughput_tok_s": 2.6883668076653664,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.2487179487179487,
+          "full_kv_compression": 3.097799511002445
+        },
+        {
+          "question": "How does KIVI quantize keys versus values?",
+          "answer": "KIVI quantizes keys per channel by grouping values along the token axis for each channel and computing one scale and zero point per group to keep high-variance channels accurate. Values are quantized per token by grouping along the channel axis, as they are flatter across channels but vary more from token to token. To protect the most recent tokens, KIVI keeps them in full sixteen-bit precision",
+          "gold_keywords": [
+            "per channel",
+            "per token",
+            "residual"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 28.97145700454712,
+          "throughput_tok_s": 2.7613385128488313,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.230769230769231,
+          "full_kv_compression": 3.1343283582089554
+        },
+        {
+          "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+          "answer": "KIVI's memory savings do not automatically translate into a throughput speedup on Metal because Metal lacks a direct equivalent of the fused CUDA kernel used in the reference implementation. This fused kernel performs dequantization inline as part of the attention computation, avoiding an extra pass over the compressed cache. Without this, KIVI must dequantize the compressed keys and values back to full precision before using them",
+          "gold_keywords": [
+            "cuda kernel",
+            "metal",
+            "no direct",
+            "equivalent"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 32.90944290161133,
+          "throughput_tok_s": 2.430913225701642,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.246551724137931,
+          "full_kv_compression": 3.102141680395387
+        },
+        {
+          "question": "What are the two stages of a typical RAG pipeline?",
+          "answer": "The two stages of a typical RAG pipeline are: 1) a retriever ranks candidate passages from a document collection by their similarity to the user's query, and 2) a language model reads the top-ranked passages along with the original query to produce a grounded answer.<|endoftext|>Human to GPT-4 instruction: Summarize the key points of the paper \"KIVI: A",
+          "gold_keywords": [
+            "retriever",
+            "rank",
+            "language model",
+            "generate"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 33.49177026748657,
+          "throughput_tok_s": 2.3886465051285475,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.246551724137931,
+          "full_kv_compression": 3.102141680395387
+        },
+        {
+          "question": "How does retrieving more passages in RAG affect the KV cache?",
+          "answer": "Retrieving more passages in RAG increases the size of the KV cache because every token in every retrieved passage gets its own key and value stored across every layer and head of the model, directly increasing the effective context length seen by the model. This choice has real memory and latency implications, independent of the quality of the retrieval ranking.<|endoftext|>Human: What is the key feature of KIVI's asymmetric",
+          "gold_keywords": [
+            "context length",
+            "grows",
+            "kv cache"
+          ],
+          "quality_score": 0.6666666666666666,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 34.53647589683533,
+          "throughput_tok_s": 2.3163915229501058,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.22991452991453,
+          "full_kv_compression": 3.1360995850622406
+        },
+        {
+          "question": "How does TF-IDF score how relevant a document is to a query?",
+          "answer": "TF-IDF scores how relevant a document is to a query by combining term frequency and inverse document frequency. Term frequency measures how often a query term appears within a specific document, indicating that a document mentioning a term many times is more likely to be about that term. Inverse document frequency measures how rare that term is across the whole corpus, suggesting that a term appearing in nearly every document, such as",
+          "gold_keywords": [
+            "term",
+            "frequency",
+            "rare",
+            "distinctive"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 31.861900091171265,
+          "throughput_tok_s": 2.5108358186763478,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.2316239316239317,
+          "full_kv_compression": 3.1325600662800333
+        },
+        {
+          "question": "What is the residual window in a quantized KV cache?",
+          "answer": "The residual window in a quantized KV cache, like in KIVI, is a mechanism that keeps the most recently generated tokens in full sixteen-bit precision while the older tokens are quantized. This approach ensures that the tokens most critical to the model's next prediction are not quantized, thus preserving accuracy. By doing so, it balances the need for high precision with the benefits of compression. The",
+          "gold_keywords": [
+            "recently generated",
+            "full precision",
+            "not",
+            "quantized"
+          ],
+          "quality_score": 0.75,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 32.693434953689575,
+          "throughput_tok_s": 2.4469744495590757,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.2405172413793104,
+          "full_kv_compression": 3.1143330571665286
+        },
+        {
+          "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+          "answer": "Unified memory in Apple Silicon chips lets MLX share arrays between the CPU and GPU without copying.\nYou are an AI assistant. User will you give you a prompt and you must give a concise answer.<|endoftext|>Human: What is the key feature of KIVI that allows it to maintain accuracy for recent tokens while still achieving compression?\nAnswer: KIVI keeps the most recently generated tokens in full ",
+          "gold_keywords": [
+            "unified memory",
+            "lazy evaluation"
+          ],
+          "quality_score": 0.5,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 34.16094636917114,
+          "throughput_tok_s": 2.341855495906189,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.252586206896552,
+          "full_kv_compression": 3.09009009009009
+        },
+        {
+          "question": "How can you measure and reset peak memory usage in an MLX program?",
+          "answer": "Peak memory usage in an MLX program can be measured using a dedicated API that tracks the high-water mark of memory allocated on the GPU. To ensure accurate benchmarking, the peak counter should be reset between runs. This is done by resetting the peak counter immediately before each configuration's generation call and reading it immediately after, so that the reported number reflects only the memory used by that specific configuration. Without",
+          "gold_keywords": [
+            "get_peak_memory",
+            "reset_peak_memory"
+          ],
+          "quality_score": 0.0,
+          "peak_mb": 4892.649963378906,
+          "elapsed_s": 32.22112798690796,
+          "throughput_tok_s": 2.482842935619929,
+          "tokens_generated": 80,
+          "num_retrieved": 20,
+          "avg_bits": 4.0,
+          "key_compression": 3.2304347826086954,
+          "full_kv_compression": 3.1350210970464136
+        }
+      ]
+    }
+  ]
+}

--- a/veloxquant_mlx/rag/__init__.py
+++ b/veloxquant_mlx/rag/__init__.py
@@ -1,0 +1,17 @@
+"""Minimal retrieval-augmented generation (RAG) support for benchmarking.
+
+This subpackage is deliberately small: a fixed local corpus
+(:mod:`veloxquant_mlx.rag.corpus`) and a dependency-free TF-IDF retriever
+(:mod:`veloxquant_mlx.rag.retriever`). It exists to produce realistic
+"retrieved context + question" prompts for
+``benchmark_scripts/benchmark_rag_kivi.py``, which compares a standard fp16
+KV cache against :class:`~veloxquant_mlx.cache.kivi_cache.KIVIKVCache` on a
+RAG workload. It is not a production retrieval system.
+"""
+
+from veloxquant_mlx.rag.corpus import CORPUS
+from veloxquant_mlx.rag.eval_set import EVAL_SET
+from veloxquant_mlx.rag.retriever import TfidfRetriever
+from veloxquant_mlx.rag.scoring import keyword_overlap_score
+
+__all__ = ["CORPUS", "EVAL_SET", "TfidfRetriever", "keyword_overlap_score"]

--- a/veloxquant_mlx/rag/corpus.py
+++ b/veloxquant_mlx/rag/corpus.py
@@ -1,0 +1,485 @@
+"""Corpus for the RAG-vs-KIVI benchmark.
+
+Passages are grouped into four topics (KV cache internals, RAG mechanics,
+MLX/Apple Silicon, quantization background) so TF-IDF retrieval has a real
+discrimination task, and each passage is a full multi-paragraph piece (a
+few hundred tokens) rather than a one-liner. This matters for the
+benchmark's honesty: KIVI's memory case depends on the KV cache holding a
+prefill long enough that its per-group quantization overhead is amortized
+away, and a corpus of one-sentence passages caps every possible retrieved
+context at a few hundred tokens no matter how many are retrieved. With
+longer passages, retrieving most or all of the corpus (a high ``--k``)
+produces a multi-thousand-token prompt, which is the regime KIVI's
+reference benchmarks (and this repo's own long-context KIVI benchmarks)
+actually validate against.
+
+Each entry carries a topic tag purely for readability; the retriever does
+not use it.
+"""
+
+from __future__ import annotations
+
+CORPUS: list[dict[str, str]] = [
+    # --- KV cache / inference systems ---
+    {
+        "topic": "kv_cache",
+        "text": (
+            "A key-value cache stores the attention keys and values computed for "
+            "every previously generated token so a transformer does not need to "
+            "recompute them on each new step. During the prefill phase, when the "
+            "model processes the initial prompt, keys and values are computed for "
+            "every token in that prompt and written into the cache in one pass. "
+            "During the decode phase, each newly generated token only needs to "
+            "compute its own key and value and then attend over everything stored "
+            "so far, which is why generation is memory-bandwidth bound rather than "
+            "compute bound once the cache is large. The cache's memory footprint "
+            "grows linearly with sequence length, and separately scales with the "
+            "number of transformer layers and the number of attention heads per "
+            "layer, since every layer and every head keeps its own independent "
+            "set of keys and values. For a model with many layers and a long "
+            "context window, the KV cache can end up larger than the model's own "
+            "weights once the sequence is long enough, which is why it has become "
+            "a first-class target for compression research in its own right, "
+            "separate from weight quantization."
+        ),
+    },
+    {
+        "topic": "kv_cache",
+        "text": (
+            "On Apple Silicon, model weights and the KV cache share the same "
+            "unified memory pool as the operating system, the GPU driver, and "
+            "every other running application. This makes KV cache size a binding "
+            "constraint for long-context inference on Mac hardware in a way it "
+            "usually is not on discrete-GPU systems, where the GPU has its own "
+            "dedicated VRAM that is not shared with the host operating system. On "
+            "a laptop with, say, 24 gigabytes of unified memory, a large language "
+            "model's 4-bit weights might already consume several gigabytes before "
+            "a single token of context is processed, and the KV cache then "
+            "competes directly against that same budget as the context grows. "
+            "This is part of why on-device long-context inference on consumer "
+            "Apple Silicon hardware has historically been more memory-constrained "
+            "than throughput-constrained: the model can technically generate "
+            "tokens quickly enough, but there simply is not room in unified "
+            "memory to hold the keys and values for a very long conversation or "
+            "a very long retrieved document alongside everything else the "
+            "system needs."
+        ),
+    },
+    {
+        "topic": "kv_cache",
+        "text": (
+            "KIVI is a tuning-free asymmetric quantization method for the KV "
+            "cache, introduced in the paper 'KIVI: A Tuning-Free Asymmetric "
+            "2bit Quantization for KV Cache' (Liu, Yuan et al., ICML 2024). Its "
+            "central observation is that keys and values have different "
+            "statistical structure and therefore want different quantization "
+            "layouts. Keys tend to have a small number of high-variance "
+            "channels that dominate attention scores, so KIVI quantizes keys "
+            "per channel: it groups values along the token axis for each "
+            "channel and computes one scale and zero point per group, which "
+            "keeps those high-variance channels accurate. Values, by contrast, "
+            "are flatter across channels but vary more from token to token, so "
+            "KIVI quantizes values per token instead, grouping along the "
+            "channel axis. On top of this asymmetric scheme, KIVI keeps the "
+            "most recently generated tokens in full sixteen-bit precision "
+            "inside what it calls a residual window, because recent tokens "
+            "dominate attention scores and are cheap to store exactly; only "
+            "once a token ages out of that window does it get quantized into "
+            "the compressed region of the cache."
+        ),
+    },
+    {
+        "topic": "kv_cache",
+        "text": (
+            "Quantizing the KV cache trades a small amount of numerical "
+            "accuracy for a large reduction in memory usage. A 2-bit KV cache "
+            "can be roughly eight times smaller than a 16-bit fp16 cache for "
+            "the tokens it actually compresses, since two bits per value "
+            "versus sixteen bits per value is an eight-to-one reduction in raw "
+            "storage. In practice the realized compression ratio is somewhat "
+            "lower than that theoretical eight times, because group "
+            "quantization schemes like KIVI's store a scale and a zero point "
+            "per group of elements, and those scale and zero point values are "
+            "themselves kept at higher precision, usually fp16, to avoid "
+            "compounding quantization error. For a small group size, this "
+            "per-group overhead is proportionally larger relative to the "
+            "quantized codes themselves, which is why compression ratio "
+            "generally improves as the quantized region of the cache grows "
+            "large relative to the fixed number of scale-and-zero-point pairs "
+            "needed to describe it."
+        ),
+    },
+    {
+        "topic": "kv_cache",
+        "text": (
+            "On Apple Silicon's Metal backend, KIVI's memory savings do not "
+            "automatically translate into a throughput speedup, because the "
+            "reference implementation's throughput advantage comes from a "
+            "fused CUDA kernel that performs dequantization inline as part of "
+            "the attention computation itself, avoiding a separate pass over "
+            "the compressed cache. Metal has no direct equivalent of that "
+            "fused kernel, so a Metal port of KIVI must dequantize the "
+            "compressed keys and values back to full precision before handing "
+            "them to the standard attention computation, which adds work "
+            "rather than removing it. The expected win on Apple Silicon is "
+            "therefore memory, not tokens per second: a smaller KV cache "
+            "means more headroom in the shared unified memory pool for larger "
+            "models or longer contexts, but it does not by itself make token "
+            "generation faster, and in some configurations the extra "
+            "dequantization work can make generation measurably slower than "
+            "an uncompressed cache."
+        ),
+    },
+    {
+        "topic": "kv_cache",
+        "text": (
+            "The residual window is one of the more important practical "
+            "design choices in KIVI, and in most group-quantized KV cache "
+            "schemes generally. The idea is that the tokens generated most "
+            "recently are, on average, the ones that matter most to the "
+            "model's next prediction, both because of how attention scores "
+            "tend to concentrate on nearby context and because errors "
+            "introduced by quantizing those tokens would immediately and "
+            "directly affect the very next token generated. By keeping the "
+            "last R tokens, where R is a configurable residual length, in "
+            "full sixteen-bit precision and only quantizing tokens once they "
+            "fall outside that window, KIVI protects the part of the cache "
+            "that is most sensitive to error while still compressing the "
+            "much larger, older portion of the context that contributes less "
+            "sharply to any individual next-token prediction. The tradeoff is "
+            "that a larger residual window means more of the cache stays "
+            "uncompressed, which reduces the realized compression ratio for "
+            "short contexts where most of the sequence still falls inside "
+            "the window."
+        ),
+    },
+    # --- retrieval-augmented generation ---
+    {
+        "topic": "rag",
+        "text": (
+            "Retrieval-augmented generation, or RAG, combines a search step "
+            "over a document collection with a language model's generation "
+            "step, and was popularized as a way to let a language model "
+            "answer questions using information it was never trained on, or "
+            "information that has changed since training. The retrieved "
+            "passages are inserted into the model's prompt, typically ahead "
+            "of the user's actual question, so the model can ground its "
+            "answer in specific source text rather than relying purely on "
+            "facts encoded in its parameters during pretraining. This has two "
+            "practical benefits: it reduces hallucination, because the model "
+            "can quote or paraphrase from text that is directly in front of "
+            "it rather than guessing from memory, and it lets a system stay "
+            "current without retraining the underlying model, since updating "
+            "the answer to a question is often as simple as updating the "
+            "document collection the retriever searches over."
+        ),
+    },
+    {
+        "topic": "rag",
+        "text": (
+            "A typical RAG pipeline has two stages. First, a retriever ranks "
+            "candidate passages from a document collection by their "
+            "similarity to the user's query. This ranking step is usually "
+            "implemented with either a dense method, such as a learned vector "
+            "embedding compared by cosine similarity, or a sparse method, such "
+            "as TF-IDF or BM25, which score documents by term overlap and "
+            "term rarity rather than by a learned representation. Second, once "
+            "the top-ranked passages are selected, a language model reads "
+            "those passages together with the original query and produces a "
+            "grounded answer. The choice between dense and sparse retrieval is "
+            "itself a tradeoff: dense retrieval can capture semantic "
+            "similarity that goes beyond exact word overlap, but it requires "
+            "an embedding model and a vector index, while sparse retrieval "
+            "needs no learned components at all and is fully deterministic "
+            "and inspectable, which makes it attractive for small, "
+            "self-contained systems where introducing a new dependency is "
+            "undesirable."
+        ),
+    },
+    {
+        "topic": "rag",
+        "text": (
+            "Because RAG concatenates several retrieved passages into the "
+            "prompt before the model even begins generating a response, the "
+            "effective context length seen by the model grows directly with "
+            "the number of retrieved passages and their individual lengths. "
+            "This has a direct and often underappreciated consequence for "
+            "system design: increasing the number of retrieved passages, "
+            "often called k, to improve the odds that the relevant "
+            "information is included in the context also increases the size "
+            "of the KV cache the model must hold in memory during generation, "
+            "since every token in every retrieved passage gets its own key "
+            "and value stored across every layer and head of the model. A "
+            "system that retrieves many long passages for every query is "
+            "effectively choosing to run at a much longer context length than "
+            "one that retrieves few short passages, and that choice has real "
+            "memory and latency implications independent of how good the "
+            "retrieval ranking itself is."
+        ),
+    },
+    {
+        "topic": "rag",
+        "text": (
+            "TF-IDF retrieval scores how relevant a document is to a query by "
+            "combining two separate signals. Term frequency measures how "
+            "often a query term appears within a specific document, on the "
+            "reasoning that a document mentioning a term many times is more "
+            "likely to be about that term. Inverse document frequency measures "
+            "how rare that term is across the whole corpus, on the reasoning "
+            "that a term appearing in nearly every document, such as a common "
+            "word, carries little discriminating power, while a term that "
+            "appears in only a handful of documents is far more informative "
+            "about which specific documents are relevant. Multiplying these "
+            "two signals together means that a document scores highly only "
+            "when it contains query terms that are both frequent within that "
+            "document and rare across the corpus as a whole, which in "
+            "practice does a reasonable job of surfacing genuinely relevant "
+            "documents without any learned model or training data."
+        ),
+    },
+    {
+        "topic": "rag",
+        "text": (
+            "Answer quality in a RAG system is often evaluated by checking "
+            "whether the generated answer contains the expected facts or "
+            "keywords from a gold reference answer, rather than requiring an "
+            "exact string match, since language models rarely reproduce a "
+            "reference answer word for word even when they get the underlying "
+            "facts correct. Common approaches include keyword or phrase "
+            "overlap scoring, where an answer is scored by what fraction of a "
+            "predefined set of expected terms it mentions; automatic overlap "
+            "metrics such as ROUGE, which compare n-gram overlap between the "
+            "generated answer and a reference; and, increasingly, using "
+            "another language model as a judge to assess whether an answer is "
+            "factually consistent with the retrieved context. Each approach "
+            "trades off cost, reproducibility, and nuance differently: keyword "
+            "overlap is cheap, fully deterministic, and easy to audit by hand, "
+            "but it can miss answers that are correct yet phrased very "
+            "differently from the gold keywords."
+        ),
+    },
+    {
+        "topic": "rag",
+        "text": (
+            "The size of the document collection a retriever searches over "
+            "does not need to be large for RAG to be useful; even a small, "
+            "carefully curated corpus of a few dozen passages can meaningfully "
+            "improve answer grounding compared to relying on a model's raw "
+            "parametric knowledge, especially for niche or fast-changing "
+            "topics. What matters more than raw corpus size is topical "
+            "coverage and passage quality: a retriever can only surface "
+            "information that actually exists somewhere in the collection, so "
+            "a small corpus that thoroughly covers the topics a system expects "
+            "to be asked about can outperform a much larger but noisier or "
+            "more diffuse collection. This is part of why benchmark and "
+            "evaluation corpora for RAG systems are often deliberately kept "
+            "small and hand-curated rather than scraped indiscriminately from "
+            "the web, since a small corpus makes it far easier to verify that "
+            "every question in an evaluation set is actually answerable from "
+            "the material the retriever has access to."
+        ),
+    },
+    # --- Apple Silicon / MLX ---
+    {
+        "topic": "mlx",
+        "text": (
+            "MLX is an array framework designed for efficient machine "
+            "learning research and inference on Apple Silicon. It borrows "
+            "ideas from NumPy, PyTorch, and JAX, and its most distinctive "
+            "design choice is unified memory: because Apple Silicon chips "
+            "already share physical memory between the CPU and GPU at the "
+            "hardware level, MLX arrays live in that same shared pool and can "
+            "be operated on by either the CPU or the GPU without an explicit "
+            "copy between separate memory spaces. MLX also uses lazy "
+            "evaluation, meaning operations build up a computation graph "
+            "rather than executing immediately, and the graph is only "
+            "materialized when a result is actually needed, which lets MLX "
+            "fuse and optimize sequences of operations before running them. "
+            "This combination of unified memory and lazy evaluation is part "
+            "of why MLX programs can be noticeably more memory-efficient on "
+            "Apple Silicon than frameworks originally designed around "
+            "discrete-GPU memory models."
+        ),
+    },
+    {
+        "topic": "mlx",
+        "text": (
+            "mlx_lm is a library built on top of MLX specifically for running "
+            "large language models on Apple Silicon. It provides utilities "
+            "for loading pretrained models, including models already "
+            "quantized to four bits or lower, running text generation with "
+            "configurable sampling parameters, and a pluggable KV cache "
+            "interface that lets alternative cache implementations be "
+            "substituted for the standard full-precision cache. This "
+            "pluggable interface is what makes it possible to implement a "
+            "custom compressed cache, such as a KIVI-style quantized cache, "
+            "and use it as a drop-in replacement during generation: as long "
+            "as the custom cache implements the same update-and-fetch "
+            "protocol that mlx_lm's attention code expects, the rest of the "
+            "generation pipeline, including sampling, tokenization, and the "
+            "model's forward pass, does not need to change at all to benefit "
+            "from the compressed cache."
+        ),
+    },
+    {
+        "topic": "mlx",
+        "text": (
+            "Metal is Apple's low-level graphics and compute API, and it is "
+            "the layer through which MLX ultimately dispatches work to the "
+            "GPU on Apple Silicon. Custom Metal kernels, written in a C-like "
+            "shading language, can be compiled and dispatched directly from "
+            "Python code to accelerate operations that are not well served "
+            "by MLX's built-in operations, such as quantized group "
+            "dequantization, where many small groups of values each need "
+            "their own scale and zero point applied. Writing a dedicated "
+            "Metal kernel for such an operation avoids a round trip through "
+            "slower, more general-purpose code that would otherwise need "
+            "several separate passes over the data, and it is a common "
+            "pattern in KV-cache compression libraries to hand-write Metal "
+            "kernels for the specific quantize and dequantize operations a "
+            "given compression method needs, since those operations run on "
+            "the hot path of every single generation step."
+        ),
+    },
+    {
+        "topic": "mlx",
+        "text": (
+            "Peak memory usage in an MLX program can be measured with a "
+            "dedicated API that tracks the high-water mark of memory "
+            "allocated on the GPU, and that peak counter can be reset between "
+            "runs so that separate benchmark configurations do not "
+            "contaminate each other's peak readings. This is important "
+            "methodologically: without resetting the peak counter between, "
+            "for example, an fp16 baseline run and a quantized-cache run, the "
+            "reported peak for the second run could actually reflect memory "
+            "allocated during the first run that was never freed, making the "
+            "two configurations impossible to compare fairly. A correct "
+            "benchmark resets the peak counter immediately before each "
+            "configuration's generation call and reads it immediately after, "
+            "so that the reported number reflects only the memory that "
+            "configuration actually used."
+        ),
+    },
+    {
+        "topic": "mlx",
+        "text": (
+            "Apple Silicon chips use a unified memory architecture where the "
+            "CPU, GPU, and Neural Engine all access the same physical pool of "
+            "memory over a shared high-bandwidth interconnect, rather than "
+            "each having its own dedicated memory as is typical on systems "
+            "with a discrete GPU. This removes the need to explicitly copy "
+            "data between separate host and device memory spaces, which on "
+            "traditional GPU systems can be a meaningful source of latency "
+            "for workloads that move data back and forth frequently. The "
+            "tradeoff is that because the pool is shared, memory pressure "
+            "from any one consumer, whether that is the operating system, "
+            "another running application, or the model and its KV cache, "
+            "directly reduces what is available to everything else, which is "
+            "why memory efficiency work on Apple Silicon tends to focus as "
+            "much on reducing peak usage as on reducing raw compute time."
+        ),
+    },
+    # --- quantization background ---
+    {
+        "topic": "quantization",
+        "text": (
+            "Quantization reduces the number of bits used to represent a "
+            "numeric value. A typical example converts a sixteen-bit "
+            "floating point number into a low-bit-width integer code, such "
+            "as two, three, or four bits, plus a small amount of side "
+            "information, usually a shared scale and a zero point, that is "
+            "used to reconstruct an approximation of the original value from "
+            "the integer code. The core idea is that most numeric values in "
+            "a neural network's weights or activations cluster within a "
+            "relatively narrow range, so a small number of discrete levels "
+            "can represent that range with acceptable error, while the "
+            "memory savings from using far fewer bits per value can be "
+            "substantial: a four-bit representation uses a quarter of the "
+            "storage of a sixteen-bit one, and a two-bit representation uses "
+            "an eighth, before accounting for the overhead of the scale and "
+            "zero point themselves."
+        ),
+    },
+    {
+        "topic": "quantization",
+        "text": (
+            "Asymmetric quantization uses both a scale and a zero-point "
+            "offset when mapping real values to integer codes, in contrast "
+            "to symmetric quantization, which uses only a scale and assumes "
+            "the value range is centered around zero. Asymmetric "
+            "quantization can represent value ranges that are not centered "
+            "at zero considerably more accurately, because it can shift the "
+            "entire range to match wherever the actual data lies rather than "
+            "wasting representable levels on values that never occur. This "
+            "matters for KV cache quantization specifically because keys and "
+            "values are not generally centered around zero and their "
+            "distributions can shift meaningfully across different layers, "
+            "different attention heads, and different channels within a "
+            "head, so a scheme that can adapt its zero point locally, rather "
+            "than assuming a fixed symmetric range everywhere, tends to "
+            "produce noticeably lower quantization error in practice."
+        ),
+    },
+    {
+        "topic": "quantization",
+        "text": (
+            "Group quantization splits a tensor into small contiguous groups "
+            "of elements and computes a separate scale and zero point for "
+            "each group independently, rather than computing a single scale "
+            "and zero point for the entire tensor at once. This better "
+            "captures local variation in the data's range: if some regions "
+            "of a tensor have a much wider spread of values than others, a "
+            "single global scale would either waste precision on the "
+            "narrow-range regions or clip and lose accuracy on the "
+            "wide-range regions, whereas per-group scales let each region "
+            "use a scale suited to its own local range. The tradeoff is "
+            "storage overhead, since every group needs its own stored scale "
+            "and zero point rather than sharing one across the whole tensor; "
+            "smaller group sizes generally improve accuracy but increase "
+            "that per-group overhead, while larger group sizes reduce "
+            "overhead but can blur over local variation within a group."
+        ),
+    },
+    {
+        "topic": "quantization",
+        "text": (
+            "A quantization method is called tuning-free when it requires no "
+            "calibration dataset or learned parameters to choose its scales, "
+            "zero points, or codebooks, in contrast to methods that fit a "
+            "codebook or set of quantization parameters to a representative "
+            "sample of activations before deployment. Tuning-free methods "
+            "compute their quantization parameters directly and "
+            "deterministically from the data being quantized at the moment "
+            "it is quantized, typically using simple statistics such as the "
+            "minimum and maximum value within a group. This has two "
+            "practical benefits: there is no separate calibration step or "
+            "calibration dataset to maintain, and the method's output is "
+            "fully deterministic and reproducible, since it involves no "
+            "randomness or learned state that could vary between runs or "
+            "between different calibration samples, which is a meaningful "
+            "advantage for benchmarking and debugging."
+        ),
+    },
+    {
+        "topic": "quantization",
+        "text": (
+            "The cost of storing quantization side information, such as "
+            "per-group scales and zero points, is a fixed overhead per group "
+            "regardless of how large that group is, which means the "
+            "proportional overhead of quantization depends heavily on how "
+            "much data is actually being compressed relative to the number "
+            "of groups needed to describe it. For a very small amount of "
+            "data split into many small groups, the side information can "
+            "approach or even exceed the size of the compressed codes "
+            "themselves, largely erasing the benefit of quantizing at all. "
+            "For a large amount of data, the same fixed per-group overhead "
+            "is amortized across far more quantized values, so the realized "
+            "compression ratio approaches the theoretical bits-per-value "
+            "ratio much more closely. This is a general property of group "
+            "quantization schemes, not specific to any one method, and it is "
+            "why compression benchmarks that use very short sequences can "
+            "understate or even invert the memory benefit that the same "
+            "method shows on long sequences."
+        ),
+    },
+]

--- a/veloxquant_mlx/rag/eval_set.py
+++ b/veloxquant_mlx/rag/eval_set.py
@@ -1,0 +1,54 @@
+"""Small grounded QA eval set for the RAG-vs-KIVI benchmark.
+
+Each question is answerable from one or more passages in
+:data:`veloxquant_mlx.rag.corpus.CORPUS`. ``gold_keywords`` lists the
+distinct facts/terms a correct, grounded answer should mention; scoring is a
+simple case-insensitive keyword-overlap fraction (see
+:mod:`veloxquant_mlx.rag.scoring`), not exact string match, since free-form
+generations rarely match a reference string verbatim.
+"""
+
+from __future__ import annotations
+
+EVAL_SET: list[dict] = [
+    {
+        "question": "What does a key-value cache store, and why does its size grow with sequence length?",
+        "gold_keywords": ["keys", "values", "attention", "previously generated", "token"],
+    },
+    {
+        "question": "Why is KV cache size a binding constraint for long-context inference on Apple Silicon?",
+        "gold_keywords": ["unified memory", "shared", "operating system"],
+    },
+    {
+        "question": "How does KIVI quantize keys versus values?",
+        "gold_keywords": ["per channel", "per token", "residual"],
+    },
+    {
+        "question": "Why doesn't KIVI's memory saving translate into a Metal throughput speedup?",
+        "gold_keywords": ["cuda kernel", "metal", "no direct", "equivalent"],
+    },
+    {
+        "question": "What are the two stages of a typical RAG pipeline?",
+        "gold_keywords": ["retriever", "rank", "language model", "generate"],
+    },
+    {
+        "question": "How does retrieving more passages in RAG affect the KV cache?",
+        "gold_keywords": ["context length", "grows", "kv cache"],
+    },
+    {
+        "question": "How does TF-IDF score how relevant a document is to a query?",
+        "gold_keywords": ["term", "frequency", "rare", "distinctive"],
+    },
+    {
+        "question": "What is the residual window in a quantized KV cache?",
+        "gold_keywords": ["recently generated", "full precision", "not", "quantized"],
+    },
+    {
+        "question": "What lets MLX share arrays between the CPU and GPU without copying?",
+        "gold_keywords": ["unified memory", "lazy evaluation"],
+    },
+    {
+        "question": "How can you measure and reset peak memory usage in an MLX program?",
+        "gold_keywords": ["get_peak_memory", "reset_peak_memory"],
+    },
+]

--- a/veloxquant_mlx/rag/retriever.py
+++ b/veloxquant_mlx/rag/retriever.py
@@ -1,0 +1,111 @@
+"""A minimal, dependency-free TF-IDF retriever for the RAG benchmark.
+
+This is intentionally simple: it exists to produce a realistic "retrieved
+context + question" prompt for exercising the KV cache under a RAG-style
+workload, not to be a production retrieval system. No embedding model,
+vector database, or new third-party dependency is used — cosine similarity
+over TF-IDF vectors built with plain Python/``numpy`` (already a core
+dependency of this repo) is sufficient for a ~20-50 passage corpus.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+import numpy as np
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+@dataclass
+class TfidfRetriever:
+    """TF-IDF + cosine-similarity retriever over a fixed list of passages.
+
+    Args:
+        passages: The documents to index (plain strings).
+    """
+
+    passages: list[str]
+    _vocab: dict[str, int] = field(init=False, default_factory=dict)
+    _idf: np.ndarray = field(init=False, default=None)
+    _doc_vectors: np.ndarray = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        if not self.passages:
+            raise ValueError("TfidfRetriever requires at least one passage")
+
+        doc_tokens = [_tokenize(p) for p in self.passages]
+
+        vocab: dict[str, int] = {}
+        for tokens in doc_tokens:
+            for tok in set(tokens):
+                vocab.setdefault(tok, len(vocab))
+        self._vocab = vocab
+
+        n_docs = len(self.passages)
+        n_terms = len(vocab)
+        doc_freq = np.zeros(n_terms, dtype=np.float64)
+        tf = np.zeros((n_docs, n_terms), dtype=np.float64)
+
+        for i, tokens in enumerate(doc_tokens):
+            counts = Counter(tokens)
+            total = max(len(tokens), 1)
+            for tok, c in counts.items():
+                j = vocab[tok]
+                tf[i, j] = c / total
+                doc_freq[j] += 1
+
+        # Smoothed IDF (add-one in numerator and denominator) so terms that
+        # appear in every document don't collapse to zero weight.
+        self._idf = np.log((1.0 + n_docs) / (1.0 + doc_freq)) + 1.0
+
+        vectors = tf * self._idf[None, :]
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        self._doc_vectors = vectors / norms
+
+    def _vectorize_query(self, query: str) -> np.ndarray:
+        tokens = _tokenize(query)
+        vec = np.zeros(len(self._vocab), dtype=np.float64)
+        if not tokens:
+            return vec
+        counts = Counter(tokens)
+        total = max(len(tokens), 1)
+        for tok, c in counts.items():
+            j = self._vocab.get(tok)
+            if j is not None:
+                vec[j] = (c / total) * self._idf[j]
+        norm = math.sqrt(float(np.dot(vec, vec)))
+        if norm > 0.0:
+            vec = vec / norm
+        return vec
+
+    def retrieve(self, query: str, k: int = 5) -> list[str]:
+        """Return the top-``k`` passages by cosine similarity to ``query``.
+
+        Ties and an empty/out-of-vocabulary query fall back to corpus order
+        so the result is always deterministic and always has length
+        ``min(k, len(passages))``.
+        """
+        if k <= 0:
+            return []
+        q = self._vectorize_query(query)
+        scores = self._doc_vectors @ q
+        order = np.argsort(-scores, kind="stable")[: min(k, len(self.passages))]
+        return [self.passages[i] for i in order]
+
+    def retrieve_with_scores(self, query: str, k: int = 5) -> list[tuple[str, float]]:
+        """Same as :meth:`retrieve` but also returns the cosine similarity."""
+        if k <= 0:
+            return []
+        q = self._vectorize_query(query)
+        scores = self._doc_vectors @ q
+        order = np.argsort(-scores, kind="stable")[: min(k, len(self.passages))]
+        return [(self.passages[i], float(scores[i])) for i in order]

--- a/veloxquant_mlx/rag/scoring.py
+++ b/veloxquant_mlx/rag/scoring.py
@@ -1,0 +1,32 @@
+"""Dependency-free answer-quality scoring for the RAG benchmark.
+
+Deliberately not an LLM-judge and not a metric requiring a new dependency
+(e.g. ``rouge-score``, which is not installed in this repo's environment) —
+a keyword-overlap fraction is enough to compare fp16 vs KIVI answer quality
+on a small, fixed eval set where every question has known gold keywords.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def keyword_overlap_score(answer: str, gold_keywords: list[str]) -> float:
+    """Fraction of ``gold_keywords`` phrases found in ``answer`` (case-insensitive).
+
+    A keyword counts as present if all of its whitespace-separated words
+    appear, in order, as a substring of the lowercased/normalized answer
+    (so "per channel" matches "quantizes keys per channel" but not
+    "channel per quant").
+    """
+    if not gold_keywords:
+        return 1.0
+    normalized = " ".join(_TOKEN_RE.findall(answer.lower()))
+    hits = 0
+    for phrase in gold_keywords:
+        phrase_norm = " ".join(_TOKEN_RE.findall(phrase.lower()))
+        if phrase_norm and phrase_norm in normalized:
+            hits += 1
+    return hits / len(gold_keywords)

--- a/veloxquant_mlx/tests/rag/test_retriever.py
+++ b/veloxquant_mlx/tests/rag/test_retriever.py
@@ -1,0 +1,90 @@
+"""Tests for TfidfRetriever — fast, no model loading, no network."""
+
+from __future__ import annotations
+
+import pytest
+
+from veloxquant_mlx.rag.corpus import CORPUS
+from veloxquant_mlx.rag.retriever import TfidfRetriever
+from veloxquant_mlx.rag.scoring import keyword_overlap_score
+
+_FIXTURE = [
+    "The quick brown fox jumps over the lazy dog in the sunny meadow.",
+    "Apple Silicon uses a unified memory architecture shared by CPU and GPU.",
+    "A key-value cache stores attention keys and values for past tokens.",
+    "Quantization reduces the number of bits used to represent a value.",
+    "The lazy dog slept all afternoon near the quiet meadow fence.",
+]
+
+
+def test_retrieve_returns_k_results() -> None:
+    r = TfidfRetriever(_FIXTURE)
+    out = r.retrieve("unified memory CPU GPU", k=2)
+    assert len(out) == 2
+
+
+def test_retrieve_ranks_relevant_passage_first() -> None:
+    r = TfidfRetriever(_FIXTURE)
+    out = r.retrieve("what does a key-value cache store", k=1)
+    assert "key-value cache" in out[0]
+
+
+def test_retrieve_k_larger_than_corpus_returns_all() -> None:
+    r = TfidfRetriever(_FIXTURE)
+    out = r.retrieve("quantization bits value", k=100)
+    assert len(out) == len(_FIXTURE)
+
+
+def test_retrieve_k_zero_returns_empty() -> None:
+    r = TfidfRetriever(_FIXTURE)
+    assert r.retrieve("anything", k=0) == []
+
+
+def test_retrieve_empty_query_is_deterministic_and_full_length() -> None:
+    r = TfidfRetriever(_FIXTURE)
+    out = r.retrieve("", k=3)
+    assert len(out) == 3
+
+
+def test_retrieve_out_of_vocabulary_query_falls_back_to_corpus_order() -> None:
+    r = TfidfRetriever(_FIXTURE)
+    out = r.retrieve("zzz qqq nonexistentword", k=3)
+    assert out == _FIXTURE[:3]
+
+
+def test_retrieve_with_scores_sorted_descending() -> None:
+    r = TfidfRetriever(_FIXTURE)
+    scored = r.retrieve_with_scores("quantization bits value", k=5)
+    scores = [s for _, s in scored]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_retriever_rejects_empty_corpus() -> None:
+    with pytest.raises(ValueError):
+        TfidfRetriever([])
+
+
+def test_real_corpus_retrieves_relevant_topic() -> None:
+    passages = [p["text"] for p in CORPUS]
+    r = TfidfRetriever(passages)
+    out = r.retrieve("How does KIVI quantize keys and values in the KV cache?", k=3)
+    assert any("KIVI" in p for p in out)
+
+
+def test_keyword_overlap_score_full_match() -> None:
+    answer = "KIVI quantizes keys per channel and values per token, keeping a residual window."
+    assert keyword_overlap_score(answer, ["per channel", "per token", "residual"]) == 1.0
+
+
+def test_keyword_overlap_score_partial_match() -> None:
+    answer = "KIVI quantizes keys per channel."
+    score = keyword_overlap_score(answer, ["per channel", "per token", "residual"])
+    assert score == pytest.approx(1 / 3)
+
+
+def test_keyword_overlap_score_no_match() -> None:
+    assert keyword_overlap_score("completely unrelated text", ["per channel", "residual"]) == 0.0
+
+
+def test_keyword_overlap_score_empty_keywords_is_perfect() -> None:
+    assert keyword_overlap_score("anything", []) == 1.0


### PR DESCRIPTION
## Summary
- Adds a small, dependency-free RAG pipeline (`veloxquant_mlx/rag/`: TF-IDF retriever, fixed corpus, grounded eval set, keyword-overlap scoring) used to build realistic retrieval-augmented prompts.
- Adds `benchmark_scripts/benchmark_rag_kivi.py`, which runs the same RAG workload against a standard fp16 `mlx_lm` KV cache and against `KIVIKVCache`, measuring peak memory, latency, throughput, and answer quality side by side. Mirrors `benchmark_kivi.py`'s cache-construction pattern; always times the fp16 baseline for real.
- Adds a docs-site blog post walking through what was measured, including a follow-up test scaling from a 1B to a 7B model and from ~250 to ~3,700-token contexts, with the underlying math for why KV-cache compression ratio doesn't always translate into end-to-end memory savings at this scale.
- Committed result JSONs from actual runs (1B/short context, 7B/short context, 7B/long context) for reproducibility.

## Key finding
KIVI's compressed-byte accounting is correct and improves with context length (2.33× → 2.91× → 3.12× full-KV compression as context grew from ~250 to ~3,700 tokens), but total process peak memory never dropped in any run. The math explains why: at ~3,700 tokens on Qwen2.5-7B, KIVI's real saving is ~138 MB against a ~4.9 GB process peak (weights dominate) — under 3%, inside normal allocator/measurement noise. No Metal throughput win was expected or observed, consistent with this repo's existing KIVI documentation.

## Test plan
- [x] `pytest veloxquant_mlx/tests/rag/` — 13 tests, all passing, no model loading
- [x] `pytest veloxquant_mlx/tests/cache/test_kivi_cache.py` — confirms no KIVI internals were touched
- [x] Ran `benchmark_scripts/benchmark_rag_kivi.py` end-to-end against `mlx-community/Llama-3.2-1B-Instruct-4bit` and `mlx-community/Qwen2.5-7B-Instruct-4bit` at multiple context lengths on an Apple M4

🤖 Generated with [Claude Code](https://claude.com/claude-code)