### PR TITLE
feat: add veloxquant auto-config CLI for select_kv_cache_config()

### DIFF
--- a/veloxquant_mlx/__main__.py
+++ b/veloxquant_mlx/__main__.py
@@ -7,7 +7,10 @@ import sys
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: veloxquant {precompute|benchmark|recommend|methods|serve|profile|panel}")
+        print(
+            "Usage: veloxquant "
+            "{precompute|benchmark|recommend|auto-config|methods|serve|profile|panel}"
+        )
         sys.exit(1)
 
     command = sys.argv[1]
@@ -24,6 +27,10 @@ def main() -> None:
         _main()
     elif command == "recommend":
         from veloxquant_mlx.cli.recommend import main as _main
+
+        _main()
+    elif command == "auto-config":
+        from veloxquant_mlx.cli.auto_config import main as _main
 
         _main()
     elif command == "methods":
@@ -45,7 +52,7 @@ def main() -> None:
     else:
         print(
             f"Unknown command: {command!r}. "
-            "Choices: precompute, benchmark, recommend, methods, serve, profile, panel"
+            "Choices: precompute, benchmark, recommend, auto-config, methods, serve, profile, panel"
         )
         sys.exit(1)
 

--- a/veloxquant_mlx/cli/auto_config.py
+++ b/veloxquant_mlx/cli/auto_config.py
@@ -1,0 +1,118 @@
+"""CLI: pick a hardware-aware KV-cache config for a workload (issue #253)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import fields
+
+from veloxquant_mlx.config.auto_config import (
+    HardwareInfo,
+    WorkloadSpec,
+    detect_hardware_info,
+    select_kv_cache_config,
+)
+
+# Per-method knob fields worth reporting, keyed by the method the selector
+# can pick. KVCacheConfig is one dataclass shared by all 40+ registry
+# methods, so every instance carries every other method's fields at their
+# unrelated defaults (e.g. a kivi config still has a `gear_bits` field) —
+# reporting only the selected method's own knobs (plus `method`/`head_dim`)
+# avoids implying those unrelated defaults were a deliberate choice.
+_METHOD_FIELDS: dict[str, list[str]] = {
+    "turboquant_rvq": ["bit_width_inlier"],
+    "kivi": ["bit_width_inlier", "kivi_group_size"],
+    "kvquant": ["kvquant_bits", "kvquant_group_size", "kvquant_outlier_fraction"],
+    "gear": ["gear_bits", "gear_group_size"],
+}
+
+
+def _config_to_dict(config: object) -> dict:
+    known = {f.name for f in fields(config)}
+    reported = ["method", "head_dim"] + _METHOD_FIELDS.get(config.method, [])
+    return {name: getattr(config, name) for name in reported if name in known}
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="veloxquant auto-config",
+        description=(
+            "Pick a KV-cache method/bit-width/group-size for a workload "
+            "(head_dim, seq_len, n_layers, batch_size), optionally biased by "
+            "detected or supplied hardware memory pressure. Selects from a "
+            "small pool of servable methods (turboquant_rvq, kivi, kvquant, "
+            "gear) rather than the full method registry."
+        ),
+    )
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--seq-len", type=int, default=4096)
+    parser.add_argument("--n-layers", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument(
+        "--total-memory-bytes",
+        type=int,
+        default=None,
+        help="Override detected total device memory. Omit to auto-detect via mx.device_info().",
+    )
+    parser.add_argument(
+        "--active-memory-bytes",
+        type=int,
+        default=None,
+        help="Override detected active (already-in-use) memory. Ignored unless --total-memory-bytes is also set.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON",
+    )
+    args = parser.parse_args(argv)
+
+    workload = WorkloadSpec(
+        head_dim=args.head_dim,
+        seq_len=args.seq_len,
+        n_layers=args.n_layers,
+        batch_size=args.batch_size,
+    )
+
+    if args.total_memory_bytes is not None:
+        hardware = HardwareInfo(
+            total_memory_bytes=args.total_memory_bytes,
+            active_memory_bytes=args.active_memory_bytes or 0,
+        )
+    else:
+        hardware = detect_hardware_info()
+
+    result = select_kv_cache_config(workload, hardware)
+
+    payload = {
+        "workload": {
+            "head_dim": workload.head_dim,
+            "seq_len": workload.seq_len,
+            "n_layers": workload.n_layers,
+            "batch_size": workload.batch_size,
+        },
+        "hardware": {
+            "total_memory_bytes": hardware.total_memory_bytes,
+            "active_memory_bytes": hardware.active_memory_bytes,
+        },
+        "config": _config_to_dict(result.config),
+        "reason": result.reason,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return
+
+    print("VeloxQuant-MLX auto-config")
+    print(
+        f"  head_dim={workload.head_dim}  seq_len={workload.seq_len}  "
+        f"n_layers={workload.n_layers}  batch_size={workload.batch_size}"
+    )
+    print(f"  method={payload['config']['method']}")
+    print(f"  config={payload['config']}")
+    print(f"  reason: {result.reason}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/veloxquant_mlx/tests/cache/test_auto_config_cli.py
+++ b/veloxquant_mlx/tests/cache/test_auto_config_cli.py
@@ -1,0 +1,109 @@
+"""Tests for ``veloxquant auto-config`` argument handling and JSON output (#253/#44)."""
+
+from __future__ import annotations
+
+import json
+
+from veloxquant_mlx.cli import auto_config as auto_config_cli
+from veloxquant_mlx.config.auto_config import LONG_CONTEXT_TOKENS, SHORT_CONTEXT_TOKENS
+
+
+def test_defaults_produce_mid_band_kivi(capsys):
+    auto_config_cli.main(["--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["workload"] == {
+        "head_dim": 128,
+        "seq_len": 4096,
+        "n_layers": 1,
+        "batch_size": 1,
+    }
+    assert payload["config"]["method"] == "kivi"
+    assert payload["config"]["head_dim"] == 128
+    assert "reason" in payload
+    assert len(payload["reason"]) > 0
+
+
+def test_short_context_selects_turboquant_rvq(capsys):
+    auto_config_cli.main(["--seq-len", str(SHORT_CONTEXT_TOKENS - 1), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["config"]["method"] == "turboquant_rvq"
+    assert payload["config"]["bit_width_inlier"] == 4
+
+
+def test_long_context_selects_kvquant(capsys):
+    auto_config_cli.main(["--seq-len", str(LONG_CONTEXT_TOKENS), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["config"]["method"] == "kvquant"
+    assert payload["config"]["kvquant_bits"] == 3
+
+
+def test_explicit_memory_pressure_forces_gear(capsys):
+    # A tiny total-memory override relative to a large multi-layer/batch
+    # workload should trip the pressure rule regardless of seq_len band.
+    auto_config_cli.main(
+        [
+            "--head-dim",
+            "128",
+            "--seq-len",
+            "100",
+            "--n-layers",
+            "32",
+            "--batch-size",
+            "8",
+            "--total-memory-bytes",
+            "1024",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["config"]["method"] == "gear"
+    assert payload["config"]["gear_bits"] == 2
+    assert "memory pressure" in payload["reason"]
+    assert payload["hardware"]["total_memory_bytes"] == 1024
+
+
+def test_active_memory_bytes_ignored_without_total_override(capsys):
+    # --active-memory-bytes alone (no --total-memory-bytes) should not
+    # override auto-detection, since active memory without a total is
+    # meaningless for the pressure calculation.
+    auto_config_cli.main(["--active-memory-bytes", "999", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    # Falls back to real hardware auto-detection; just assert it didn't crash
+    # and produced a valid pool method.
+    assert payload["config"]["method"] in {"turboquant_rvq", "kivi", "kvquant", "gear"}
+
+
+def test_large_head_dim_doubles_group_size(capsys):
+    auto_config_cli.main(["--head-dim", "256", "--seq-len", "8000", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["config"]["method"] == "kivi"
+    assert payload["config"]["kivi_group_size"] == 64
+
+
+def test_non_json_output_does_not_crash(capsys):
+    auto_config_cli.main(["--seq-len", "100"])
+    out = capsys.readouterr().out
+    assert "auto-config" in out
+    assert "method=" in out
+
+
+def test_config_dict_excludes_non_serializable_fields():
+    from veloxquant_mlx.cache.base import KVCacheConfig
+
+    config = KVCacheConfig(method="kivi", head_dim=128, kivi_group_size=32)
+    result = auto_config_cli._config_to_dict(config)
+    assert "observers" not in result
+    assert "store" not in result
+    assert "dtype" not in result
+    assert result["method"] == "kivi"
+    assert result["kivi_group_size"] == 32
+
+
+def test_config_dict_omits_fields_not_relevant_to_selected_method():
+    from veloxquant_mlx.cache.base import KVCacheConfig
+
+    config = KVCacheConfig(method="turboquant_rvq", head_dim=128, bit_width_inlier=4)
+    result = auto_config_cli._config_to_dict(config)
+    assert "kivi_group_size" not in result
+    assert "gear_bits" not in result


### PR DESCRIPTION
## Summary
- `select_kv_cache_config()` (`config/auto_config.py`, issue #253) has had no CLI exposure since it landed — nothing outside a Python caller could invoke it.
- Blocks VeloxQuant-Studio issue #44 (surfacing an "Auto" recommended-config path in the macOS app), which needs a `--json` subcommand to shell out to, mirroring the existing `recommend --json` pattern.
- Adds `veloxquant auto-config`: `--head-dim/--seq-len/--n-layers/--batch-size` build a `WorkloadSpec`; optional `--total-memory-bytes/--active-memory-bytes` override hardware auto-detection (useful for a caller that already knows the Mac's memory via sysctl and wants to pass it explicitly rather than relying on `mx.device_info()` running again in the subprocess).
- `--json` output reports only the selected method's own knob fields, not every other pool method's unrelated `KVCacheConfig` defaults (all 40+ methods share one dataclass, so an unfiltered dump would include e.g. `gear_bits` on a `kivi` result).

## Test plan
- [x] `pytest veloxquant_mlx/tests/cache/test_auto_config_cli.py veloxquant_mlx/tests/config/test_auto_config.py` — 165/165 passing
- [x] Manual smoke test: `python -m veloxquant_mlx auto-config --seq-len 32000 --json` and non-JSON output both verified on real Apple Silicon hardware

Refs rajveer43/VeloxQuant-Studio#44

🤖 Generated with [Claude Code](https://claude.com/claude-code)