### PR TITLE
fix(landing): bump styles.css cache-busting version

### DIFF
--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -29,7 +29,7 @@
   <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
        third-party hop, no render-blocking preconnect. -->
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260901" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260902" />
 
   <script type="application/ld+json">
   {

--- a/landing/index.html
+++ b/landing/index.html
@@ -33,7 +33,7 @@
   <meta name="twitter:image:alt" content="VeloxQuant-MLX Metal kernel benchmark summary: compression ratio and speedup charts" />
 
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260901" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260902" />
 
   <script type="application/ld+json">
   {

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -29,7 +29,7 @@
   <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
        third-party hop, no render-blocking preconnect. -->
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260901" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260902" />
 
   <script type="application/ld+json">
   {


### PR DESCRIPTION
## Summary
- Follow-up to #299, which fixed the same `Cache-Control: immutable` issue for `main.js`/`calc.js`/`playground.js` but whose `styles.css?v=20260901 -> 20260902` bump didn't make it into the merged commit (`bb6dbcf`) — confirmed the live site still serves `assets/styles.css?v=20260901` post-merge.
- Any browser that had that exact versioned URL cached before today's announcement-banner CSS was added to `styles.css` keeps serving the old stylesheet indefinitely, so the banner renders as bare, unstyled blue underlined link text instead of the intended bar — even though the deployed `styles.css` content is already correct.
- This PR only bumps the version string in the three landing pages; no CSS content changes (that part is already on master).

## Test plan
- [x] `curl -s https://veloxquant-mlx.netlify.app/ | grep styles.css` — confirmed pre-fix it still read `?v=20260901`
- [x] `python scripts/check_site_links.py` — all 65 site URLs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)