### PR TITLE
style: fix ruff-format drift on master

### DIFF
--- a/benchmark_scripts/benchmark_age_tiered.py
+++ b/benchmark_scripts/benchmark_age_tiered.py
@@ -330,7 +330,9 @@ def _run_config(
             val_fp16 += c.full_seq_bytes - c.full_seq_bytes // 2
     if caches and hasattr(caches[0], "assigned_avg_bits"):
         avg_bits = float(caches[0].assigned_avg_bits)
-    elif caches and hasattr(caches[0], "compression_ratio") and hasattr(caches[0], "full_seq_bytes"):
+    elif (
+        caches and hasattr(caches[0], "compression_ratio") and hasattr(caches[0], "full_seq_bytes")
+    ):
         # Back out an effective avg-bits from the realized compression ratio
         # (fp16 baseline is 16 bits/element by construction).
         ratio = caches[0].compression_ratio

--- a/docs-site/docs/algorithms/age-tiered.md
+++ b/docs-site/docs/algorithms/age-tiered.md
@@ -67,11 +67,11 @@ model, tokenizer = mlx_lm.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
 config = KVCacheConfig(
     method="age_tiered",
     age_recent_boundary=128,  # age < this -> 8-bit
-    age_mid_boundary=1024,    # age < this -> 4-bit; older -> 2-bit
+    age_mid_boundary=1024,  # age < this -> 4-bit; older -> 2-bit
     age_bits_recent=8,
     age_bits_mid=4,
     age_bits_old=2,
-    age_group_size=32,        # min/max group size, shared across tiers
+    age_group_size=32,  # min/max group size, shared across tiers
 )
 caches = KVCacheBuilder.for_model(model, config)
 model.make_cache = lambda *_a, **_k: caches

--- a/docs/ZERO_COPY_KV_CACHE_FINDINGS.md
+++ b/docs/ZERO_COPY_KV_CACHE_FINDINGS.md
@@ -33,16 +33,16 @@ stores everything as `np.ndarray` ring buffers:
 
 ```python
 self._k_indices_packed = np.zeros((capacity, self._idx_packed_len), dtype=np.uint8)
-self._k_signs_packed   = np.zeros((capacity, self._sign_packed_len), dtype=np.uint8)
-self._v_cache           = np.zeros((capacity, self._d), dtype=np.int8)
+self._k_signs_packed = np.zeros((capacity, self._sign_packed_len), dtype=np.uint8)
+self._v_cache = np.zeros((capacity, self._d), dtype=np.int8)
 ```
 
 Every `append_key` converts the incoming MLX key to NumPy to write it in:
 
 ```python
-k_np = np.array(k, dtype=np.float16).reshape(1, -1)   # mx -> np
+k_np = np.array(k, dtype=np.float16).reshape(1, -1)  # mx -> np
 ...
-idx_np = np.array(ev.indices[0], dtype=np.uint8)        # mx -> np (again, post-encode)
+idx_np = np.array(ev.indices[0], dtype=np.uint8)  # mx -> np (again, post-encode)
 ```
 
 Every `attend` slices the NumPy ring buffer by physical index, unpacks bits
@@ -52,9 +52,9 @@ converts back to MLX to run the actual math:
 ```python
 phys = self._physical_indices(n)
 k_indices_np = self._unpack_indices_block(self._k_indices_packed[phys])  # np slice + np loop
-k_indices = mx.array(k_indices_np, dtype=mx.uint8)                        # np -> mx
+k_indices = mx.array(k_indices_np, dtype=mx.uint8)  # np -> mx
 ...
-v_int8 = mx.array(self._v_cache[phys], dtype=mx.int8)                     # np -> mx
+v_int8 = mx.array(self._v_cache[phys], dtype=mx.int8)  # np -> mx
 ```
 
 This hits all four boundaries issue #255 called out:
@@ -132,7 +132,11 @@ actual KV-cache storage" the issue describes.
 
 ```python
 from veloxquant_mlx.cache.base import KVCacheConfig, KVCacheFactory
-from veloxquant_mlx.profiling.kv_profiler import KVCacheProfiler, format_profile_table, profile_layers
+from veloxquant_mlx.profiling.kv_profiler import (
+    KVCacheProfiler,
+    format_profile_table,
+    profile_layers,
+)
 import mlx.core as mx
 
 cfg = KVCacheConfig(method="turboquant_prod", head_dim=128, bit_width_inlier=2, seed=42)
@@ -146,7 +150,9 @@ q = mx.random.normal((128,)).astype(mx.float16)
 mx.eval(keys, vals, q)
 
 for i in range(500):
-    prof.append_key(keys[i]); prof.append_value(vals[i]); prof.attend(q)
+    prof.append_key(keys[i])
+    prof.append_value(vals[i])
+    prof.attend(q)
 
 print(format_profile_table(profile_layers([prof])))
 ```

--- a/scripts/streaming_prefill_benchmark.py
+++ b/scripts/streaming_prefill_benchmark.py
@@ -148,7 +148,9 @@ def run(n_iter: int, skip_large: bool) -> list[dict]:
         # Shapes to test per D: full prefill (S_q==S_kv) for every S, plus
         # exactly one cache-continuation (S_q<S_kv) case.
         shapes = [(S, S, "full") for S in S_values]
-        shapes.append((max(1, S_values[len(S_values) // 2] // 4), S_values[len(S_values) // 2], "cache_cont"))
+        shapes.append(
+            (max(1, S_values[len(S_values) // 2] // 4), S_values[len(S_values) // 2], "cache_cont")
+        )
 
         for S_q, S_kv, kind in shapes:
             # Reduce iteration count for very large sequences to keep the

--- a/veloxquant_mlx/cache/age_tiered_cache.py
+++ b/veloxquant_mlx/cache/age_tiered_cache.py
@@ -83,7 +83,11 @@ class AgeTieredKVCache(_MLXKVCache):
         bits_recent = int(getattr(config, "age_bits_recent", 8))
         bits_mid = int(getattr(config, "age_bits_mid", 4))
         bits_old = int(getattr(config, "age_bits_old", 2))
-        for name, b in (("age_bits_recent", bits_recent), ("age_bits_mid", bits_mid), ("age_bits_old", bits_old)):
+        for name, b in (
+            ("age_bits_recent", bits_recent),
+            ("age_bits_mid", bits_mid),
+            ("age_bits_old", bits_old),
+        ):
             if not 1 <= b <= 16:
                 raise ValueError(f"AgeTieredKVCache: {name} must be in [1, 16], got {b}.")
         self._tiers = default_age_tiers(bits_recent, bits_mid, bits_old)

--- a/veloxquant_mlx/tests/metal/test_experimental_streaming_prefill.py
+++ b/veloxquant_mlx/tests/metal/test_experimental_streaming_prefill.py
@@ -126,7 +126,10 @@ def test_streaming_prefill_first_middle_last_token(implementation, D):
     _assert_no_nan_inf(got, implementation)
     for row, label in [(0, "first"), (32, "middle"), (64, "last")]:
         np.testing.assert_allclose(
-            got[:, :, row, :], expected[:, :, row, :], atol=_ATOL, rtol=_RTOL,
+            got[:, :, row, :],
+            expected[:, :, row, :],
+            atol=_ATOL,
+            rtol=_RTOL,
             err_msg=f"{implementation} D={D} {label} token (row={row}) mismatch",
         )
 
@@ -239,7 +242,10 @@ def test_streaming_prefill_variants_agree_with_each_other(D):
     for impl, got in outs.items():
         _assert_no_nan_inf(got, impl)
         np.testing.assert_allclose(
-            got, baseline, atol=1e-3, rtol=1e-3,
+            got,
+            baseline,
+            atol=1e-3,
+            rtol=1e-3,
             err_msg=f"{impl} disagrees with block=1 baseline beyond fp arithmetic-order noise",
         )
 


### PR DESCRIPTION
## Summary
- master's \`lint\` CI check (ruff-format) has been failing on every push/PR for several merges — confirmed via \`gh run list --branch master --workflow lint.yml\`, failing since at least PR #288
- 6 files had drifted from ruff's current formatting rules (line-wrapping only, no logic changes): \`benchmark_scripts/benchmark_age_tiered.py\`, \`docs-site/docs/algorithms/age-tiered.md\`, \`docs/ZERO_COPY_KV_CACHE_FINDINGS.md\`, \`scripts/streaming_prefill_benchmark.py\`, \`veloxquant_mlx/cache/age_tiered_cache.py\`, \`veloxquant_mlx/tests/metal/test_experimental_streaming_prefill.py\`
- Ran \`ruff format .\` to bring the repo back in line with the CI check's own tool (\`pipx run ruff format --check .\`, unpinned version)

## Test plan
- [x] \`ruff format --check .\` — 679 files already formatted (clean)
- [x] \`pytest veloxquant_mlx/tests/quantizers/test_age_tiered.py veloxquant_mlx/tests/metal/test_experimental_streaming_prefill.py\` — 431 passed, 90 skipped (the two files with actual source/test changes; diff confirmed pure whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)