### PR TITLE
chore(ci): stop landing/docs-only pushes from bumping the package ver…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,18 @@ name: release
 on:
   push:
     branches: [master]
+    # Belt-and-suspenders alongside the commit-type discipline in
+    # CONTRIBUTING.md ("Commit conventions"): PSR bumps purely on commit
+    # *type* (feat/fix/perf), not on which files changed, so a landing-only
+    # push typed as feat(landing)/fix(landing) still bumps the Python
+    # package version and republishes to PyPI with zero package changes.
+    # This only skips the run when EVERY changed file matches below -- a
+    # push that also touches veloxquant_mlx/** still runs normally and
+    # still syncs landing/index.html via scripts/sync_release_badges.py.
+    paths-ignore:
+      - 'landing/**'
+      - 'docs/**'
+      - '**.md'
 
 # `cancel-in-progress: false` is deliberate and must stay that way: this job
 # pushes a tag, publishes a GitHub Release, and uploads to PyPI. Cancelling it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,16 @@ Reference the relevant issue number when one exists (`Closes #12`). Avoid
 commits that mix unrelated changes — each commit/PR should map to one
 semver-meaningful change so the automated changelog entry stays accurate.
 
+**`landing/` changes are not package releases.** The commit parser looks
+only at the `feat`/`fix`/`perf` prefix, not at which files changed, so
+`feat(landing): ...` or `fix(landing): ...` still bumps `VeloxQuant-MLX`'s
+version and republishes to PyPI even though nothing in `veloxquant_mlx/`
+changed. Use `chore(landing): ...` or `docs(landing): ...` for landing-page
+work instead — both are recognized types with no version effect. (The
+release workflow also skips entirely for pushes that touch only
+`landing/`, `docs/`, or `*.md` as a second line of defense, but the commit
+type should still be correct.)
+
 ## Code of conduct
 
 Please be respectful and constructive. We follow the


### PR DESCRIPTION
…sion

python-semantic-release bumps VeloxQuant-MLX's version based only on commit type (feat/fix/perf), not on which files changed. Landing-page work committed as feat(landing)/fix(landing) has been triggering real version bumps and PyPI republishes with zero Python package changes (e.g. 0.71.1, 0.72.0, 0.73.0 were all landing-only).

- release.yml: add paths-ignore for landing/**, docs/**, **.md so a push touching only those paths never starts the release job. A push that also touches veloxquant_mlx/** is unaffected and still syncs landing/index.html via scripts/sync_release_badges.py as before.
- CONTRIBUTING.md: document that landing/ work should use chore(landing)/docs(landing), not feat(landing)/fix(landing), since the commit parser has no path awareness.

## Summary

Brief description of what this PR changes and why.

## Related issue

Closes #

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
- [ ] New or updated unit tests cover the change
- [ ] Docs updated if user-facing behavior changed

## Number claims (if any)

Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.

- Script path:
- Results path:
- Metric type (check one):
  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
  - [ ] Full-KV accounting (keys + values + residual windows)
  - [ ] MLX peak memory (`mx.get_peak_memory`)
  - [ ] OS RSS / long-context OOM comparison
  - [ ] Throughput (tok/s)

Do not describe accounting ratios as resident RAM savings unless resident memory was measured.
