### PR TITLE
research(kernels): roofline analysis of KV-cache kernels (issue #259)

### DIFF
--- a/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
+++ b/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
@@ -1,0 +1,217 @@
+# KV-Cache Kernel Roofline Analysis (issue #259)
+
+## TL;DR
+
+VeloxQuant's quantize/dequantize/fused-attend Metal kernels are, as
+expected, **overwhelmingly memory-bound by construction** — none of them
+does enough arithmetic per byte touched to ever be compute-bound (argmin
+over ≤16 centroids, a min/max reduction, or a dot product against a long
+but thin K/V cache). Measured arithmetic intensity across all kernels
+tested is **1–11 FLOPs/byte**, far below the point where any Apple Silicon
+GPU's compute throughput would become the constraint. Two of the four
+measured kernels reach 55–102% of this machine's calibrated memory
+bandwidth at large sizes, confirming the roofline model's prediction
+directly. The interesting exception — `scalar_fused_decode_attend`, the
+fused dequantize+attention kernel — **never becomes memory-bound even at
+16k cached tokens**, topping out at 6% of peak bandwidth. That is not a
+bandwidth problem; the occupancy sweep in this analysis shows it is
+**dispatch/occupancy-bound**: realistic single-token decode shapes
+(`B*H*S_q` small) launch too few threadgroups to fill a 10-core GPU,
+regardless of how much data any one threadgroup has to move.
+
+This complements, not duplicates, the existing prefill roofline
+([blogs/prefill-roofline.md](../blogs/prefill-roofline.md)), which applied
+issue #259's methodology to the *compute-bound* causal-prefill regime
+(`S_q ≈ S_kv`, both large — dominated by big matmuls). This analysis covers
+what #259 actually names: the KV-cache read/write kernels, which are a
+different regime (decode: one query against a long cache, low reuse).
+
+## Method
+
+Following the same self-calibration principle as the prefill roofline
+(never trust an unverified spec-sheet bandwidth number):
+
+1. **Theoretical bytes moved** and **FLOPs** are derived analytically from
+   each kernel's own `.metal` source — input/output shapes, dtypes, and
+   documented per-element work (see each kernel's docstring in
+   `scripts/kv_kernel_roofline_bench.py`).
+2. **Arithmetic intensity** = FLOPs / bytes.
+3. **Achieved bandwidth** = bytes / measured latency; achieved GFLOP/s =
+   FLOPs / measured latency.
+4. **Calibrated bandwidth peak**: measured directly on this GPU, this run,
+   via a large elementwise op (`a * 2.0` at 100M–300M fp16 elements) —
+   mirrors `_calibrate_matmul_peak()` in `prefill_roofline_bench.py`, which
+   found the naive spec-sheet-derived FLOPs number was off by ~3x. On this
+   machine: **~97–99 GB/s achieved** (some run-to-run variance, same
+   caveat the prefill roofline noted — see below).
+5. **Classification**: ≥60% of calibrated peak bandwidth ⇒ memory-bound.
+   Below that, latency within ~2x of the same kernel's smallest-tested-size
+   latency ⇒ launch-bound (fixed dispatch overhead dominates). Otherwise ⇒
+   occupancy-limited — neither bandwidth- nor launch-dominated, confirmed
+   separately via a threadgroup-count sweep at fixed problem size.
+
+Hardware: one Apple M4 (10-core GPU, 24 GB), the same machine used for the
+prefill roofline — see that document's own caveat about run-to-run
+variance from thermal/scheduling effects; numbers here were reproduced
+across two runs and agreed within a few percent except where noted.
+
+## Results
+
+### `turboquant_scalar_quantize` — nearest-centroid encode (argmin over 2^b centroids)
+
+| N | b | latency | GB/s | % peak | AI (F/B) | class |
+|---|---|---|---|---|---|---|
+| 10,000 | 2 | 0.20 ms | 0.2 | 0.2% | 2.67 | launch-bound |
+| 1,000,000 | 2 | 0.25 ms | 12.2 | 12.3% | 2.67 | launch-bound |
+| 16,000,000 | 2 | 0.92 ms | 51.9 | 52.2% | 2.67 | occupancy-limited (near memory-bound) |
+| 10,000 | 4 | 0.18 ms | 0.2 | 0.2% | 10.67 | launch-bound |
+| 1,000,000 | 4 | 0.24 ms | 12.4 | 12.5% | 10.67 | launch-bound |
+| 16,000,000 | 4 | 0.88 ms | 54.6 | 54.9% | 10.67 | occupancy-limited (near memory-bound) |
+
+Even at b=4 (16 centroids scanned per element, the highest FLOPs/byte
+tested), AI stays at 10.67 — nowhere near compute-bound. Bandwidth climbs
+toward ~55% of peak as N grows and plateaus; it doesn't clearly cross the
+60% memory-bound threshold at the largest size tested here, so more
+headroom may exist at even larger N (not tested — see Limitations).
+
+### `turboquant_scalar_dequantize` — centroid gather decode (zero arithmetic)
+
+| N | b | latency | GB/s | % peak | class |
+|---|---|---|---|---|---|
+| 10,000 | 2/4 | ~0.17 ms | 0.2 | 0.2% | launch-bound |
+| 1,000,000 | 2/4 | ~0.23 ms | 13.0 | 13.2% | launch-bound |
+| 16,000,000 | 2 | 0.78 ms | 61.5 | 61.8% | **memory-bound** |
+| 16,000,000 | 4 | 0.79 ms | 60.6 | 61.0% | **memory-bound** |
+
+Zero FLOPs per element by design (a pure gather) — this is the purest test
+of the memory-bound hypothesis in this suite, and it confirms it directly:
+at large N the kernel crosses the 60% threshold and sits within ~40% of
+this machine's calibrated bandwidth ceiling, doing no arithmetic at all.
+
+### `kivi_group_quant_dequant` — group-affine quantize+dequantize (fused, group_size=32)
+
+| shape (BH×S×D) | latency | GB/s | % peak | AI (F/B) | class |
+|---|---|---|---|---|---|
+| 8×128×128 | 0.20 ms | 4.0 | 4.0% | 1.17 | launch-bound |
+| 32×512×128 | 0.32 ms | 38.8 | 39.0% | 1.17 | launch-bound |
+| 32×4096×128 | 0.99 ms | 101.6 | **102.2%** | 1.17 | **memory-bound** |
+
+The cleanest confirmation in this analysis: at the largest tested shape
+(32 batch-heads × 4096 tokens × 128 channels — a realistic long-context
+KIVI cache size) this kernel **matches or slightly exceeds** the
+calibrated bandwidth ceiling (102%, within measurement/calibration noise
+of 100%). It's genuinely memory-bound and, at this size, essentially
+optimal against the bandwidth roofline — there is no headroom left for a
+faster kernel to capture without moving fewer bytes.
+
+### `scalar_fused_decode_attend` — fused group-affine decode + attention
+
+| S_kv | D | latency | GB/s | % peak | AI (F/B) | class |
+|---|---|---|---|---|---|---|
+| 128 | 128 | 0.25 ms | 1.3 | 1.3% | 1.62 | launch-bound |
+| 2,048 | 128 | 0.98 ms | 5.3 | 5.4% | 1.62 | occupancy-limited |
+| 16,384 | 128 | 6.92 ms | 6.1 | 6.1% | 1.62 | occupancy-limited |
+
+This is the interesting negative result. Unlike the other three kernels,
+**bandwidth utilization never climbs meaningfully with problem size** — it
+goes from 1.3% to 6.1% as S_kv grows 128x, nowhere near the 55–100%
+other kernels reach at comparable byte counts. AI stays low (1.62), so
+it's not compute-bound either. The kernel dispatches exactly one
+threadgroup per `(batch, head, query position)` — at a realistic single
+decode step (`B=1, H=8, S_q=1`), that's only **8 threadgroups total**, far
+too few to fill a 10-core GPU regardless of how many bytes each
+threadgroup streams through S_kv.
+
+**Occupancy sweep** (fixed S_kv=16384, D=128, varying dispatched threadgroup count):
+
+| B | H | S_q | threadgroups | latency | GB/s | % peak |
+|---|---|---|---|---|---|---|
+| 1 | 8 | 1 | 8 | 6.95 ms | 6.0 | 6.1% |
+| 1 | 32 | 1 | 32 | 7.74 ms | 21.7 | 21.8% |
+| 4 | 32 | 1 | 128 | 18.4 ms | 36.5 | 36.7% |
+
+Bandwidth utilization scales with threadgroup count, not with S_kv or
+bytes moved per threadgroup — direct evidence this kernel is
+**occupancy/dispatch-bound**, not memory- or compute-bound, at the shapes
+that matter for real single-token decode (few heads, batch size 1). This
+matches the kernel's own design comment
+(`_scalar_attend.py`: "A single 32-lane pass over S_kv under-fills the GPU
+for decode shapes... so the kv axis is split flash-decoding style") —
+that split (NSG_C SIMD-groups per threadgroup) helps *within* a
+threadgroup, but doesn't add threadgroups, so it can't fix under-dispatch
+at the B*H*S_q level tested here.
+
+## Classification summary
+
+| Kernel | Regime | Bottleneck at realistic scale |
+|---|---|---|
+| `turboquant_scalar_quantize` | argmin, AI 2.67–10.67 | memory-bound (trending toward it, ~55% at largest N tested) |
+| `turboquant_scalar_dequantize` | pure gather, AI ≈ 0 | **memory-bound** (confirmed, ~61% of peak) |
+| `kivi_group_quant_dequant` | group reduce + fused write, AI 1.17 | **memory-bound** (confirmed, ~102% of peak) |
+| `scalar_fused_decode_attend` | fused decode+attend, AI 1.62 | **occupancy/dispatch-bound**, not bandwidth — confirmed via threadgroup-count sweep |
+
+No kernel measured here is compute-bound, and none showed evidence of
+synchronization-bound behavior in isolation (the fused-attend kernel's
+online-softmax merge uses one `threadgroup_barrier` per threadgroup,
+amortized over its full S_kv loop — negligible at the S_kv sizes tested).
+The one real surprise is that **the fused-attend kernel's problem isn't
+memory bandwidth at all** — it's that a single-query decode step doesn't
+generate enough parallel work to fill a modern GPU's core count, no matter
+how efficiently each unit of that work is streamed.
+
+## Recommendation
+
+1. **Kernels already at or near the bandwidth roofline** (`kivi_group_quant_dequant`
+   at 102%, `turboquant_scalar_dequantize` at 61%) are not worth further
+   micro-optimization — the only way to speed them up is to move fewer
+   bytes (smaller codes / narrower groups / avoiding materializing
+   intermediates), not to tune the kernel's arithmetic.
+2. **`scalar_fused_decode_attend`'s bottleneck is occupancy, not
+   bandwidth or FLOPs** — the fix is architectural, not a kernel-internals
+   tune. The obvious lever from the occupancy sweep: dispatch more
+   threadgroups per call by processing multiple layers or multiple
+   requests in one kernel launch (batching across what's currently
+   separate per-layer Python-level calls), rather than trying to make a
+   single (B=1, H=8, S_q=1) dispatch stream memory faster — there simply
+   isn't enough independent work in that shape to fill the GPU, at any
+   bandwidth. This is a concrete, scoped follow-up for a future issue, not
+   attempted here (this issue is investigation-only, per its own framing).
+3. **`turboquant_scalar_quantize` didn't clearly cross the memory-bound
+   threshold even at 16M elements** (52–55%, vs. 61–102% for the other
+   two bandwidth-confirmed kernels) — worth a follow-up at larger N to see
+   whether it plateaus below the ceiling (suggesting real headroom, e.g.
+   from its per-element centroid-scan loop not being fully hidden by
+   memory latency) or simply needs more elements to amortize dispatch
+   overhead the same way the others did. Not resolved here.
+
+## Limitations
+
+- **One machine, one GPU tier.** All numbers are from a base 10-core Apple
+  M4, 24 GB — the same caveat the prefill roofline gives. Occupancy
+  headroom in particular is core-count-dependent; a higher-tier Apple GPU
+  (more cores) would likely show occupancy-limited kernels hitting the
+  ceiling at even larger threadgroup counts than tested here.
+- **No GPU-level profiling.** Metal System Trace / GPU performance
+  counters (real occupancy %, actual achieved bandwidth per counter
+  rather than inferred from wall-clock latency) weren't used — the
+  bandwidth/occupancy story here is inferred from black-box latency
+  measurements and the kernels' own dispatch-shape documentation, the
+  same limitation the prefill roofline's Step 4 flagged for its own
+  root-cause hypothesis.
+- **`turboquant_scalar_quantize`'s trend at N > 16M is untested** (see
+  Recommendation #3).
+- **Synchronization-bound behavior wasn't isolated with a dedicated
+  experiment** (e.g. varying `NSG_C` and measuring barrier count vs.
+  throughput directly) — the conclusion that no kernel here is
+  synchronization-bound rests on reading the source's barrier structure,
+  not a targeted measurement.
+
+## Reproduction
+
+```
+python scripts/kv_kernel_roofline_bench.py
+```
+
+Deterministic inputs (fixed `np.random.default_rng` seeds); re-run 2-3x
+and compare, per the prefill roofline's own observed run-to-run variance
+on this hardware.

--- a/scripts/kv_kernel_roofline_bench.py
+++ b/scripts/kv_kernel_roofline_bench.py
@@ -1,0 +1,347 @@
+"""Roofline analysis of VeloxQuant's decode-side quantize/dequantize kernels.
+
+Issue #259: classify VeloxQuant's KV-cache kernels by arithmetic intensity
+(FLOPs/byte) and compare achieved vs. theoretical memory bandwidth, to
+identify whether each kernel is compute-bound, memory-bound, launch-bound,
+or synchronization-bound *before* spending effort optimizing it further.
+
+Unlike issue #277's prefill roofline (``prefill_roofline_bench.py``, FLOPs
+vs. a calibrated matmul-TFLOP/s ceiling — that workload is compute-bound),
+this script targets the KV-cache read/write kernels #259 was actually
+scoped around: quantize, dequantize, and fused dequantize+attend. Decode
+touches one query against a long cache — low reuse, low arithmetic
+intensity — so the right ceiling to calibrate against is memory bandwidth,
+not FLOPs. Both scripts follow the same principle: never trust an
+unverified spec-sheet number, measure the machine's own achieved ceiling
+on the same run.
+
+Method
+------
+For each kernel:
+  1. Compute *theoretical* bytes moved (bytes read + bytes written, from
+     the kernel's own input/output shapes/dtypes) and FLOPs done, from the
+     .metal source's documented per-element work.
+  2. Compute arithmetic intensity = FLOPs / bytes.
+  3. Measure achieved latency, derive achieved bandwidth (bytes / time)
+     and achieved FLOP/s (flops / time).
+  4. Compare achieved bandwidth against a self-calibrated memory-bandwidth
+     ceiling (large elementwise op on this GPU, this run — see
+     ``_calibrate_bandwidth_peak``, mirroring ``_calibrate_matmul_peak`` in
+     ``prefill_roofline_bench.py``).
+  5. Classify: achieved-bandwidth/peak-bandwidth near 100% at very low
+     arithmetic intensity => memory-bound, the roofline model's expected
+     outcome for a gather/argmin-shaped kernel. A low % at low sizes with a
+     latency floor that doesn't shrink with size suggests launch-bound
+     (fixed dispatch overhead dominating a tiny kernel) rather than
+     memory-bound; that's read off by comparing the smallest and largest
+     tested sizes for each kernel, not from a single-point measurement.
+
+Usage: python scripts/kv_kernel_roofline_bench.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import mlx.core as mx
+import numpy as np
+
+from veloxquant_mlx.metal._kivi_quant import kivi_group_quant_dequant
+from veloxquant_mlx.metal._scalar_attend import scalar_fused_decode_attend
+from veloxquant_mlx.metal._scalar_quant import (
+    turboquant_scalar_dequantize,
+    turboquant_scalar_quantize,
+)
+
+N_WARMUP, N_ITER = 5, 30
+
+
+def _bench(fn, n_warmup: int = N_WARMUP, n_iter: int = N_ITER) -> float:
+    for _ in range(n_warmup):
+        mx.eval(fn())
+    t0 = time.perf_counter()
+    for _ in range(n_iter):
+        mx.eval(fn())
+    return (time.perf_counter() - t0) / n_iter
+
+
+def _calibrate_bandwidth_peak() -> float:
+    """Achieved GB/s on a large elementwise op — the practical bandwidth
+    ceiling memory-bound kernels can realistically approach on this GPU, as
+    opposed to an unverified spec-sheet unified-memory-bandwidth number.
+    Mirrors ``_calibrate_matmul_peak`` in ``prefill_roofline_bench.py``."""
+    best = 0.0
+    for n in (100_000_000, 200_000_000, 300_000_000):
+        a = mx.random.normal((n,)).astype(mx.float16)
+        mx.eval(a)
+        t = _bench(lambda: a * 2.0, n_warmup=3, n_iter=8)
+        bytes_moved = n * 2 * 2  # fp16 read + fp16 write
+        best = max(best, bytes_moved / t / 1e9)
+    return best
+
+
+def _classify(pct_of_peak: float, latency_ms: float, latency_floor_ms: float) -> str:
+    """Classify one measured point given the *smallest tested size's*
+    latency for the same kernel (``latency_floor_ms``) as a launch-overhead
+    reference. A point within ~2x of that floor is dominated by fixed
+    per-dispatch cost, not by the bytes/FLOPs it's actually moving/doing —
+    regardless of its own size in isolation, which is why this takes the
+    floor as an explicit argument rather than inferring it from element
+    count (element count and threadgroup count aren't comparable units
+    across different kernels)."""
+    if pct_of_peak >= 60.0:
+        return "memory-bound"
+    if latency_ms < 2.0 * latency_floor_ms:
+        return "launch-bound (within 2x of this kernel's smallest-size latency floor)"
+    return "underutilized (occupancy-limited — see occupancy sweep, not bandwidth- or launch-dominated)"
+
+
+def bench_scalar_quantize(peak_gbs: float) -> None:
+    """turboquant_scalar_quantize: nearest-centroid argmin, b in {1,2,4}.
+
+    Per element: read 1 fp16 (2B), N_CENTS=2^b distance comparisons
+    (2 FLOPs each: subtract + multiply), write 1 uint8 (1B).
+    """
+    print("=" * 78)
+    print("turboquant_scalar_quantize — nearest-centroid encode")
+    print("=" * 78)
+    print(
+        f"{'N':>10} {'b':>2} {'lat (ms)':>10} {'GB/s':>8} {'%peak':>7} "
+        f"{'AI (F/B)':>9} {'GFLOP/s':>9}  class"
+    )
+    rng = np.random.default_rng(0)
+    sizes = [10_000, 1_000_000, 16_000_000]
+    for b in (2, 4):
+        n_cents = 1 << b
+        centroids = mx.array(np.linspace(-2.0, 2.0, n_cents).astype(np.float32))
+        first_lat = None
+        for n in sizes:
+            x = mx.array(rng.standard_normal(n).astype(np.float16))
+            mx.eval(x)
+            t = _bench(lambda: turboquant_scalar_quantize(x, centroids, b))
+            if first_lat is None:
+                first_lat = t * 1000
+            bytes_moved = n * (2 + 1)  # read fp16 + write uint8
+            flops = n * n_cents * 2  # sub + mul per centroid
+            gbs = bytes_moved / t / 1e9
+            pct = 100.0 * gbs / peak_gbs
+            ai = flops / bytes_moved
+            gflops = flops / t / 1e9
+            cls = _classify(pct, t * 1000, first_lat)
+            print(
+                f"{n:>10} {b:>2} {t * 1000:>10.4f} {gbs:>8.1f} {pct:>6.1f}% "
+                f"{ai:>9.2f} {gflops:>9.2f}  {cls}"
+            )
+    print()
+
+
+def bench_scalar_dequantize(peak_gbs: float) -> None:
+    """turboquant_scalar_dequantize: centroid gather, zero arithmetic.
+
+    Per element: read 1 uint8 (1B) + 1 gather load from a tiny (<=16-entry)
+    centroid table (cached, not counted as DRAM traffic), write 1 fp16 (2B).
+    """
+    print("=" * 78)
+    print("turboquant_scalar_dequantize — centroid gather decode")
+    print("=" * 78)
+    print(f"{'N':>10} {'b':>2} {'lat (ms)':>10} {'GB/s':>8} {'%peak':>7} {'AI (F/B)':>9}  class")
+    rng = np.random.default_rng(0)
+    sizes = [10_000, 1_000_000, 16_000_000]
+    for b in (2, 4):
+        n_cents = 1 << b
+        centroids = mx.array(np.linspace(-2.0, 2.0, n_cents).astype(np.float32))
+        first_lat = None
+        for n in sizes:
+            idx = mx.array(rng.integers(0, n_cents, size=n).astype(np.uint8))
+            mx.eval(idx)
+            t = _bench(lambda: turboquant_scalar_dequantize(idx, centroids))
+            if first_lat is None:
+                first_lat = t * 1000
+            bytes_moved = n * (1 + 2)  # read uint8 + write fp16
+            gbs = bytes_moved / t / 1e9
+            pct = 100.0 * gbs / peak_gbs
+            cls = _classify(pct, t * 1000, first_lat)
+            print(f"{n:>10} {b:>2} {t * 1000:>10.4f} {gbs:>8.1f} {pct:>6.1f} {0.0:>9.2f}  {cls}")
+    print()
+
+
+def bench_kivi_group_quant(peak_gbs: float) -> None:
+    """kivi_group_quant_dequant: group min/max reduce + fused quant-dequant.
+
+    Per element (approx, group_size=32): 1 read for the min/max pass, 1 read
+    + 1 write for the quant-dequant pass = 2 reads + 1 write of the element
+    dtype. Reduction FLOPs: 2 compares per element for min/max (amortized
+    over the group), plus ~4 FLOPs/element for the round-trip
+    (subtract, divide, round, multiply, add ~ 5 ops); counted generously at
+    7 FLOPs/element total.
+    """
+    print("=" * 78)
+    print("kivi_group_quant_dequant — group-affine quantize+dequantize (fused)")
+    print("=" * 78)
+    print(
+        f"{'BH x S x D':>16} {'lat (ms)':>10} {'GB/s':>8} {'%peak':>7} "
+        f"{'AI (F/B)':>9} {'GFLOP/s':>9}  class"
+    )
+    shapes = [(8, 128, 128), (32, 512, 128), (32, 4096, 128)]
+    first_lat = None
+    for BH, S, D in shapes:
+        x = mx.random.normal((BH, S, D)).astype(mx.float16)
+        mx.eval(x)
+        t = _bench(lambda: kivi_group_quant_dequant(x, axis=-2, group_size=32, levels=3))
+        if first_lat is None:
+            first_lat = t * 1000
+        n = BH * S * D
+        bytes_moved = n * (2 + 2 + 2)  # 2 reads + 1 write, all fp16
+        flops = n * 7
+        gbs = bytes_moved / t / 1e9
+        pct = 100.0 * gbs / peak_gbs
+        ai = flops / bytes_moved
+        gflops = flops / t / 1e9
+        cls = _classify(pct, t * 1000, first_lat)
+        print(
+            f"{BH:>4}x{S:>5}x{D:<4} {t * 1000:>10.4f} {gbs:>8.1f} {pct:>6.1f}% "
+            f"{ai:>9.2f} {gflops:>9.2f}  {cls}"
+        )
+    print()
+
+
+def bench_scalar_fused_decode_attend(peak_gbs: float) -> None:
+    """scalar_fused_decode_attend: fused group-affine decode + SDPA.
+
+    The highest-arithmetic-intensity kernel of the three: per (query, kv
+    slot) pair it does a D-length dot product (2D FLOPs), online-softmax
+    updates (~5 FLOPs), and a D-length weighted accumulate (2D FLOPs) ~=
+    4D + 5 FLOPs per kv slot.
+
+    Bytes actually moved (not per-pair amortization, which double-counts):
+    k_codes/v_codes are each read exactly once per (b, h, slot, d) —
+    B*H*S_kv*D bytes each; k_scale/k_zero/v_scale/v_zero are each read once
+    per (b, h, group, d) or (b, h, slot, group) — B*H*GK*D and B*H*S_kv*GV
+    elements respectively, fp32 (4B). q and the output are negligible
+    (O(D) per query, S_kv-independent).
+
+    One threadgroup is dispatched per (b, h, s_q) — see
+    ``_scalar_affine_attend.py``'s grid comment. At small B*H*S_q (a single
+    decode step against few heads) this under-fills a 10-core GPU
+    regardless of how large S_kv is, which this script's occupancy sweep
+    (varying H and B at fixed S_kv) is designed to surface separately from
+    the bandwidth ceiling itself.
+    """
+    print("=" * 78)
+    print("scalar_fused_decode_attend — fused group-affine decode + attention")
+    print("=" * 78)
+    print(
+        f"{'S_kv':>8} {'D':>4} {'lat (ms)':>10} {'GB/s':>8} {'%peak':>7} "
+        f"{'AI (F/B)':>9} {'GFLOP/s':>9}  class"
+    )
+    B, H, S_q, group = 1, 8, 1, 32
+    first_lat = None
+    s_kvs = [128, 2048, 16384]
+    for S_kv in s_kvs:
+        D = 128
+        rng = np.random.default_rng(0)
+        q = mx.array(rng.standard_normal((B, H, S_q, D)).astype(np.float16))
+        GK = (S_kv + group - 1) // group
+        GV = (D + group - 1) // group
+        k_codes = mx.array(rng.integers(0, 16, size=(B, H, S_kv, D)).astype(np.uint8))
+        k_scale = mx.array(rng.uniform(0.01, 0.1, size=(B, H, GK, D)).astype(np.float32))
+        k_zero = mx.array(rng.uniform(-1, 1, size=(B, H, GK, D)).astype(np.float32))
+        v_codes = mx.array(rng.integers(0, 16, size=(B, H, S_kv, D)).astype(np.uint8))
+        v_scale = mx.array(rng.uniform(0.01, 0.1, size=(B, H, S_kv, GV)).astype(np.float32))
+        v_zero = mx.array(rng.uniform(-1, 1, size=(B, H, S_kv, GV)).astype(np.float32))
+        mx.eval(q, k_codes, k_scale, k_zero, v_codes, v_scale, v_zero)
+        scale = 1.0 / float(D) ** 0.5
+
+        def run():
+            return scalar_fused_decode_attend(
+                q, k_codes, k_scale, k_zero, v_codes, v_scale, v_zero, group, scale
+            )
+
+        t = _bench(run)
+        if first_lat is None:
+            first_lat = t * 1000
+
+        n_pairs = B * H * S_q * S_kv
+        bytes_codes = 2 * B * H * S_kv * D  # k_codes + v_codes, 1B each
+        bytes_scale = (B * H * GK * D + B * H * S_kv * GV) * 4 * 2  # scale+zero, fp32
+        bytes_moved = bytes_codes + bytes_scale
+        flops = n_pairs * (4 * D + 5)
+        gbs = bytes_moved / t / 1e9
+        pct = 100.0 * gbs / peak_gbs
+        ai = flops / bytes_moved
+        gflops = flops / t / 1e9
+        cls = _classify(pct, t * 1000, first_lat)
+        print(
+            f"{S_kv:>8} {D:>4} {t * 1000:>10.4f} {gbs:>8.1f} {pct:>6.1f}% "
+            f"{ai:>9.2f} {gflops:>9.2f}  {cls}"
+        )
+    print()
+
+    # ------------------------------------------------------------------
+    # Occupancy sweep: hold S_kv fixed at a large value and vary B*H*S_q
+    # (the threadgroup-dispatch count) to separate "not enough parallel
+    # work dispatched" from "bandwidth-limited". One threadgroup per
+    # (b, h, s_q); a 10-core GPU needs dozens of threadgroups in flight to
+    # fill itself, so a single decode step (S_q=1) against few heads
+    # dispatches far too few threadgroups regardless of S_kv.
+    # ------------------------------------------------------------------
+    print("[occupancy sweep] fixed S_kv=16384, D=128 — varying dispatched threadgroup count")
+    print(f"{'B':>3} {'H':>4} {'S_q':>4} {'n_tg':>6} {'lat (ms)':>10} {'GB/s':>8} {'%peak':>7}")
+    S_kv, D = 16384, 128
+    rng = np.random.default_rng(0)
+    for B, H, S_q in [(1, 8, 1), (1, 32, 1), (4, 32, 1)]:
+        q = mx.array(rng.standard_normal((B, H, S_q, D)).astype(np.float16))
+        GK = (S_kv + group - 1) // group
+        GV = (D + group - 1) // group
+        k_codes = mx.array(rng.integers(0, 16, size=(B, H, S_kv, D)).astype(np.uint8))
+        k_scale = mx.array(rng.uniform(0.01, 0.1, size=(B, H, GK, D)).astype(np.float32))
+        k_zero = mx.array(rng.uniform(-1, 1, size=(B, H, GK, D)).astype(np.float32))
+        v_codes = mx.array(rng.integers(0, 16, size=(B, H, S_kv, D)).astype(np.uint8))
+        v_scale = mx.array(rng.uniform(0.01, 0.1, size=(B, H, S_kv, GV)).astype(np.float32))
+        v_zero = mx.array(rng.uniform(-1, 1, size=(B, H, S_kv, GV)).astype(np.float32))
+        mx.eval(q, k_codes, k_scale, k_zero, v_codes, v_scale, v_zero)
+        scale = 1.0 / float(D) ** 0.5
+
+        def run():
+            return scalar_fused_decode_attend(
+                q, k_codes, k_scale, k_zero, v_codes, v_scale, v_zero, group, scale
+            )
+
+        t = _bench(run)
+        n_tg = B * H * S_q
+        bytes_codes = 2 * B * H * S_kv * D
+        bytes_scale = (B * H * GK * D + B * H * S_kv * GV) * 4 * 2
+        gbs = (bytes_codes + bytes_scale) / t / 1e9
+        pct = 100.0 * gbs / peak_gbs
+        print(f"{B:>3} {H:>4} {S_q:>4} {n_tg:>6} {t * 1000:>10.4f} {gbs:>8.1f} {pct:>6.1f}%")
+    print()
+
+
+def main() -> None:
+    print("[roofline] calibrating achieved memory-bandwidth peak on this GPU...")
+    peak_gbs = _calibrate_bandwidth_peak()
+    print(f"[roofline] calibrated peak: {peak_gbs:.1f} GB/s (achieved, not spec-sheet)\n")
+
+    bench_scalar_quantize(peak_gbs)
+    bench_scalar_dequantize(peak_gbs)
+    bench_kivi_group_quant(peak_gbs)
+    bench_scalar_fused_decode_attend(peak_gbs)
+
+    print(
+        "Reading this table: arithmetic intensity (AI, FLOPs/byte) near or below\n"
+        "~1-2 is the classic memory-bound regime — every one of this repo's\n"
+        "quantize/dequantize/fused-attend kernels lands there by construction\n"
+        "(gather, argmin over a handful of centroids, or a group-wide reduction —\n"
+        "none of it is FLOP-heavy per byte touched). '%peak' near 100% at that low\n"
+        "AI confirms the kernel is successfully saturating memory bandwidth, i.e.\n"
+        "there is no compute headroom being left on the table — the only way to\n"
+        "speed it up further is to move fewer bytes (smaller codes, fused ops that\n"
+        "avoid materializing intermediates) or use faster memory, not to add more\n"
+        "ALU throughput. A low %peak at small N with a latency floor that doesn't\n"
+        "shrink between the smallest and largest tested size instead points at\n"
+        "kernel-launch/dispatch overhead dominating, not bandwidth."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Investigates issue #259 (roofline analysis: arithmetic intensity, achieved/theoretical bandwidth, occupancy, compute- vs. memory- vs. launch- vs. sync-bound classification of VeloxQuant's KV-cache kernels)
- New `scripts/kv_kernel_roofline_bench.py`: self-calibrates a memory-bandwidth ceiling on this GPU (mirrors the existing `prefill_roofline_bench.py`'s self-calibrated matmul-TFLOP/s ceiling — never trust an unverified spec-sheet number), then measures arithmetic intensity and achieved-vs-peak bandwidth for `turboquant_scalar_quantize`, `turboquant_scalar_dequantize`, `kivi_group_quant_dequant`, and `scalar_fused_decode_attend`
- All four kernels have low arithmetic intensity (1-11 FLOPs/byte) — none is compute-bound, as expected for gather/argmin/reduction-shaped work
- `turboquant_scalar_dequantize` (pure gather) and `kivi_group_quant_dequant` (group-affine quant-dequant) directly confirm the memory-bound prediction: 61% and 102% of calibrated bandwidth peak at large sizes
- The interesting finding: `scalar_fused_decode_attend` (fused dequantize+attention) never becomes memory-bound even at 16k cached tokens — tops out at 6% of peak. An occupancy sweep (varying dispatched threadgroup count at fixed problem size) shows it's **occupancy/dispatch-bound**, not bandwidth-bound: realistic single-token decode shapes (B*H*S_q small) don't dispatch enough threadgroups to fill a 10-core GPU, no matter how much data streams through each one
- Full methodology, tables, and recommendations in `docs/KV_KERNEL_ROOFLINE_FINDINGS.md`, including a scoped follow-up (batch across layers/requests to raise the fused-attend kernel's threadgroup count) that isn't implemented here — this issue is investigation-only, per its own framing

## Test plan
- [x] `python scripts/kv_kernel_roofline_bench.py` runs cleanly, reproduced across two runs with numbers agreeing within a few percent
- [x] No library code touched (docs + a standalone benchmark script only), so no existing test suite is affected

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)