### PR TITLE
Replace Studio waitlist with direct download link

### DIFF
--- a/landing/assets/main.js
+++ b/landing/assets/main.js
@@ -410,6 +410,27 @@ function initThemeToggle() {
   });
 }
 
+// ── ANNOUNCEMENT BANNER (dismissible, persisted in localStorage) ──
+function initAnnouncementBanner() {
+  const banner = document.getElementById('announcement-banner');
+  if (!banner) return;
+
+  const dismissKey = 'vq-announcement-dismissed-studio-v0.1.0';
+  try {
+    if (localStorage.getItem(dismissKey)) return;
+  } catch (e) { /* storage unavailable — fall through and show it */ }
+
+  banner.hidden = false;
+
+  const closeBtn = document.getElementById('announcement-banner-close');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      banner.hidden = true;
+      try { localStorage.setItem(dismissKey, '1'); } catch (e) { /* storage unavailable */ }
+    });
+  }
+}
+
 // ── TOAST ──
 function showToast({ title, desc, duration = 6000 }) {
   const stack = document.getElementById('toast-stack');
@@ -452,4 +473,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initActiveNav();
   initHamburgerMenu();
   initThemeToggle();
+  initAnnouncementBanner();
 });

--- a/landing/assets/main.js
+++ b/landing/assets/main.js
@@ -440,49 +440,6 @@ function showToast({ title, desc, duration = 6000 }) {
   setTimeout(dismiss, duration);
 }
 
-// ── WAITLIST FORM ──
-// Netlify Forms: the static <form data-netlify="true"> is enough for Netlify's
-// build-time HTML parser to register the "waitlist" form and start capturing
-// submissions server-side, with zero backend of our own. This just upgrades
-// the UX from "reload to a plain success page" to an inline swap plus a
-// toast, and falls back to a normal (non-JS) POST if fetch is unavailable
-// or fails.
-function initWaitlistForm() {
-  const form = document.getElementById('waitlist-form');
-  if (!form) return;
-
-  const success = document.getElementById('waitlist-success');
-  const submitBtn = document.getElementById('waitlist-submit');
-
-  form.addEventListener('submit', (e) => {
-    e.preventDefault();
-    submitBtn.disabled = true;
-    submitBtn.textContent = 'Joining…';
-
-    const body = new URLSearchParams(new FormData(form)).toString();
-
-    fetch('/', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body,
-    })
-      .then((res) => {
-        if (!res.ok) throw new Error('Network response was not ok');
-        form.hidden = true;
-        success.hidden = false;
-        showToast({
-          title: "You're on the waitlist",
-          desc: "We'll announce VeloxQuant Studio here as soon as we start building — watch your inbox.",
-        });
-      })
-      .catch(() => {
-        // Fall back to a real form submission (full Netlify redirect flow)
-        // rather than stranding the user on a form that silently did nothing.
-        form.submit();
-      });
-  });
-}
-
 // ── INIT ──
 document.addEventListener('DOMContentLoaded', () => {
   initCopyButtons();
@@ -495,5 +452,4 @@ document.addEventListener('DOMContentLoaded', () => {
   initActiveNav();
   initHamburgerMenu();
   initThemeToggle();
-  initWaitlistForm();
 });

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -202,6 +202,80 @@ body {
 ::-webkit-scrollbar-track { background: var(--bg); }
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 
+/* ===== ANNOUNCEMENT BANNER ===== */
+/* Sits above the sticky nav in normal flow, so it scrolls away with the
+   page and nav then sticks at top:0 on its own — no extra offset math
+   needed between the two. Shown/hidden via main.js (initAnnouncementBanner),
+   default [hidden] so a no-JS visitor never sees a banner they can't
+   dismiss. */
+.announcement-banner[hidden] { display: none; }
+
+.announcement-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.6rem 2.5rem 0.6rem 1rem;
+  background: var(--accent);
+  color: var(--on-accent);
+  position: relative;
+  text-align: center;
+}
+
+.announcement-banner-link {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: var(--on-accent);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.announcement-banner-link:hover .announcement-banner-cta {
+  text-decoration: underline;
+}
+
+.announcement-banner-badge {
+  background: var(--on-accent);
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+}
+
+.announcement-banner-cta {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.announcement-banner-close {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: var(--on-accent);
+  opacity: 0.75;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.announcement-banner-close:hover { opacity: 1; }
+
+@media (max-width: 640px) {
+  .announcement-banner { padding: 0.6rem 2.25rem 0.6rem 0.75rem; font-size: 0.8rem; }
+  .announcement-banner-link { font-size: 0.8rem; }
+}
+
 /* ===== NAV ===== */
 nav {
   position: sticky;

--- a/landing/index.html
+++ b/landing/index.html
@@ -165,7 +165,7 @@
        Atmospheric decoration (matrix-canvas, aurora blobs, floating
        particles) removed for the calmer "oMLX-style" restyle — background is
        flat/static now (see #hero rules in styles.css). Nav trimmed to 6
-       links for a calmer bar; "macOS app" (#waitlist), "Start here"
+       links for a calmer bar; "macOS app" (#download), "Start here"
        (#scenarios) and "Playground" (playground.html) are no longer linked
        from nav, but their target IDs are preserved below since main.js's
        scroll-spy and other pages still reference them. -->
@@ -340,11 +340,10 @@
 
   <div class="divider"></div>
 
-  <!-- Toast — fires on successful waitlist join, independent of scroll
-       position, so the confirmation lands even if the inline success box
-       (inside #waitlist, further down the page) has already scrolled out
-       of view. Kept high in the DOM (fixed-position, so location doesn't
-       matter visually) rather than moved with #waitlist itself. -->
+  <!-- Toast stack — fixed-position container for main.js's showToast().
+       Not currently wired to anything (the waitlist form it originally
+       served was replaced by a direct Studio download link), kept for the
+       next feature that needs an inline confirmation toast. -->
   <div class="toast-stack" id="toast-stack" aria-live="polite" aria-atomic="true"></div>
 
   <!-- Legacy anchor aliases. #benefits was the old stats section, dropped in
@@ -530,18 +529,20 @@
 
   <div class="divider"></div>
 
-  <!-- ── §1.5 MACOS APP WAITLIST ──
+  <!-- ── §1.5 MACOS APP DOWNLOAD ──
        VeloxQuant Studio is a native SwiftUI control panel for this library
-       (separate repo) — drives `veloxquant methods/serve/recommend` as a
-       subprocess instead of reimplementing the engine. Not shipped yet, so
-       this collects interest via Netlify Forms rather than linking a build.
-       Repositioned here (was right after the hero) to match the new section
-       order; id and JS hooks (#waitlist-form/#waitlist-success/#waitlist-submit)
-       are unchanged. -->
-  <section id="waitlist">
+       (separate repo, github.com/rajveer43/VeloxQuant-Studio) — drives
+       `veloxquant methods/serve/recommend` as a subprocess instead of
+       reimplementing the engine. Shipped as of v0.1.0: links straight to the
+       GitHub Release DMG rather than the old waitlist form. Ad-hoc signed,
+       not notarized (no Apple Developer Program account yet), so Gatekeeper
+       warns on first launch — called out explicitly below so it doesn't read
+       as broken. Uses /releases/latest/download/... so this link keeps
+       resolving to the newest release without an edit here. -->
+  <section id="download">
     <div class="waitlist-shell fade-in">
       <div class="waitlist-copy">
-        <p class="section-label">Coming soon</p>
+        <p class="section-label">Available now</p>
         <h2 class="section-title">VeloxQuant Studio — a native macOS app</h2>
         <p class="section-desc" style="margin-left:0">
           A point-and-click app for this tool: pick a model, pick a compression setting, and
@@ -557,41 +558,22 @@
       </div>
 
       <div class="waitlist-form-wrap">
-        <form
-          id="waitlist-form"
-          name="waitlist"
-          method="POST"
-          data-netlify="true"
-          netlify-honeypot="waitlist-company"
+        <a
+          href="https://github.com/rajveer43/VeloxQuant-Studio/releases/latest/download/VeloxQuant-Studio-0.1.0.dmg"
+          class="btn btn-filled"
+          id="studio-download-btn"
         >
-          <input type="hidden" name="form-name" value="waitlist" />
-          <p class="waitlist-hp-field" aria-hidden="true">
-            <label>Company<input name="waitlist-company" tabindex="-1" autocomplete="off" /></label>
-          </p>
-
-          <label for="waitlist-email" class="waitlist-label">Email address</label>
-          <div class="waitlist-field-row">
-            <input
-              type="email"
-              id="waitlist-email"
-              name="email"
-              placeholder="you@example.com"
-              required
-              autocomplete="email"
-            />
-            <button type="submit" class="btn btn-filled" id="waitlist-submit">
-              Join waitlist <span data-icon>→</span>
-            </button>
-          </div>
-          <p class="waitlist-note" id="waitlist-status">
-            No spam — we'll announce it here the moment we start building.
-          </p>
-        </form>
-
-        <div class="waitlist-success" id="waitlist-success" hidden>
-          <p class="waitlist-success-title">You're on the list.</p>
-          <p class="waitlist-success-body">We'll email you as soon as we start building. In the meantime, the CLI works today — see the <a href="#quickstart" class="t-accent">quickstart</a> above.</p>
-        </div>
+          Download for Mac <span data-icon>↓</span>
+        </a>
+        <p class="waitlist-note">
+          macOS will warn this is from an unidentified developer the first time you open it —
+          right-click the app → Open (or System Settings → Privacy &amp; Security → Open Anyway)
+          to run it. Requires a local Python environment with
+          <code>veloxquant_mlx</code> installed.
+        </p>
+        <p class="waitlist-note">
+          <a href="https://github.com/rajveer43/VeloxQuant-Studio/releases/tag/v0.1.0" class="t-accent" target="_blank" rel="noopener">Release notes for v0.1.0 →</a>
+        </p>
       </div>
     </div>
   </section>
@@ -888,6 +870,7 @@ pip install -e ".[dev]"</span></pre>
           <li><a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener">GitHub</a></li>
           <li><a href="https://pypi.org/project/VeloxQuant-MLX/" target="_blank" rel="noopener">PyPI</a></li>
           <li><a href="https://marketplace.visualstudio.com/items?itemName=veloxquant-mlx.veloxquant-vscode" target="_blank" rel="noopener">VS Code Extension</a></li>
+          <li><a href="https://github.com/rajveer43/VeloxQuant-Studio/releases/latest" target="_blank" rel="noopener">VeloxQuant Studio (macOS app)</a></li>
           <li><a href="playground.html">Playground</a></li>
           <li><a href="https://github.com/rajveer43/VeloxQuant-MLX/blob/master/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
           <li><a href="https://github.com/rajveer43/VeloxQuant-MLX/issues" target="_blank" rel="noopener">Issues</a></li>

--- a/landing/index.html
+++ b/landing/index.html
@@ -138,6 +138,22 @@
 </head>
 <body>
 
+  <!-- ── ANNOUNCEMENT BANNER ──
+       VeloxQuant Studio v0.1.0 (macOS app) shipped — see #download below.
+       Dismissible, persisted in localStorage like the theme toggle, so a
+       returning visitor who already dismissed it doesn't see it again
+       (see initAnnouncementBanner in main.js). Hidden entirely if JS is
+       disabled or localStorage throws, rather than defaulting to shown,
+       since a banner that can never be dismissed is worse than none. -->
+  <div id="announcement-banner" class="announcement-banner" hidden>
+    <a href="#download" class="announcement-banner-link">
+      <span class="announcement-banner-badge">New</span>
+      <span>VeloxQuant Studio for macOS is here — a native app for this library.</span>
+      <span class="announcement-banner-cta">Download it free <span data-icon>→</span></span>
+    </a>
+    <button type="button" class="announcement-banner-close" id="announcement-banner-close" aria-label="Dismiss announcement">×</button>
+  </div>
+
   <!-- ── NAVIGATION ── -->
   <nav id="navbar">
     <a href="#hero" class="nav-logo"><img src="assets/logo.svg" alt="" width="28" height="28" class="nav-logo-mark" />VeloxQuant-MLX</a>


### PR DESCRIPTION
## Summary
- VeloxQuant Studio v0.1.0 has shipped: https://github.com/rajveer43/VeloxQuant-Studio/releases/tag/v0.1.0
- Swaps the landing page's "Coming soon" waitlist section for a "Download for Mac" button pointing at the release DMG, with a Gatekeeper disclosure note (ad-hoc signed, not notarized yet)
- Adds a link to the Studio release under the footer's Build column
- Removes the now-dead `initWaitlistForm()` wiring from main.js since the waitlist form markup is gone

## Test plan
- [x] Netlify deploy preview renders the new download section correctly in both light/dark theme
- [ ] Download button resolves to the DMG and downloads successfully
- [ ] No console errors from main.js (waitlist form removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)