### PR TITLE
seo: add keywords metadata across landing pages and docs site

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -7,6 +7,20 @@ const config: Config = {
   tagline: '16× KV cache compression for Apple Silicon',
   favicon: 'img/favicon.ico',
 
+  // Site-wide <meta name="keywords"> — real vocabulary used throughout the
+  // docs (method names, concepts) rather than generic filler, so it stays
+  // truthful to what each page actually covers.
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'keywords',
+        content:
+          'KV cache compression, KV cache quantization, LLM memory optimization, Apple Silicon, MLX framework, mlx_lm, local LLM inference, on-device AI, long context inference, key-value cache, Metal kernels, token eviction, KIVI, GEAR, KVQuant, RaBitQ, VecInfer, TurboQuant RVQ, H2O, SnapKV, StreamingLLM, SpectralQuant, CommVQ, RateQuant, CacheRoute, low-bit quantization, Llama, Mistral, Qwen, Gemma',
+      },
+    },
+  ],
+
   future: {
     v4: true,
   },

--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg?v=2" />
   <link rel="shortcut icon" href="assets/favicon.svg?v=2" />
   <meta name="description" content="Detailed, real-hardware benchmarks for VeloxQuant-MLX: Q-Filters attention-correlation accuracy and generation perplexity." />
+  <meta name="keywords" content="VeloxQuant-MLX benchmarks, KV cache quantization benchmark, LLM compression accuracy, perplexity benchmark, Q-Filters, Metal kernel speedup, Apple Silicon LLM performance, KIVI benchmark, GEAR benchmark, RaBitQ benchmark" />
   <link rel="canonical" href="https://veloxquant-mlx.netlify.app/benchmarks.html" />
 
   <meta property="og:type" content="website" />

--- a/landing/index.html
+++ b/landing/index.html
@@ -11,11 +11,13 @@
   <!-- One sentence. Search engines truncate around 160 characters; the old
        1,400-character method dump was never shown in full anywhere. -->
   <meta name="description" content="Free, open-source tool that shrinks the memory a local AI model uses on your Mac, so you can run longer conversations or bigger models. Runs entirely on your machine — nothing is sent anywhere." />
+  <meta name="keywords" content="VeloxQuant-MLX, KV cache compression, KV cache quantization, LLM memory optimization, Apple Silicon, MLX framework, mlx_lm, local LLM inference, on-device AI, long context inference, LLM quantization, key-value cache, GPU memory reduction, Metal kernels, macOS AI tools, token eviction, KIVI, GEAR, KVQuant, RaBitQ, VecInfer, TurboQuant RVQ, H2O, SnapKV, StreamingLLM, SpectralQuant, CommVQ, RateQuant, CacheRoute, low-bit quantization, 4-bit quantization, 2-bit quantization, Llama, Mistral, Qwen, Gemma, open source Python library" />
   <link rel="canonical" href="https://veloxquant-mlx.netlify.app/" />
 
   <!-- Open Graph / Twitter — the page had none, so every share on HN,
        Reddit and X rendered as a bare link. -->
   <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
   <meta property="og:site_name" content="VeloxQuant-MLX" />
   <meta property="og:title" content="VeloxQuant-MLX — run longer AI conversations on your Mac" />
   <meta property="og:description" content="Free, open-source tool that shrinks the memory a local AI model uses on your Mac — up to 16×, in three lines of code. Runs entirely on your machine." />
@@ -42,9 +44,10 @@
     "operatingSystem": "macOS (Apple Silicon M1 or later)",
     "description": "Shrinks the memory a local AI model uses on Apple Silicon Macs — up to 16× smaller, with near-identical output quality.",
     "url": "https://veloxquant-mlx.netlify.app/",
-    "softwareVersion": "0.67.1",
+    "softwareVersion": "0.70.0",
     "license": "https://opensource.org/licenses/MIT",
     "programmingLanguage": "Python",
+    "keywords": "KV cache compression, KV cache quantization, LLM memory optimization, Apple Silicon, MLX framework, mlx_lm, local LLM inference, long context inference, Metal kernels, KIVI, GEAR, KVQuant, RaBitQ, VecInfer",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": { "@type": "Person", "name": "Rajveer Rathod" }
   }

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg?v=2" />
   <link rel="shortcut icon" href="assets/favicon.svg?v=2" />
   <meta name="description" content="Pick your Mac and the model you want to run, and see which VeloxQuant-MLX setting to use, how long a conversation fits in your RAM, and the measured benchmarks behind it — all worked out in your browser, nothing sent anywhere." />
+  <meta name="keywords" content="VeloxQuant-MLX playground, KV cache calculator, LLM memory calculator, Mac RAM requirements, Apple Silicon LLM sizing, context length calculator, KV cache size estimator, MLX model memory" />
   <link rel="canonical" href="https://veloxquant-mlx.netlify.app/playground.html" />
 
   <meta property="og:type" content="website" />

--- a/landing/sitemap.xml
+++ b/landing/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://veloxquant-mlx.netlify.app/</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://veloxquant-mlx.netlify.app/benchmarks.html</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://veloxquant-mlx.netlify.app/playground.html</loc>
-    <lastmod>2026-08-27</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary
- No page on the site (landing pages or docs-site) had a `meta name="keywords"` tag, and the JSON-LD `SoftwareApplication` schema's `softwareVersion` was stale at 0.67.1 (several releases behind current 0.70.0).
- Adds a `keywords` meta tag to each landing page (`index.html`, `benchmarks.html`, `playground.html`), scoped to what that page actually covers — real terms already used throughout the project (method names like KIVI/GEAR/KVQuant/RaBitQ/VecInfer, MLX/Apple Silicon/mlx_lm vocabulary) rather than generic filler.
- Adds a site-wide `keywords` meta tag to every docs-site page via Docusaurus's `headTags` config (`docusaurus.config.ts`) — same real vocabulary.
- Adds a `keywords` field to the landing page's JSON-LD `SoftwareApplication` schema (Google surfaces this in rich results, unlike the plain meta tag) and refreshes `softwareVersion` to 0.70.0.
- Adds `og:locale`, bumps `sitemap.xml` `lastmod` dates to today.
- Left `robots.txt` untouched — it already correctly references both `/sitemap.xml` and `/docs/sitemap.xml` (Docusaurus auto-generates the latter).

## Test plan
- [x] `cd docs-site && npm run build` — succeeds, verified `<meta name=keywords ...>` renders on every built page (checked `getting-started/intro/index.html`)
- [x] `python scripts/check_site_links.py` — all 65 site URLs still resolve
- [x] Loaded `landing/index.html` in a headless browser — keywords tag present, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)