### PR TITLE
fix(landing): cache-bust main.js so browsers pick up the announcement banner

### DIFF
--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -551,7 +551,7 @@
     <p class="footer-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</p>
   </footer>
 
-  <script src="assets/main.js" defer></script>
+  <script src="assets/main.js?v=20260902" defer></script>
 
   <!-- GoatCounter: privacy-friendly, cookieless page counts. Client-side, so
        it records browsers rather than crawlers — expect it to read lower than

--- a/landing/index.html
+++ b/landing/index.html
@@ -907,8 +907,8 @@ pip install -e ".[dev]"</span></pre>
     <p class="footer-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</p>
   </footer>
 
-  <script src="assets/calc.js" defer></script>
-  <script src="assets/main.js" defer></script>
+  <script src="assets/calc.js?v=20260902" defer></script>
+  <script src="assets/main.js?v=20260902" defer></script>
 
   <!-- GoatCounter: privacy-friendly, cookieless page counts. Client-side, so
        it records browsers rather than crawlers — expect it to read lower than

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -338,9 +338,9 @@
     <p class="footer-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</p>
   </footer>
 
-  <script src="assets/calc.js" defer></script>
-  <script src="assets/main.js" defer></script>
-  <script src="assets/playground.js" defer></script>
+  <script src="assets/calc.js?v=20260902" defer></script>
+  <script src="assets/main.js?v=20260902" defer></script>
+  <script src="assets/playground.js?v=20260902" defer></script>
 
   <!-- GoatCounter: privacy-friendly, cookieless page counts. Client-side, so
        it records browsers rather than crawlers — expect it to read lower than


### PR DESCRIPTION
## Summary
- Root cause of the announcement banner (#297) being invisible on the live site: `assets/main.js` is served by Netlify with `Cache-Control: public, max-age=31536000, immutable` (verified via `curl -sI`), but every landing page referenced it as a bare `assets/main.js` with no version query string — unlike `styles.css`, which already carries `?v=20260901` for this exact reason.
- Any browser that loaded the site before the banner code shipped keeps serving its year-old cached `main.js` indefinitely (immutable means no revalidation), so `initAnnouncementBanner()` never runs for a returning visitor — even though the deployed HTML/CSS/JS are all current (confirmed: `curl` against the live site shows the banner markup, CSS rules, and JS function all present).
- Applies the same `?v=` cache-busting convention to `main.js`, and to `calc.js`/`playground.js`, which had the identical gap.

## Test plan
- [x] `curl -sI https://veloxquant-mlx.netlify.app/assets/main.js` — confirmed `immutable` 1-year cache header, no version query in any page's `<script>` tag before this fix
- [x] Local server + headless browser: banner renders correctly with the versioned script tag, zero console errors
- [x] `python scripts/check_site_links.py` — all 65 site URLs still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)