### PR TITLE
perf(metal): GQA head-packing + SIMD-shuffle spike for scalar_fused_decode_attend (#307, #308)

### DIFF
--- a/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
+++ b/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
@@ -337,6 +337,50 @@ useful building block outside this specific attend pairing. Reproduction:
 "decode_once or two_pass"` for correctness; the crossover table prints
 from `test_scalar_attend_two_pass_benchmark`.
 
+**Why real-model end-to-end integration was not attempted, despite the
+short-context win above being real.** All numbers in this document and
+its addenda are synthetic microbenchmarks: a fresh `q`/`k`/`v` call per
+measurement, decoding K/V from scratch every time. A real decode loop
+does not look like this — `mlx_lm`'s standard `KVCache` materializes and
+*retains* the dequantized fp16 `K_hat`/`V_hat` tensor across decode
+steps, so per-step dequantization cost is already amortized to
+effectively zero on the standard path. Any fused kernel that redoes
+decode work (or, for the two-pass design, pays a fresh DRAM round-trip)
+on every call is competing against a baseline that mostly isn't doing
+that redundant work in the first place during real generation — a
+materially different comparison than this document's isolated-call
+benchmarks.
+
+This is not a hypothesis — **this exact experiment has already been run
+in this repo, on a real model, for the closest sibling kernel family**.
+`veloxquant_mlx/cache/vecinfer_cache.py`'s `fused_sdpa` opt-in path pairs
+a fused Metal decode+attend kernel (`metal/fused_sdpa.py`) with codebook
+(VQ) index storage, structurally the same shape of integration this
+document's kernels would need for KIVI. `patch_mlx_lm_for_fused_sdpa()`
+(`veloxquant_mlx/metal/fused_sdpa.py:317-351`) is the dispatcher that
+would route real `mlx_lm.generate()` calls to it — and its own inline
+comment records the result: *"Profiling on Llama-3.1-8B showed that the
+fused kernel cannot beat MLX SDPA on an already-materialized K_hat
+tensor because the per-step dequant cost is amortized to zero by
+mlx_lm's persistent cache buffer."* The dispatcher is coded as a
+pass-through no-op today specifically because of this measured result —
+not a stub awaiting completion.
+
+Given a first-party, already-measured result on this exact failure mode
+for a structurally identical integration, re-running it for
+`scalar_predecoded_attend`/`scalar_fused_decode_attend` against KIVI was
+judged unlikely to produce new information proportional to the
+integration cost (wiring compressed-state storage into `KIVIKVCache`,
+a monkeypatch dispatcher, and real-model benchmark plumbing — see
+`docs/RVQ_PACKED_STORAGE_FINDINGS.md` for how much work the analogous
+`turboquant_rvq` conversion took). If a future change alters the premise
+— e.g. part 1's cross-layer batched dispatch changes what "amortized"
+means by changing the call granularity itself, or a caller emerges that
+genuinely cannot retain a materialized fp16 `K_hat` (the memory-bound
+case `fused_sdpa`'s docstring already names as its own remaining
+rationale) — this is the reference point to revisit, not a closed
+question in principle.
+
 ## Recommendation
 
 1. **Kernels already at or near the bandwidth roofline** (`kivi_group_quant_dequant`

--- a/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
+++ b/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
@@ -259,6 +259,84 @@ this hardware, and occupancy should win until part 1 changes what
 structure enough that revisiting packing at that point is a fair
 question, not a re-run of this same experiment).
 
+## Addendum: SIMD-shuffle spike and two-pass decode-once (issue #308)
+
+Issue #308 asked whether `simd_shuffle`/`quad_shuffle` — a genuine, cheap
+(single hardware crossbar instruction, no barrier) cross-*lane* exchange
+confirmed to exist unconditionally on all Apple Silicon since MSL 2.2 —
+could give head-packing's K/V-decode-sharing benefit without sacrificing
+threadgroup count the way part 2 above does.
+
+**It cannot, and this is a straightforward consequence of the same
+architectural fact already established above, not a new limit.**
+`simd_shuffle` exchanges data only between lanes already co-resident in
+one SIMD-group, which is a subset of one threadgroup. Under the
+full-occupancy dispatch shape (`B*H_q*S_q` threadgroups, one per query
+head) that this document recommends, a single threadgroup by construction
+only ever holds *one* query head's work for its entire lifetime — there is
+no other query head's data anywhere in that threadgroup's address space to
+shuffle with. Getting any cross-head sharing still requires those heads to
+be co-resident in one threadgroup, which means dropping to `B*H_kv*S_q`
+threadgroups — reproducing part 2's already-measured tradeoff, just with a
+cheaper merge mechanism, not a way to avoid the threadgroup-count cost.
+
+**A genuinely different two-pass alternative was implemented and measured
+instead**, trading a different resource: one extra DRAM round-trip instead
+of threadgroup count. `scalar_decode_once` (new:
+`veloxquant_mlx/metal/src/scalar_affine_decode_once.metal`) decodes every
+K/V code exactly once into a `[B, H_kv, S_kv, D]` fp16 device buffer,
+dispatched flat over all elements — occupancy-friendly by construction,
+since it scales with `S_kv` rather than `S_q`. `scalar_predecoded_attend`
+(new: `veloxquant_mlx/metal/src/scalar_predecoded_attend.metal`) then runs
+the *original* full-occupancy `B*H_q*S_q` dispatch against the
+already-decoded buffer — heads sharing a kv head still redundantly re-read
+the same decoded fp16 rows from DRAM, but no longer redundantly re-decode
+them (no dequant multiply-add repeated per head).
+
+Correctness: 10/10 new tests pass, including parity against the same
+numpy reference used throughout this document across three head ratios
+(`(H_q,H_kv) ∈ {(4,4), (8,2), (32,4)}`) and `S_kv ∈ {64, 512, 2048}`.
+
+**Result: a genuine, S_kv-dependent crossover, not a uniform win or
+loss.** Measured on the same M4 hardware at `H_q=32, H_kv=4, D=128, nsg=2`
+against the unpacked-redundant baseline (this document's fastest
+measurement so far):
+
+| S_kv | unpacked ms | two-pass ms | two-pass vs. unpacked |
+|------|-------------|-------------|------------------------|
+| 256  | 1.22 | 0.38 | **3.18x faster** |
+| 1024 | 1.33 | 0.98 | **1.36x faster** |
+| 2048 | 2.05 | 1.94 | **1.06x faster** |
+| 3072 | 2.77 | 3.27 | 0.85x (slower) |
+| 4096 | 3.63 | 4.41 | 0.82x (slower) |
+| 8192 | 7.25 | 9.10 | 0.80x (slower) |
+| 16384 | 13.89 | 17.44 | 0.80x (slower) |
+
+The crossover (~S_kv 2048-3072 at this shape) holds directionally across
+`(H_q,H_kv) ∈ {(32,4), (32,8), (8,2)}` — two-pass wins by 1.1-3.2x at
+short/moderate context and loses by 0.7-0.85x at long context in every
+ratio tested. The mechanism: the decode pass's own read-then-write cost
+scales with `S_kv * H_kv * D` regardless of `heads_per_kv`, while the
+*savings* (redundant on-the-fly decode arithmetic avoided) scale with
+`S_kv * H_kv * D * (heads_per_kv - 1)`. At small `S_kv` the saved
+redundant-decode ALU work outweighs the extra round-trip; at large `S_kv`
+the fixed per-byte round-trip overhead — a real DRAM write plus a second
+real DRAM read that redundant on-the-fly decode never pays at all —
+dominates over the saved arithmetic, which is cheap relative to a byte
+round-trip in the first place.
+
+**Disposition:** not adopted for the same reason part 2 wasn't — this
+repo's realistic decode targets (long-context KV caches, `S_kv` in the
+thousands to tens of thousands) sit past the crossover, where two-pass is
+a net loss. Kept as correct, tested code (same rationale as part 2:
+available groundwork, not dead weight) rather than reverted, since the
+short-context win is real and could matter for a caller with a small
+context budget, and because `scalar_decode_once` in particular could be a
+useful building block outside this specific attend pairing. Reproduction:
+`pytest veloxquant_mlx/tests/metal/test_scalar_attend.py -v -k
+"decode_once or two_pass"` for correctness; the crossover table prints
+from `test_scalar_attend_two_pass_benchmark`.
+
 ## Recommendation
 
 1. **Kernels already at or near the bandwidth roofline** (`kivi_group_quant_dequant`

--- a/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
+++ b/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
@@ -159,6 +159,106 @@ memory bandwidth at all** — it's that a single-query decode step doesn't
 generate enough parallel work to fill a modern GPU's core count, no matter
 how efficiently each unit of that work is streamed.
 
+## Addendum: GQA head-packing experiment (issue #307, part 2)
+
+Issue #307 proposed two fixes on top of this analysis. Part 2 — GQA-style
+head-packing, where the `heads_per_kv` query heads sharing one kv head are
+packed into a single threadgroup so each K/V code is decoded once and
+reused across those heads instead of redundantly redecoded per head — has
+been implemented in `scalar_fused_decode_attend`
+(`veloxquant_mlx/metal/src/scalar_affine_attend.metal`,
+`veloxquant_mlx/metal/_scalar_attend.py`) and is correctness-verified:
+43/43 tests pass, including new GQA-shaped parity cases
+(`H_q/H_kv ∈ {(8,2), (32,4), (32,8)}`, max abs error < 2e-3 against a
+numpy reference) and confirmation that `H_q == H_kv` (plain MHA) produces
+unchanged output on every pre-existing test.
+
+**The performance result is a clear negative, and it directly confirms
+this document's own occupancy diagnosis rather than contradicting it.**
+Packing trades away threadgroup *count* to save K/V byte traffic — but
+byte traffic isn't the bottleneck at these shapes; occupancy is. Packing
+`H_q=32, H_kv=4` (`heads_per_kv=8`) into one threadgroup per kv-head drops
+total dispatched threadgroups to `B*H_kv*S_q = 4` — *below* the
+`B=1,H=8,S_q=1` (8 threadgroups) row this document already measured at
+6.1% of peak bandwidth. Measured on the same M4 hardware, `S_kv=16384`:
+
+| Variant | threadgroups | latency | vs. packed |
+|---|---|---|---|
+| packed (nsg=2) | 4 | 43.8 ms | 1.0x |
+| unpacked, 32 separate 1-threadgroup dispatches (nsg=2) | 32 (across 32 dispatches) | 16.3 ms | **2.7x faster** |
+| unpacked, 32 separate 1-threadgroup dispatches (nsg=8) | 32 (across 32 dispatches) | 9.4 ms | **4.7x faster** |
+
+The "unpacked" baseline here is deliberately the redundant-redecode
+anti-pattern (each query head independently redecodes the same shared
+K/V codes) — i.e. strictly *more* total DRAM traffic than packed — and it
+still wins by 2.7-4.7x, because 32 independent small dispatches give the
+GPU scheduler enough concurrent work to fill its cores, while 4 large
+dispatches (even without any redundant work inside them) do not. This
+matches this document's Recommendation #2 below almost exactly: dispatch
+count is the lever that matters at these shapes, not bytes moved.
+
+**Conclusion: GQA head-packing, as scoped in issue #307 part 2, is not a
+net win in isolation and should not be adopted as implemented.** It
+remains correct and available (useful if a future caller needs the
+byte-traffic reduction for a different reason, e.g. once part 1's
+cross-layer batching fixes occupancy first — packing would then compose
+with a large multi-layer dispatch rather than being the sole source of
+threadgroup count). But taken alone, it makes the exact metric this
+document identified as the actual bottleneck (threadgroup count) worse in
+exchange for optimizing a metric (K/V byte traffic) that isn't yet the
+constraint. Issue #307 should be updated to reflect this: part 1
+(cross-layer batched dispatch, which increases threadgroup count) is the
+correct next step, not an optional companion to part 2 — packing should
+be revisited only after occupancy is fixed, to see whether it adds
+further gains once dispatch count is no longer the limiter.
+
+Reproduction: `pytest veloxquant_mlx/tests/metal/test_scalar_attend.py -v
+-k gqa` for correctness; the packing-vs-unpacked timing table prints from
+`test_scalar_attend_gqa_packing_benchmark`.
+
+**Why this isn't fixable with a smarter packing design.** Before
+concluding, we checked whether some other threadgroup layout could get
+both K/V-decode sharing *and* full `B*H_q*S_q` threadgroup count
+simultaneously. It cannot, on Metal, and this is an architectural limit,
+not a gap in this design:
+
+- Metal `threadgroup`-address-space memory is scoped strictly to threads
+  co-resident in one threadgroup; there is no barrier, SIMD-group
+  primitive, imageblock mechanism, or Metal 3/4 feature that lets two
+  independently-dispatched threadgroups read each other's on-chip state.
+  The only way to make a value visible across a threadgroup boundary is
+  `device` (DRAM) memory — exactly the round-trip this kernel family
+  exists to avoid.
+- GPU occupancy at these shapes is gated by threadgroup *count* (the
+  hardware scheduler needs enough independently-schedulable units to
+  spread across the GPU's cores), not by making individual threadgroups
+  internally wider. A "fatter" threadgroup (more SIMD-groups packed in to
+  add real concurrency instead of a serial per-head loop) is still one
+  scheduling unit landing on one core — it doesn't recover the cross-core
+  distribution that dispatching 32 separate threadgroups gives for free.
+- **This is confirmed by MLX's own production kernel.** We read MLX's
+  vendored `sdpa_vector.h` (the Metal kernel `mx.fast.scaled_dot_product_
+  attention` itself dispatches to at decode/small-S_q shapes) directly:
+  it uses one threadgroup per query head with **no K/V-decode sharing
+  across heads that share a kv-head** — `gqa_factor` is used only for
+  pointer arithmetic (`kv_head_idx = q_head_idx / gqa_factor`), and every
+  threadgroup independently re-reads the same K/V data. Where MLX's own
+  2-pass long-context variant *does* need state visible across
+  independently-scheduled threadgroups (merging partial softmax across a
+  KV-axis split), it goes through a `device`-space scratch buffer between
+  kernel launches — the same DRAM round-trip this analysis says is the
+  only way to do it. MLX had every incentive to solve this if it were
+  solvable; it makes the same redundant-refetch-for-occupancy tradeoff
+  this document now recommends.
+
+So the recommendation isn't "revert and try again later" in the sense of
+expecting a different kernel design to close the gap — it's that
+head-packing and full decode-shape occupancy are in genuine tension on
+this hardware, and occupancy should win until part 1 changes what
+"occupancy" costs (batching across layers changes `S_q`/dispatch
+structure enough that revisiting packing at that point is a fair
+question, not a re-run of this same experiment).
+
 ## Recommendation
 
 1. **Kernels already at or near the bandwidth roofline** (`kivi_group_quant_dequant`

--- a/veloxquant_mlx/metal/_scalar_attend.py
+++ b/veloxquant_mlx/metal/_scalar_attend.py
@@ -19,15 +19,15 @@ S_kv while the packed codes are ``16/b`` times smaller.
 Quantization layout (matches KIVI's ``_quant_dequant_along``)
 ------------------------------------------------------------
 Keys — per-CHANNEL groups (group along the token axis):
-  * ``k_codes [B, H, S_kv, D]``  uint8 codes in ``[0, 2^b - 1]``
-  * ``k_scale [B, H, GK,   D]``  fp32, GK = ceil(S_kv / g)
-  * ``k_zero  [B, H, GK,   D]``  fp32
+  * ``k_codes [B, H_kv, S_kv, D]``  uint8 codes in ``[0, 2^b - 1]``
+  * ``k_scale [B, H_kv, GK,   D]``  fp32, GK = ceil(S_kv / g)
+  * ``k_zero  [B, H_kv, GK,   D]``  fp32
   reconstruction: ``k_hat[.., sk, d] = k_codes[..,sk,d] * k_scale[..,sk/g,d] + k_zero[..,sk/g,d]``
 
 Values — per-TOKEN groups (group along the channel axis):
-  * ``v_codes [B, H, S_kv, D]``  uint8
-  * ``v_scale [B, H, S_kv, GV]`` fp32, GV = ceil(D / g)
-  * ``v_zero  [B, H, S_kv, GV]`` fp32
+  * ``v_codes [B, H_kv, S_kv, D]``  uint8
+  * ``v_scale [B, H_kv, S_kv, GV]`` fp32, GV = ceil(D / g)
+  * ``v_zero  [B, H_kv, S_kv, GV]`` fp32
   reconstruction: ``v_hat[.., sk, d] = v_codes[..,sk,d] * v_scale[..,sk,d/g] + v_zero[..,sk,d/g]``
 
 Score model (per kv slot sk, query (b, h, sq)):
@@ -36,6 +36,20 @@ Score model (per kv slot sk, query (b, h, sq)):
 
 ``scale`` (typically ``1/sqrt(D)``) is passed in and applied by the
 kernel; no other scaling is folded in.
+
+GQA head-packing
+-----------------
+``q`` carries ``H_q`` query heads while ``k_codes``/``v_codes`` (and their
+scale/zero arrays) carry ``H_kv`` key/value heads, with ``H_q`` required to
+be an exact multiple of ``H_kv``. ``H_kv`` is inferred from
+``k_codes.shape[1]`` — no separate parameter is needed. When ``H_q >
+H_kv``, the ``heads_per_kv = H_q // H_kv`` query heads that share one kv
+head (contiguous blocks: query heads ``[h_kv*heads_per_kv,
+(h_kv+1)*heads_per_kv)`` map to kv head ``h_kv``, i.e. ``repeat_interleave``
+order) are packed into one threadgroup, so each K/V code is decoded once
+and reused across all heads that share it, instead of being redundantly
+redecoded per query head. ``H_q == H_kv`` (plain MHA, ``heads_per_kv=1``)
+degenerates to the original per-head dispatch with bit-identical output.
 
 Public API:
   - :func:`scalar_fused_decode_attend`
@@ -59,16 +73,20 @@ _cache: dict = {}
 # ===========================================================================
 # Metal source — fused affine decode + flash-decoding attend
 # ===========================================================================
-# Grid:        (B * H * S_q * 32, NSG_C, 1) — MLX grid = total threads.
-# Threadgroup: (32, NSG_C, 1)               — NSG_C SIMD-groups of 32 lanes.
+# Grid:        (B * H_kv * S_q * 32, NSG_C, 1) — MLX grid = total threads.
+# Threadgroup: (32, NSG_C, 1)                  — NSG_C SIMD-groups of 32 lanes.
 #
-# Each threadgroup handles one query position (b, h, sq). A single
-# 32-lane pass over S_kv under-fills the GPU for decode shapes
-# (B*H*S_q small), so the kv axis is split flash-decoding style:
-# SIMD-group sg processes slots sk = sg, sg + NSG_C, ... with its own
-# online softmax (running_m, running_d, my_out[]). The NSG_C partial
-# results are merged through threadgroup memory at the end (identical
-# merge to _rabitq_attend).
+# Each threadgroup handles one (b, h_kv, sq) slot and ALL HEADS_PER_KV_C
+# query heads sharing that kv head — K/V codes are decoded once per
+# (sk, d) and the dot-product/weighted-accumulate is repeated per packed
+# head against the already-decoded value, so K/V DRAM reads don't scale
+# with heads_per_kv. A single 32-lane pass over S_kv under-fills the GPU
+# for decode shapes (B*H_kv*S_q small), so the kv axis is also split
+# flash-decoding style: SIMD-group sg processes slots sk = sg, sg +
+# NSG_C, ... with its own per-packed-head online softmax (running_m[],
+# running_d[], my_out[][]). The NSG_C partial results are merged through
+# threadgroup memory at the end (identical merge to _rabitq_attend, just
+# repeated per packed head).
 #
 # Within one SIMD-group the 32 lanes stripe the D-dim vectors in steps
 # of 32; simd_sum reduces the partial dot product, so the per-slot loop
@@ -76,7 +94,9 @@ _cache: dict = {}
 #
 # GK (key groups along tokens) and GV (value groups along channels) and
 # the group size G are read from the passed shapes / a param, so one
-# compiled kernel serves any (S_kv, D, g).
+# compiled kernel serves any (S_kv, D, g). heads_per_kv=1 (H_q == H_kv)
+# degenerates every per-head loop to a single trip, compiling down to
+# the original non-GQA code path.
 
 _SCALAR_AFFINE_ATTEND_SRC = _read_kernel_source("scalar_affine_attend.metal")
 
@@ -86,11 +106,11 @@ _SCALAR_AFFINE_ATTEND_SRC = _read_kernel_source("scalar_affine_attend.metal")
 # ---------------------------------------------------------------------------
 
 
-def _scalar_affine_attend_kernel(D: int, nsg: int):
-    key = ("scalar_affine_attend", D, nsg)
+def _scalar_affine_attend_kernel(D: int, nsg: int, heads_per_kv: int):
+    key = ("scalar_affine_attend", D, nsg, heads_per_kv)
     if key not in _cache:
         _cache[key] = mx.fast.metal_kernel(
-            name=f"scalar_affine_attend_d{D}_nsg{nsg}",
+            name=f"scalar_affine_attend_d{D}_nsg{nsg}_hpk{heads_per_kv}",
             input_names=[
                 "q",
                 "k_codes",
@@ -103,11 +123,21 @@ def _scalar_affine_attend_kernel(D: int, nsg: int):
                 "scale_arr",
             ],
             output_names=["out"],
-            header=f"#define NSG_C {nsg}\n",
+            header=f"#define NSG_C {nsg}\n#define HEADS_PER_KV_C {heads_per_kv}\n",
             source=_SCALAR_AFFINE_ATTEND_SRC,
             ensure_row_contiguous=True,
         )
     return _cache[key]
+
+
+# Threadgroup-memory budget (bytes), matching the 32KB ceiling
+# _flash_prefill.py's _PDT_HARD_BUDGET already assumes for this GPU family.
+_TG_MEM_BUDGET_BYTES = 32768
+
+# Defensive ceiling on heads_per_kv — 2x the largest ratio in any current
+# open-weights model (Qwen2's 7x), bounding the compile-time per-lane
+# register-array sizes (running_m/running_d/my_out) against pathological inputs.
+_MAX_HEADS_PER_KV = 16
 
 
 # ---------------------------------------------------------------------------
@@ -133,34 +163,83 @@ def scalar_fused_decode_attend(
     and ``v_hat = v_codes*v_scale + v_zero`` (per-token groups) on-the-fly
     inside an online-softmax loop — no intermediate fp16 K_hat/V_hat.
 
+    Supports grouped-query attention: ``k_codes``/``v_codes`` (and their
+    scale/zero arrays) may carry fewer heads than ``q``. ``H_kv`` is
+    inferred from ``k_codes.shape[1]`` and must evenly divide ``q``'s head
+    count ``H_q``; the ``heads_per_kv = H_q // H_kv`` query heads sharing
+    a kv head are packed into one threadgroup so each K/V code is decoded
+    once and reused across them. ``H_q == H_kv`` (plain MHA) is unaffected.
+
     Args:
-        q:        ``[B, H, S_q, D]`` fp16/fp32 queries (pre-rotated).
-        k_codes:  ``[B, H, S_kv, D]`` uint8 key codes.
-        k_scale:  ``[B, H, GK, D]``   fp32, GK = ceil(S_kv/group_size).
-        k_zero:   ``[B, H, GK, D]``   fp32.
-        v_codes:  ``[B, H, S_kv, D]`` uint8 value codes.
-        v_scale:  ``[B, H, S_kv, GV]`` fp32, GV = ceil(D/group_size).
-        v_zero:   ``[B, H, S_kv, GV]`` fp32.
+        q:        ``[B, H_q, S_q, D]`` fp16/fp32 queries (pre-rotated).
+        k_codes:  ``[B, H_kv, S_kv, D]`` uint8 key codes.
+        k_scale:  ``[B, H_kv, GK, D]``   fp32, GK = ceil(S_kv/group_size).
+        k_zero:   ``[B, H_kv, GK, D]``   fp32.
+        v_codes:  ``[B, H_kv, S_kv, D]`` uint8 value codes.
+        v_scale:  ``[B, H_kv, S_kv, GV]`` fp32, GV = ceil(D/group_size).
+        v_zero:   ``[B, H_kv, S_kv, GV]`` fp32.
         group_size: quantization group size g.
         scale:    attention scale applied to the raw dot (e.g. 1/sqrt(D)).
         nsg:      SIMD-groups per threadgroup splitting the kv axis.
 
     Returns:
-        ``[B, H, S_q, D]`` fp16 attention output.
+        ``[B, H_q, S_q, D]`` fp16 attention output.
     """
     if q.ndim != 4:
         raise ValueError(f"scalar_fused_decode_attend: q must be 4D, got {q.shape}")
+    if k_codes.ndim != 4 or v_codes.ndim != 4:
+        raise ValueError(
+            "scalar_fused_decode_attend: k_codes and v_codes must be 4D, "
+            f"got k_codes={k_codes.shape}, v_codes={v_codes.shape}"
+        )
     B, H, S_q, D = q.shape
     if D > 256:
         raise ValueError(f"scalar_fused_decode_attend: D={D} must be <= 256")
     if not (1 <= nsg <= 32):
         raise ValueError(f"scalar_fused_decode_attend: nsg={nsg} must be in 1..32")
 
-    n_tg = B * H * S_q
+    Bk, H_kv, _, Dk = k_codes.shape
+    if Bk != B:
+        raise ValueError(
+            f"scalar_fused_decode_attend: batch mismatch: q B={B} vs k_codes B={Bk}"
+        )
+    if Dk != D:
+        raise ValueError(
+            f"scalar_fused_decode_attend: head_dim mismatch: q D={D} vs k_codes D={Dk}"
+        )
+    if v_codes.shape[1] != H_kv:
+        raise ValueError(
+            f"scalar_fused_decode_attend: k_codes H_kv={H_kv} vs "
+            f"v_codes H_kv={v_codes.shape[1]} mismatch"
+        )
+    if H % H_kv != 0:
+        raise ValueError(
+            f"scalar_fused_decode_attend: H_q={H} must be a multiple of "
+            f"H_kv={H_kv} (k_codes.shape[1]) for GQA head-packing"
+        )
+    heads_per_kv = H // H_kv
+    if heads_per_kv > _MAX_HEADS_PER_KV:
+        raise ValueError(
+            f"scalar_fused_decode_attend: heads_per_kv={heads_per_kv} exceeds "
+            f"the supported maximum of {_MAX_HEADS_PER_KV}"
+        )
+    # sh_o[NSG_C*HEADS_PER_KV_C*8*32] + sh_m[NSG_C*HEADS_PER_KV_C] + sh_d[NSG_C*HEADS_PER_KV_C],
+    # all float32 — must match scalar_affine_attend.metal's threadgroup array declarations.
+    n_slots = nsg * heads_per_kv
+    tg_mem_bytes = (n_slots * 8 * 32 + n_slots + n_slots) * 4
+    if tg_mem_bytes > _TG_MEM_BUDGET_BYTES:
+        raise ValueError(
+            f"scalar_fused_decode_attend: nsg={nsg} * heads_per_kv={heads_per_kv} "
+            f"exceeds the {_TG_MEM_BUDGET_BYTES}B threadgroup-memory budget for "
+            f"the softmax merge buffers ({tg_mem_bytes}B); reduce nsg or use a "
+            f"smaller H_q/H_kv ratio"
+        )
+
+    n_tg = B * H_kv * S_q
     gsize = mx.array([group_size], dtype=mx.uint32)
     scale_arr = mx.array([scale], dtype=mx.float32)
 
-    outputs = _scalar_affine_attend_kernel(D, nsg)(
+    outputs = _scalar_affine_attend_kernel(D, nsg, heads_per_kv)(
         inputs=[
             q.astype(mx.float16),
             k_codes.astype(mx.uint8),

--- a/veloxquant_mlx/metal/_scalar_attend.py
+++ b/veloxquant_mlx/metal/_scalar_attend.py
@@ -51,8 +51,36 @@ and reused across all heads that share it, instead of being redundantly
 redecoded per query head. ``H_q == H_kv`` (plain MHA, ``heads_per_kv=1``)
 degenerates to the original per-head dispatch with bit-identical output.
 
+Two-pass decode-once + predecoded-attend (issue #308 spike)
+-------------------------------------------------------------
+Issue #307's GQA head-packing (above) trades away threadgroup count
+(``B*H_q*S_q`` -> ``B*H_kv*S_q``) to save K/V decode work, and was
+measured 2.7-4.7x *slower* because occupancy, not bandwidth or decode
+compute, is the binding constraint at realistic decode shapes. Issue #308
+investigated a SIMD-shuffle-based alternative and found it inapplicable:
+``simd_shuffle`` only exchanges data between lanes already co-resident in
+one threadgroup, so it cannot share decoded state across query heads that
+live in *different*, independently-dispatched threadgroups without first
+sacrificing the same threadgroup count as head-packing already does.
+
+This module instead offers a genuinely different two-pass experiment:
+:func:`scalar_decode_once` decodes every K/V code exactly once into a
+``[B, H_kv, S_kv, D]`` fp16 device buffer (dispatched flat over all
+elements -- large and occupancy-friendly by construction, since it scales
+with ``S_kv`` rather than ``S_q``), and :func:`scalar_predecoded_attend`
+then runs the *original* full-occupancy ``B*H_q*S_q`` dispatch against
+that already-decoded buffer -- heads sharing a kv head still redundantly
+*re-read* the same decoded fp16 rows from DRAM, but no longer redundantly
+*re-decode* them. This trades one extra DRAM round-trip (the decode
+pass's own read-then-write) for eliminating the redundant per-head decode
+arithmetic, without touching threadgroup count on the attend dispatch.
+Whether that round-trip is cheaper than redundant on-the-fly decode is
+exactly the open, unverified question this spike measures.
+
 Public API:
   - :func:`scalar_fused_decode_attend`
+  - :func:`scalar_decode_once`
+  - :func:`scalar_predecoded_attend`
 """
 
 from __future__ import annotations
@@ -99,6 +127,8 @@ _cache: dict = {}
 # the original non-GQA code path.
 
 _SCALAR_AFFINE_ATTEND_SRC = _read_kernel_source("scalar_affine_attend.metal")
+_SCALAR_AFFINE_DECODE_ONCE_SRC = _read_kernel_source("scalar_affine_decode_once.metal")
+_SCALAR_PREDECODED_ATTEND_SRC = _read_kernel_source("scalar_predecoded_attend.metal")
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +155,35 @@ def _scalar_affine_attend_kernel(D: int, nsg: int, heads_per_kv: int):
             output_names=["out"],
             header=f"#define NSG_C {nsg}\n#define HEADS_PER_KV_C {heads_per_kv}\n",
             source=_SCALAR_AFFINE_ATTEND_SRC,
+            ensure_row_contiguous=True,
+        )
+    return _cache[key]
+
+
+def _scalar_affine_decode_kernel(mode: str):
+    assert mode in ("K", "V")
+    key = ("scalar_affine_decode_once", mode)
+    if key not in _cache:
+        _cache[key] = mx.fast.metal_kernel(
+            name=f"scalar_affine_decode_once_{mode.lower()}",
+            input_names=["codes", "scale", "zero", "gsize"],
+            output_names=["out"],
+            header=f"#define DECODE_MODE_K {1 if mode == 'K' else 0}\n",
+            source=_SCALAR_AFFINE_DECODE_ONCE_SRC,
+            ensure_row_contiguous=True,
+        )
+    return _cache[key]
+
+
+def _scalar_predecoded_attend_kernel(nsg: int):
+    key = ("scalar_predecoded_attend", nsg)
+    if key not in _cache:
+        _cache[key] = mx.fast.metal_kernel(
+            name=f"scalar_predecoded_attend_nsg{nsg}",
+            input_names=["q", "k_hat", "v_hat", "scale_arr"],
+            output_names=["out"],
+            header=f"#define NSG_C {nsg}\n",
+            source=_SCALAR_PREDECODED_ATTEND_SRC,
             ensure_row_contiguous=True,
         )
     return _cache[key]
@@ -200,9 +259,7 @@ def scalar_fused_decode_attend(
 
     Bk, H_kv, _, Dk = k_codes.shape
     if Bk != B:
-        raise ValueError(
-            f"scalar_fused_decode_attend: batch mismatch: q B={B} vs k_codes B={Bk}"
-        )
+        raise ValueError(f"scalar_fused_decode_attend: batch mismatch: q B={B} vs k_codes B={Bk}")
     if Dk != D:
         raise ValueError(
             f"scalar_fused_decode_attend: head_dim mismatch: q D={D} vs k_codes D={Dk}"
@@ -260,4 +317,134 @@ def scalar_fused_decode_attend(
     return outputs[0]
 
 
-__all__ = ["scalar_fused_decode_attend"]
+def scalar_decode_once(
+    codes: mx.array,
+    scale: mx.array,
+    zero: mx.array,
+    group_size: int,
+    mode: str,
+) -> mx.array:
+    """Decode a group-affine quantized K or V tensor to fp16, once.
+
+    Part of the issue #308 two-pass spike: decodes every code exactly
+    once into a full ``[B, H_kv, S, D]`` fp16 buffer, dispatched flat
+    over all elements (occupancy scales with ``S``, not ``S_q`` -- large
+    and GPU-friendly by construction). Feeds
+    :func:`scalar_predecoded_attend`.
+
+    Args:
+        codes: ``[B, H_kv, S, D]`` uint8 codes (K or V).
+        scale: K -> ``[B, H_kv, GK, D]``; V -> ``[B, H_kv, S, GV]``, fp32.
+        zero:  same shape as ``scale``, fp32.
+        group_size: quantization group size g.
+        mode: ``"K"`` (per-channel groups along tokens) or ``"V"``
+            (per-token groups along channels) -- selects the group-index
+            arithmetic matching the two layouts documented on
+            :func:`scalar_fused_decode_attend`.
+
+    Returns:
+        ``[B, H_kv, S, D]`` fp16 decoded tensor.
+    """
+    if mode not in ("K", "V"):
+        raise ValueError(f"scalar_decode_once: mode must be 'K' or 'V', got {mode!r}")
+    if codes.ndim != 4:
+        raise ValueError(f"scalar_decode_once: codes must be 4D, got {codes.shape}")
+
+    B, H_kv, S, D = codes.shape
+    N = B * H_kv * S * D
+    gsize = mx.array([group_size], dtype=mx.uint32)
+
+    outputs = _scalar_affine_decode_kernel(mode)(
+        inputs=[
+            codes.astype(mx.uint8),
+            scale.astype(mx.float32),
+            zero.astype(mx.float32),
+            gsize,
+        ],
+        grid=(N, 1, 1),
+        threadgroup=(min(256, N), 1, 1),
+        output_shapes=[(B, H_kv, S, D)],
+        output_dtypes=[mx.float16],
+    )
+    return outputs[0]
+
+
+def scalar_predecoded_attend(
+    q: mx.array,
+    k_hat: mx.array,
+    v_hat: mx.array,
+    scale: float,
+    nsg: int = 4,
+) -> mx.array:
+    """Flash-decoding SDPA over already-decoded fp16 k_hat/v_hat.
+
+    Part of the issue #308 two-pass spike: pairs with
+    :func:`scalar_decode_once`. Dispatches the full
+    ``B*H_q*S_q`` threadgroups (one per query head), matching the
+    high-occupancy baseline from issue #307's addendum -- heads sharing a
+    kv head redundantly re-read the same decoded fp16 rows, but no
+    on-the-fly dequantization happens in this kernel.
+
+    Args:
+        q:     ``[B, H_q, S_q, D]`` fp16/fp32 queries (pre-rotated).
+        k_hat: ``[B, H_kv, S_kv, D]`` fp16 decoded keys (from
+            ``scalar_decode_once(..., mode="K")``).
+        v_hat: ``[B, H_kv, S_kv, D]`` fp16 decoded values (from
+            ``scalar_decode_once(..., mode="V")``).
+        scale: attention scale applied to the raw dot (e.g. 1/sqrt(D)).
+        nsg:   SIMD-groups per threadgroup splitting the kv axis.
+
+    Returns:
+        ``[B, H_q, S_q, D]`` fp16 attention output.
+    """
+    if q.ndim != 4:
+        raise ValueError(f"scalar_predecoded_attend: q must be 4D, got {q.shape}")
+    if k_hat.ndim != 4 or v_hat.ndim != 4:
+        raise ValueError(
+            "scalar_predecoded_attend: k_hat and v_hat must be 4D, "
+            f"got k_hat={k_hat.shape}, v_hat={v_hat.shape}"
+        )
+    B, H, S_q, D = q.shape
+    if D > 256:
+        raise ValueError(f"scalar_predecoded_attend: D={D} must be <= 256")
+    if not (1 <= nsg <= 32):
+        raise ValueError(f"scalar_predecoded_attend: nsg={nsg} must be in 1..32")
+
+    Bk, H_kv, _, Dk = k_hat.shape
+    if Bk != B:
+        raise ValueError(f"scalar_predecoded_attend: batch mismatch: q B={B} vs k_hat B={Bk}")
+    if Dk != D:
+        raise ValueError(f"scalar_predecoded_attend: head_dim mismatch: q D={D} vs k_hat D={Dk}")
+    if v_hat.shape != k_hat.shape:
+        raise ValueError(
+            f"scalar_predecoded_attend: k_hat shape={k_hat.shape} vs "
+            f"v_hat shape={v_hat.shape} mismatch"
+        )
+    if H % H_kv != 0:
+        raise ValueError(
+            f"scalar_predecoded_attend: H_q={H} must be a multiple of H_kv={H_kv} (k_hat.shape[1])"
+        )
+
+    n_tg = B * H * S_q
+    scale_arr = mx.array([scale], dtype=mx.float32)
+
+    outputs = _scalar_predecoded_attend_kernel(nsg)(
+        inputs=[
+            q.astype(mx.float16),
+            k_hat.astype(mx.float16),
+            v_hat.astype(mx.float16),
+            scale_arr,
+        ],
+        grid=(n_tg * 32, nsg, 1),
+        threadgroup=(32, nsg, 1),
+        output_shapes=[(B, H, S_q, D)],
+        output_dtypes=[mx.float16],
+    )
+    return outputs[0]
+
+
+__all__ = [
+    "scalar_fused_decode_attend",
+    "scalar_decode_once",
+    "scalar_predecoded_attend",
+]

--- a/veloxquant_mlx/metal/src/scalar_affine_attend.metal
+++ b/veloxquant_mlx/metal/src/scalar_affine_attend.metal
@@ -10,9 +10,10 @@
     uint sg   = thread_position_in_threadgroup.y;
 
     uint B    = uint(q_shape[0]);
-    uint H    = uint(q_shape[1]);
+    uint H_q  = uint(q_shape[1]);
     uint S_q  = uint(q_shape[2]);
     uint D    = uint(q_shape[3]);
+    uint H_kv = uint(k_codes_shape[1]);
     uint S_kv = uint(k_codes_shape[2]);
     uint GK   = uint(k_scale_shape[2]);   // key groups along tokens
     uint GV   = uint(v_scale_shape[3]);   // value groups along channels
@@ -21,19 +22,26 @@
     uint G        = uint(gsize[0]);       // group size
     float scale   = scale_arr[0];
     uint  NSG     = uint(NSG_C);
+    uint  HPK     = uint(HEADS_PER_KV_C);
 
-    uint sq_idx = tg % S_q;
-    uint h_idx  = (tg / S_q) % H;
-    uint b_idx  = tg / (S_q * H);
+    // Each threadgroup owns one (batch, kv-head, query-position) slot and
+    // handles ALL HEADS_PER_KV_C query heads that share this kv head —
+    // K/V codes are decoded once per (sk, d) and reused across those heads.
+    uint sq_idx  = tg % S_q;
+    uint hkv_idx = (tg / S_q) % H_kv;
+    uint b_idx   = tg / (S_q * H_kv);
 
-    uint q_base   = ((b_idx * H + h_idx) * S_q + sq_idx) * D;
-    uint bh       = b_idx * H + h_idx;
+    uint bh_kv = b_idx * H_kv + hkv_idx;    // indexes k/v arrays (H_kv-wide)
 
-    // ----- per-lane online-softmax state for this SIMD-group -----
-    float running_m = -INFINITY;
-    float running_d = 0.0f;
-    float my_out[8];                       // D/32 <= 256/32 = 8
-    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
+    // ----- per-lane online-softmax state for this SIMD-group, per packed head -----
+    float running_m[HEADS_PER_KV_C];
+    float running_d[HEADS_PER_KV_C];
+    float my_out[HEADS_PER_KV_C][8];        // D/32 <= 256/32 = 8
+    for (uint hp = 0; hp < HPK; ++hp) {
+        running_m[hp] = -INFINITY;
+        running_d[hp] = 0.0f;
+        for (int i = 0; i < 8; ++i) my_out[hp][i] = 0.0f;
+    }
     uint n_owned = (D + 31u) / 32u;
 
     // ----- main loop: this SIMD-group strides kv by NSG -----
@@ -41,67 +49,91 @@
         // key group index along tokens for this slot
         uint kg = sk / G;
 
-        // partial dot product over lane-owned dims
-        float partial_dot = 0.0f;
+        // Decode K once per (sk, d) — shared across all HEADS_PER_KV_C heads —
+        // and accumulate each head's partial dot product in the same pass.
+        float partial_dot[HEADS_PER_KV_C];
+        for (uint hp = 0; hp < HPK; ++hp) partial_dot[hp] = 0.0f;
         for (uint d = lane; d < D; d += 32u) {
-            uint  code_off = (bh * S_kv + sk) * D + d;
-            uint  ks_off   = (bh * GK + kg) * D + d;
+            uint  code_off = (bh_kv * S_kv + sk) * D + d;
+            uint  ks_off   = (bh_kv * GK + kg) * D + d;
             float k_hat = float(k_codes[code_off]) * k_scale[ks_off]
                         + k_zero[ks_off];
-            partial_dot += float(q[q_base + d]) * k_hat;
+            for (uint hp = 0; hp < HPK; ++hp) {
+                uint h_q_idx = hkv_idx * HPK + hp;
+                uint q_off   = ((b_idx * H_q + h_q_idx) * S_q + sq_idx) * D + d;
+                partial_dot[hp] += float(q[q_off]) * k_hat;
+            }
         }
-        float score = simd_sum(partial_dot) * scale;
 
-        // online softmax update (every lane holds identical score)
-        float m_new  = metal::max(running_m, score);
-        float factor = metal::exp(running_m - m_new);
-        float w      = metal::exp(score      - m_new);
-        running_d    = running_d * factor + w;
-        running_m    = m_new;
-        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
+        float score[HEADS_PER_KV_C];
+        for (uint hp = 0; hp < HPK; ++hp) {
+            score[hp] = simd_sum(partial_dot[hp]) * scale;
+        }
 
-        // value decode + weighted accumulate (per-token groups over channels)
+        // online softmax update, per packed head
+        float w[HEADS_PER_KV_C];
+        for (uint hp = 0; hp < HPK; ++hp) {
+            float m_new  = metal::max(running_m[hp], score[hp]);
+            float factor = metal::exp(running_m[hp] - m_new);
+            w[hp]        = metal::exp(score[hp]      - m_new);
+            running_d[hp] = running_d[hp] * factor + w[hp];
+            running_m[hp] = m_new;
+            for (uint i = 0; i < n_owned; ++i) my_out[hp][i] *= factor;
+        }
+
+        // Decode V once per (sk, d) — shared across all HEADS_PER_KV_C heads —
+        // and accumulate each head's weighted value in the same pass.
         for (uint d = lane; d < D; d += 32u) {
             uint  vg      = d / G;
-            uint  code_off = (bh * S_kv + sk) * D + d;
-            uint  vs_off   = (bh * S_kv + sk) * GV + vg;
+            uint  code_off = (bh_kv * S_kv + sk) * D + d;
+            uint  vs_off   = (bh_kv * S_kv + sk) * GV + vg;
             float v_hat = float(v_codes[code_off]) * v_scale[vs_off]
                         + v_zero[vs_off];
             uint  out_i = (d - lane) / 32u;
-            my_out[out_i] += w * v_hat;
+            for (uint hp = 0; hp < HPK; ++hp) {
+                my_out[hp][out_i] += w[hp] * v_hat;
+            }
         }
     }
 
     // ----- merge the NSG partial softmaxes through threadgroup memory -----
-    // sh_o layout: [NSG_C][8][32]  (SIMD-group, owned-slot, lane).
-    threadgroup float sh_m[NSG_C];         // one slot per SIMD-group
-    threadgroup float sh_d[NSG_C];
-    threadgroup float sh_o[NSG_C * 8 * 32];
+    // sh_o layout: [NSG_C][HEADS_PER_KV_C][8][32]  (SIMD-group, packed head, owned-slot, lane).
+    threadgroup float sh_m[NSG_C * HEADS_PER_KV_C];
+    threadgroup float sh_d[NSG_C * HEADS_PER_KV_C];
+    threadgroup float sh_o[NSG_C * HEADS_PER_KV_C * 8 * 32];
 
-    // stash this SIMD-group's per-lane partials
-    for (uint i = 0; i < n_owned; ++i) {
-        sh_o[(sg * 8u + i) * 32u + lane] = my_out[i];
+    // stash this SIMD-group's per-lane partials, per packed head
+    for (uint hp = 0; hp < HPK; ++hp) {
+        for (uint i = 0; i < n_owned; ++i) {
+            sh_o[((sg * HPK + hp) * 8u + i) * 32u + lane] = my_out[hp][i];
+        }
+        if (lane == 0) {
+            sh_m[sg * HPK + hp] = running_m[hp];
+            sh_d[sg * HPK + hp] = running_d[hp];
+        }
     }
-    if (lane == 0) { sh_m[sg] = running_m; sh_d[sg] = running_d; }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // SIMD-group 0 reduces across all groups
+    // SIMD-group 0 reduces across all groups, per packed head
     if (sg == 0) {
-        float gm = -INFINITY;
-        for (uint s = 0; s < NSG; ++s) gm = metal::max(gm, sh_m[s]);
-        float gd = 0.0f;
-        for (uint s = 0; s < NSG; ++s) gd += sh_d[s] * metal::exp(sh_m[s] - gm);
+        for (uint hp = 0; hp < HPK; ++hp) {
+            float gm = -INFINITY;
+            for (uint s = 0; s < NSG; ++s) gm = metal::max(gm, sh_m[s * HPK + hp]);
+            float gd = 0.0f;
+            for (uint s = 0; s < NSG; ++s) gd += sh_d[s * HPK + hp] * metal::exp(sh_m[s * HPK + hp] - gm);
 
-        for (uint i = 0; i < n_owned; ++i) {
-            float acc = 0.0f;
-            for (uint s = 0; s < NSG; ++s) {
-                acc += sh_o[(s * 8 + i) * 32 + lane]
-                     * metal::exp(sh_m[s] - gm);
-            }
-            uint d = lane + i * 32u;
-            if (d < D) {
-                uint out_off = ((b_idx * H + h_idx) * S_q + sq_idx) * D + d;
-                out[out_off] = half(acc / gd);
+            uint h_q_idx = hkv_idx * HPK + hp;
+            for (uint i = 0; i < n_owned; ++i) {
+                float acc = 0.0f;
+                for (uint s = 0; s < NSG; ++s) {
+                    acc += sh_o[((s * HPK + hp) * 8 + i) * 32 + lane]
+                         * metal::exp(sh_m[s * HPK + hp] - gm);
+                }
+                uint d = lane + i * 32u;
+                if (d < D) {
+                    uint out_off = ((b_idx * H_q + h_q_idx) * S_q + sq_idx) * D + d;
+                    out[out_off] = half(acc / gd);
+                }
             }
         }
     }

--- a/veloxquant_mlx/metal/src/scalar_affine_decode_once.metal
+++ b/veloxquant_mlx/metal/src/scalar_affine_decode_once.metal
@@ -1,0 +1,45 @@
+// scalar_affine_decode_once.metal
+// Extracted from veloxquant_mlx/metal/_scalar_attend.py (_SCALAR_AFFINE_DECODE_K_SRC /
+// _SCALAR_AFFINE_DECODE_V_SRC) — see that file's docstring for the algorithm
+// and issue #308's spike rationale. This file is read as plain text at
+// import time via _read_kernel_source() and JIT-compiled by
+// mx.fast.metal_kernel at call time; it is NOT separately compiled
+// (see issue #64).
+//
+// Flat elementwise decode of one (batch, kv_head, s, d) code into fp16,
+// writing a full [B, H_kv, S, D] device buffer once. Dispatched at
+// B*H_kv*S*D threadgroups' worth of threads -- large and occupancy-friendly
+// by construction, unlike the tiny B*H*S_q attend dispatch this feeds.
+//
+// Two group layouts share this same flat-index shape (K: groups along
+// tokens; V: groups along channels) so this file is compiled twice with a
+// DECODE_MODE_K / DECODE_MODE_V header switch selecting the group-index
+// arithmetic; the element loop itself is identical.
+
+    uint elem = thread_position_in_grid.x;
+    uint N    = uint(codes_shape[0]) * uint(codes_shape[1]) * uint(codes_shape[2]) * uint(codes_shape[3]);
+    if (elem >= N) return;
+
+    uint D    = uint(codes_shape[3]);
+    uint S    = uint(codes_shape[2]);
+    uint G    = uint(gsize[0]);
+
+    uint d  = elem % D;
+    uint s  = (elem / D) % S;
+    uint bh = elem / (D * S);   // flattened (b * H_kv + h_kv)
+
+#if DECODE_MODE_K
+    // K: per-CHANNEL groups (group along the token axis) -- scale/zero
+    // shaped [B, H_kv, GK, D], GK = ceil(S/G).
+    uint gk       = s / G;
+    uint sz_off   = (bh * uint(scale_shape[2]) + gk) * D + d;
+#else
+    // V: per-TOKEN groups (group along the channel axis) -- scale/zero
+    // shaped [B, H_kv, S, GV], GV = ceil(D/G).
+    uint GV       = uint(scale_shape[3]);
+    uint gv       = d / G;
+    uint sz_off   = (bh * S + s) * GV + gv;
+#endif
+
+    float hat = float(codes[elem]) * scale[sz_off] + zero[sz_off];
+    out[elem] = half(hat);

--- a/veloxquant_mlx/metal/src/scalar_predecoded_attend.metal
+++ b/veloxquant_mlx/metal/src/scalar_predecoded_attend.metal
@@ -1,0 +1,101 @@
+// scalar_predecoded_attend.metal
+// Extracted from veloxquant_mlx/metal/_scalar_attend.py (_SCALAR_PREDECODED_ATTEND_SRC)
+// -- see that file's docstring and issue #308 for the algorithm and spike
+// rationale. This file is read as plain text at import time via
+// _read_kernel_source() and JIT-compiled by mx.fast.metal_kernel at call
+// time; it is NOT separately compiled (see issue #64).
+//
+// Flash-decoding SDPA over ALREADY-DECODED fp16 k_hat/v_hat (produced by
+// scalar_affine_decode_once.metal), one threadgroup per (b, h_q, sq) --
+// i.e. full B*H_q*S_q dispatch, matching the high-occupancy baseline
+// measured in issue #307's addendum. This kernel does no on-the-fly
+// dequantization; heads sharing a kv head each independently re-READ the
+// same decoded fp16 rows (redundant DRAM reads, no redundant decode ALU
+// work) -- the exact tradeoff issue #308 exists to measure against both
+// on-the-fly redundant decode (307's unpacked baseline) and threadgroup
+// packing (307's packed kernel).
+
+    uint tg   = threadgroup_position_in_grid.x;
+    uint lane = thread_position_in_threadgroup.x;
+    uint sg   = thread_position_in_threadgroup.y;
+
+    uint B    = uint(q_shape[0]);
+    uint H_q  = uint(q_shape[1]);
+    uint S_q  = uint(q_shape[2]);
+    uint D    = uint(q_shape[3]);
+    uint H_kv = uint(k_hat_shape[1]);
+    uint S_kv = uint(k_hat_shape[2]);
+    (void)B;
+
+    float scale = scale_arr[0];
+    uint  NSG   = uint(NSG_C);
+    uint  HPK   = uint(H_q / H_kv);
+
+    uint sq_idx = tg % S_q;
+    uint h_idx  = (tg / S_q) % H_q;
+    uint b_idx  = tg / (S_q * H_q);
+    uint hkv_idx = h_idx / HPK;
+    uint bh_kv   = b_idx * H_kv + hkv_idx;   // indexes k_hat/v_hat (H_kv-wide)
+    uint bh_q    = b_idx * H_q + h_idx;      // indexes q/out (H_q-wide)
+
+    float running_m = -INFINITY;
+    float running_d = 0.0f;
+    float my_out[8]; // D/32 <= 256/32 = 8
+    for (int i = 0; i < 8; ++i) my_out[i] = 0.0f;
+    uint n_owned = (D + 31u) / 32u;
+
+    for (uint sk = sg; sk < S_kv; sk += NSG) {
+        float partial_dot = 0.0f;
+        for (uint d = lane; d < D; d += 32u) {
+            uint q_off = (bh_q * S_q + sq_idx) * D + d;
+            uint k_off = (bh_kv * S_kv + sk) * D + d;
+            partial_dot += float(q[q_off]) * float(k_hat[k_off]);
+        }
+        float score = simd_sum(partial_dot) * scale;
+
+        float m_new  = metal::max(running_m, score);
+        float factor = metal::exp(running_m - m_new);
+        float w      = metal::exp(score - m_new);
+        running_d    = running_d * factor + w;
+        running_m    = m_new;
+        for (uint i = 0; i < n_owned; ++i) my_out[i] *= factor;
+
+        for (uint d = lane; d < D; d += 32u) {
+            uint v_off  = (bh_kv * S_kv + sk) * D + d;
+            uint out_i  = (d - lane) / 32u;
+            my_out[out_i] += w * float(v_hat[v_off]);
+        }
+    }
+
+    // ----- merge the NSG partial softmaxes through threadgroup memory -----
+    threadgroup float sh_m[NSG_C];
+    threadgroup float sh_d[NSG_C];
+    threadgroup float sh_o[NSG_C * 8 * 32];
+
+    for (uint i = 0; i < n_owned; ++i) {
+        sh_o[(sg * 8u + i) * 32u + lane] = my_out[i];
+    }
+    if (lane == 0) {
+        sh_m[sg] = running_m;
+        sh_d[sg] = running_d;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (sg == 0) {
+        float gm = -INFINITY;
+        for (uint s = 0; s < NSG; ++s) gm = metal::max(gm, sh_m[s]);
+        float gd = 0.0f;
+        for (uint s = 0; s < NSG; ++s) gd += sh_d[s] * metal::exp(sh_m[s] - gm);
+
+        for (uint i = 0; i < n_owned; ++i) {
+            float acc = 0.0f;
+            for (uint s = 0; s < NSG; ++s) {
+                acc += sh_o[(s * 8 + i) * 32 + lane] * metal::exp(sh_m[s] - gm);
+            }
+            uint d = lane + i * 32u;
+            if (d < D) {
+                uint out_off = (bh_q * S_q + sq_idx) * D + d;
+                out[out_off] = half(acc / gd);
+            }
+        }
+    }

--- a/veloxquant_mlx/tests/metal/test_scalar_attend.py
+++ b/veloxquant_mlx/tests/metal/test_scalar_attend.py
@@ -70,8 +70,25 @@ def _quant_values(v: np.ndarray, g: int, levels: int, eps=1e-8):
 
 
 def _reference_attend(q, kc, ks, kz, vc, vs, vz, g, scale):
-    """Reconstruct fp32 K_hat/V_hat then dense softmax attention (numpy)."""
+    """Reconstruct fp32 K_hat/V_hat then dense softmax attention (numpy).
+
+    Supports GQA: if k/v carry fewer heads than q (kc.shape[1] < q.shape[1]),
+    they are repeat-interleaved up to q's head count first — contiguous
+    blocks of ``heads_per_kv`` query heads share one kv head, matching the
+    kernel's own hkv_idx*heads_per_kv + hp mapping.
+    """
     B, H, S_q, D = q.shape
+    H_kv = kc.shape[1]
+    if H_kv != H:
+        assert H % H_kv == 0, f"H={H} not a multiple of H_kv={H_kv}"
+        heads_per_kv = H // H_kv
+        kc = np.repeat(kc, heads_per_kv, axis=1)
+        ks = np.repeat(ks, heads_per_kv, axis=1)
+        kz = np.repeat(kz, heads_per_kv, axis=1)
+        vc = np.repeat(vc, heads_per_kv, axis=1)
+        vs = np.repeat(vs, heads_per_kv, axis=1)
+        vz = np.repeat(vz, heads_per_kv, axis=1)
+
     S_kv = kc.shape[2]
     kg = np.arange(S_kv) // g
     k_hat = kc.astype(np.float32) * ks[:, :, kg, :] + kz[:, :, kg, :]  # [B,H,Skv,D]
@@ -85,12 +102,15 @@ def _reference_attend(q, kc, ks, kz, vc, vs, vz, g, scale):
     return np.einsum("bhqs,bhsd->bhqd", w, v_hat).astype(np.float32)
 
 
-def _make_inputs(B, H, S_kv, D, b, g, seed=0):
+def _make_inputs(B, H, S_kv, D, b, g, seed=0, H_kv=None):
+    """Build q at H query heads and k/v at H_kv heads (defaults to H, i.e. MHA)."""
+    if H_kv is None:
+        H_kv = H
     rng = np.random.default_rng(seed)
     levels = (1 << b) - 1
     q = rng.standard_normal((B, H, 1, D)).astype(np.float16)
-    kf = rng.standard_normal((B, H, S_kv, D)).astype(np.float32)
-    vf = rng.standard_normal((B, H, S_kv, D)).astype(np.float32)
+    kf = rng.standard_normal((B, H_kv, S_kv, D)).astype(np.float32)
+    vf = rng.standard_normal((B, H_kv, S_kv, D)).astype(np.float32)
     kc, ks, kz = _quant_keys(kf, g, levels)
     vc, vs, vz = _quant_values(vf, g, levels)
     return q, kc, ks, kz, vc, vs, vz
@@ -152,6 +172,80 @@ def test_scalar_attend_bitwidths(b):
     assert max_abs < 2e-3, f"b={b}: max|abs|={max_abs:.3e}"
 
 
+# ---------------------------------------------------------------------------
+# GQA head-packing parity
+# ---------------------------------------------------------------------------
+
+
+def _tg_mem_bytes(nsg, heads_per_kv):
+    # Mirrors _scalar_attend.py's own budget check: sh_o + sh_m + sh_d, all fp32.
+    n_slots = nsg * heads_per_kv
+    return (n_slots * 8 * 32 + n_slots + n_slots) * 4
+
+
+_GQA_CASES = [
+    (H_q, H_kv, S_kv, nsg)
+    for H_q, H_kv in [(8, 2), (32, 4), (32, 8)]
+    for S_kv in [64, 512, 2048]
+    for nsg in [1, 2, 4]
+    if _tg_mem_bytes(nsg, H_q // H_kv) <= 32768
+]
+
+
+@pytest.mark.parametrize("H_q,H_kv,S_kv,nsg", _GQA_CASES)
+def test_scalar_attend_gqa_parity(H_q, H_kv, S_kv, nsg):
+    D, b, g = 128, 2, 32
+    scale = 1.0 / math.sqrt(D)
+    q, kc, ks, kz, vc, vs, vz = _make_inputs(1, H_q, S_kv, D, b, g, H_kv=H_kv)
+
+    ref = _reference_attend(q, kc, ks, kz, vc, vs, vz, g, scale)
+    got = scalar_fused_decode_attend(
+        mx.array(q),
+        mx.array(kc),
+        mx.array(ks),
+        mx.array(kz),
+        mx.array(vc),
+        mx.array(vs),
+        mx.array(vz),
+        g,
+        scale,
+        nsg=nsg,
+    )
+    mx.eval(got)
+    got_np = np.array(got).astype(np.float32)
+
+    assert got_np.shape == ref.shape == (1, H_q, 1, D)
+    max_abs = np.abs(got_np - ref).max()
+    assert max_abs < 2e-3, f"H_q={H_q} H_kv={H_kv} S_kv={S_kv} nsg={nsg}: max|abs|={max_abs:.3e}"
+
+
+def test_scalar_attend_gqa_parity_batched():
+    # B=2 exercises the b_idx*H_kv term in bh_kv, which B=1 alone can't catch.
+    B, H_q, H_kv, S_kv, D, b, g = 2, 8, 2, 512, 128, 2, 32
+    scale = 1.0 / math.sqrt(D)
+    q, kc, ks, kz, vc, vs, vz = _make_inputs(B, H_q, S_kv, D, b, g, H_kv=H_kv)
+
+    ref = _reference_attend(q, kc, ks, kz, vc, vs, vz, g, scale)
+    got = scalar_fused_decode_attend(
+        mx.array(q),
+        mx.array(kc),
+        mx.array(ks),
+        mx.array(kz),
+        mx.array(vc),
+        mx.array(vs),
+        mx.array(vz),
+        g,
+        scale,
+        nsg=4,
+    )
+    mx.eval(got)
+    got_np = np.array(got).astype(np.float32)
+
+    assert got_np.shape == ref.shape == (B, H_q, 1, D)
+    max_abs = np.abs(got_np - ref).max()
+    assert max_abs < 2e-3, f"B={B}: max|abs|={max_abs:.3e}"
+
+
 def test_scalar_attend_validation():
     q = mx.zeros((1, 4, 1, 128), dtype=mx.float16)
     z = mx.zeros((1, 4, 8, 128), dtype=mx.uint8)
@@ -173,6 +267,48 @@ def test_scalar_attend_validation():
     with pytest.raises(ValueError):
         scalar_fused_decode_attend(
             q, z, z.astype(mx.float32), z.astype(mx.float32), z, s, s, 32, 0.1, nsg=0
+        )
+    # H_q not a multiple of H_kv rejected
+    with pytest.raises(ValueError):
+        scalar_fused_decode_attend(
+            mx.zeros((1, 5, 1, 128), dtype=mx.float16),  # H_q=5
+            mx.zeros((1, 2, 8, 128), dtype=mx.uint8),  # H_kv=2, 5 % 2 != 0
+            mx.zeros((1, 2, 1, 128), dtype=mx.float32),
+            mx.zeros((1, 2, 1, 128), dtype=mx.float32),
+            mx.zeros((1, 2, 8, 128), dtype=mx.uint8),
+            mx.zeros((1, 2, 8, 4), dtype=mx.float32),
+            mx.zeros((1, 2, 8, 4), dtype=mx.float32),
+            32,
+            0.1,
+        )
+    # heads_per_kv exceeding _MAX_HEADS_PER_KV rejected
+    with pytest.raises(ValueError):
+        scalar_fused_decode_attend(
+            mx.zeros((1, 32, 1, 128), dtype=mx.float16),  # H_q=32
+            mx.zeros((1, 1, 8, 128), dtype=mx.uint8),  # H_kv=1 -> heads_per_kv=32
+            mx.zeros((1, 1, 1, 128), dtype=mx.float32),
+            mx.zeros((1, 1, 1, 128), dtype=mx.float32),
+            mx.zeros((1, 1, 8, 128), dtype=mx.uint8),
+            mx.zeros((1, 1, 8, 4), dtype=mx.float32),
+            mx.zeros((1, 1, 8, 4), dtype=mx.float32),
+            32,
+            0.1,
+            nsg=1,
+        )
+    # threadgroup-memory budget overflow (nsg * heads_per_kv within the
+    # heads_per_kv cap but still too large for the softmax merge buffers)
+    with pytest.raises(ValueError):
+        scalar_fused_decode_attend(
+            mx.zeros((1, 32, 1, 128), dtype=mx.float16),  # H_q=32
+            mx.zeros((1, 4, 8, 128), dtype=mx.uint8),  # H_kv=4 -> heads_per_kv=8
+            mx.zeros((1, 4, 1, 128), dtype=mx.float32),
+            mx.zeros((1, 4, 1, 128), dtype=mx.float32),
+            mx.zeros((1, 4, 8, 128), dtype=mx.uint8),
+            mx.zeros((1, 4, 8, 4), dtype=mx.float32),
+            mx.zeros((1, 4, 8, 4), dtype=mx.float32),
+            32,
+            0.1,
+            nsg=4,  # nsg=4 * heads_per_kv=8 -> 33024B > 32768B budget
         )
 
 
@@ -233,3 +369,76 @@ def test_scalar_attend_benchmark(capsys):
                 )
             )
             print(f"| {S_kv:5d} | {tb:15.3f} | {ta:16.3f} | {tb / ta:6.2f}x |")
+
+
+def test_scalar_attend_gqa_packing_benchmark(capsys):
+    """Packed single dispatch vs. heads_per_kv sequential unpacked dispatches.
+
+    Output parity alone can't prove K/V decode is actually being shared
+    (a buggy kernel that redundantly redecodes per head could still produce
+    correct output). This times the packed kernel against heads_per_kv
+    separate calls of the same (heads_per_kv=1) kernel, each against one
+    query head sliced against the shared kv head's codes — i.e. simulating
+    the redundant-redecode baseline with the same underlying kernel, so a
+    real speedup at large S_kv is direct evidence sharing is happening.
+    """
+    B, H_q, H_kv, D, b, g = 1, 32, 4, 128, 2, 32
+    heads_per_kv = H_q // H_kv
+    scale = 1.0 / math.sqrt(D)
+    nsg = 2  # nsg=4 would overflow the 32KB threadgroup-memory budget at heads_per_kv=8
+
+    def _timeit(fn, iters=20, warmup=10):
+        for _ in range(warmup):
+            mx.eval(fn())
+        mx.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            mx.eval(fn())
+        mx.synchronize()
+        return (time.perf_counter() - t0) / iters * 1e3
+
+    with capsys.disabled():
+        print(
+            f"\n# GQA head-packing  |  B={B} H_q={H_q} H_kv={H_kv} "
+            f"heads_per_kv={heads_per_kv} D={D} b={b} g={g} nsg={nsg}  |  MLX {mx.__version__}"
+        )
+        print("| S_kv | packed ms | unpacked ms | speedup |")
+        print("|------|-----------|-------------|---------|")
+        for S_kv in [512, 2048, 8192, 16384]:
+            q, kc, ks, kz, vc, vs, vz = _make_inputs(B, H_q, S_kv, D, b, g, H_kv=H_kv)
+            aq = mx.array(q)
+            akc = mx.array(kc)
+            aks = mx.array(ks)
+            akz = mx.array(kz)
+            avc = mx.array(vc)
+            avs = mx.array(vs)
+            avz = mx.array(vz)
+            mx.eval(aq, akc, aks, akz, avc, avs, avz)
+
+            def _packed():
+                return scalar_fused_decode_attend(aq, akc, aks, akz, avc, avs, avz, g, scale, nsg=nsg)
+
+            def _unpacked():
+                outs = []
+                for hkv in range(H_kv):
+                    for hp in range(heads_per_kv):
+                        hq = hkv * heads_per_kv + hp
+                        outs.append(
+                            scalar_fused_decode_attend(
+                                aq[:, hq : hq + 1],
+                                akc[:, hkv : hkv + 1],
+                                aks[:, hkv : hkv + 1],
+                                akz[:, hkv : hkv + 1],
+                                avc[:, hkv : hkv + 1],
+                                avs[:, hkv : hkv + 1],
+                                avz[:, hkv : hkv + 1],
+                                g,
+                                scale,
+                                nsg=nsg,
+                            )
+                        )
+                return mx.concatenate(outs, axis=1)
+
+            tp = _timeit(_packed)
+            tu = _timeit(_unpacked)
+            print(f"| {S_kv:5d} | {tp:9.3f} | {tu:11.3f} | {tu / tp:6.2f}x |")

--- a/veloxquant_mlx/tests/metal/test_scalar_attend.py
+++ b/veloxquant_mlx/tests/metal/test_scalar_attend.py
@@ -17,11 +17,15 @@ from __future__ import annotations
 import math
 import time
 
-import numpy as np
 import mlx.core as mx
+import numpy as np
 import pytest
 
 from veloxquant_mlx.metal import metal_available
+from veloxquant_mlx.metal._scalar_attend import (
+    scalar_decode_once,
+    scalar_predecoded_attend,
+)
 from veloxquant_mlx.metal.kernels import scalar_fused_decode_attend
 
 pytestmark = pytest.mark.skipif(
@@ -416,7 +420,9 @@ def test_scalar_attend_gqa_packing_benchmark(capsys):
             mx.eval(aq, akc, aks, akz, avc, avs, avz)
 
             def _packed():
-                return scalar_fused_decode_attend(aq, akc, aks, akz, avc, avs, avz, g, scale, nsg=nsg)
+                return scalar_fused_decode_attend(
+                    aq, akc, aks, akz, avc, avs, avz, g, scale, nsg=nsg
+                )
 
             def _unpacked():
                 outs = []
@@ -442,3 +448,128 @@ def test_scalar_attend_gqa_packing_benchmark(capsys):
             tp = _timeit(_packed)
             tu = _timeit(_unpacked)
             print(f"| {S_kv:5d} | {tp:9.3f} | {tu:11.3f} | {tu / tp:6.2f}x |")
+
+
+# ---------------------------------------------------------------------------
+# Issue #308 spike: two-pass decode-once + predecoded-attend
+# ---------------------------------------------------------------------------
+
+
+def _two_pass_attend(q, kc, ks, kz, vc, vs, vz, g, scale, nsg=4):
+    """scalar_decode_once (K, V) followed by scalar_predecoded_attend."""
+    k_hat = scalar_decode_once(kc, ks, kz, g, mode="K")
+    v_hat = scalar_decode_once(vc, vs, vz, g, mode="V")
+    return scalar_predecoded_attend(q, k_hat, v_hat, scale, nsg=nsg)
+
+
+@pytest.mark.parametrize("S_kv", [64, 512, 2048])
+@pytest.mark.parametrize("H_q,H_kv", [(4, 4), (8, 2), (32, 4)])
+def test_scalar_decode_once_predecoded_attend_parity(H_q, H_kv, S_kv):
+    """Two-pass output must match the same numpy reference as the fused kernel."""
+    B, D, b, g = 1, 128, 2, 32
+    scale = 1.0 / math.sqrt(D)
+    q, kc, ks, kz, vc, vs, vz = _make_inputs(B, H_q, S_kv, D, b, g, H_kv=H_kv)
+
+    aq = mx.array(q)
+    akc, aks, akz = mx.array(kc), mx.array(ks), mx.array(kz)
+    avc, avs, avz = mx.array(vc), mx.array(vs), mx.array(vz)
+
+    out = _two_pass_attend(aq, akc, aks, akz, avc, avs, avz, g, scale)
+    ref = _reference_attend(q, kc, ks, kz, vc, vs, vz, g, scale)
+
+    err = np.abs(np.array(out.astype(mx.float32)) - ref)
+    assert err.max() < 2e-3, f"max abs error {err.max():.6f} at H_q={H_q},H_kv={H_kv},S_kv={S_kv}"
+
+
+def test_scalar_decode_once_validation():
+    with pytest.raises(ValueError, match="mode must be"):
+        scalar_decode_once(
+            mx.zeros((1, 2, 8, 128), dtype=mx.uint8),
+            mx.zeros((1, 2, 1, 128), dtype=mx.float32),
+            mx.zeros((1, 2, 1, 128), dtype=mx.float32),
+            group_size=32,
+            mode="bogus",
+        )
+    with pytest.raises(ValueError, match="H_q=.*must be a multiple"):
+        scalar_predecoded_attend(
+            mx.zeros((1, 5, 1, 128), dtype=mx.float16),  # H_q=5
+            mx.zeros((1, 2, 8, 128), dtype=mx.float16),  # H_kv=2 -- 5 % 2 != 0
+            mx.zeros((1, 2, 8, 128), dtype=mx.float16),
+            scale=1.0,
+        )
+
+
+def test_scalar_attend_two_pass_benchmark(capsys):
+    """Three-way timing: packed (307 pt.2) vs. unpacked-redundant vs. two-pass (308).
+
+    Issue #308's spike question: does paying one DRAM round-trip to decode
+    K/V exactly once, then running the existing full-occupancy per-head
+    attend dispatch against the decoded buffer, beat redundantly
+    re-decoding K/V on-the-fly per query head (today's fastest baseline,
+    per #307's addendum)? Printed only -- the go/no-go call is made from
+    reading these numbers, not asserted here, matching
+    test_scalar_attend_gqa_packing_benchmark's style.
+    """
+    B, H_q, H_kv, D, b, g = 1, 32, 4, 128, 2, 32
+    heads_per_kv = H_q // H_kv
+    scale = 1.0 / math.sqrt(D)
+    nsg = 2  # matches the nsg used in the #307 packed-vs-unpacked benchmark
+
+    def _timeit(fn, iters=20, warmup=10):
+        for _ in range(warmup):
+            mx.eval(fn())
+        mx.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            mx.eval(fn())
+        mx.synchronize()
+        return (time.perf_counter() - t0) / iters * 1e3
+
+    with capsys.disabled():
+        print(
+            f"\n# Two-pass decode-once + predecoded-attend (issue #308)  |  "
+            f"B={B} H_q={H_q} H_kv={H_kv} heads_per_kv={heads_per_kv} "
+            f"D={D} b={b} g={g} nsg={nsg}  |  MLX {mx.__version__}"
+        )
+        print("| S_kv | packed ms | unpacked ms | two-pass ms | two-pass vs unpacked |")
+        print("|------|-----------|-------------|-------------|-----------------------|")
+        for S_kv in [512, 2048, 8192, 16384]:
+            q, kc, ks, kz, vc, vs, vz = _make_inputs(B, H_q, S_kv, D, b, g, H_kv=H_kv)
+            aq = mx.array(q)
+            akc, aks, akz = mx.array(kc), mx.array(ks), mx.array(kz)
+            avc, avs, avz = mx.array(vc), mx.array(vs), mx.array(vz)
+            mx.eval(aq, akc, aks, akz, avc, avs, avz)
+
+            def _packed():
+                return scalar_fused_decode_attend(
+                    aq, akc, aks, akz, avc, avs, avz, g, scale, nsg=nsg
+                )
+
+            def _unpacked():
+                outs = []
+                for hkv in range(H_kv):
+                    for hp in range(heads_per_kv):
+                        hq = hkv * heads_per_kv + hp
+                        outs.append(
+                            scalar_fused_decode_attend(
+                                aq[:, hq : hq + 1],
+                                akc[:, hkv : hkv + 1],
+                                aks[:, hkv : hkv + 1],
+                                akz[:, hkv : hkv + 1],
+                                avc[:, hkv : hkv + 1],
+                                avs[:, hkv : hkv + 1],
+                                avz[:, hkv : hkv + 1],
+                                g,
+                                scale,
+                                nsg=nsg,
+                            )
+                        )
+                return mx.concatenate(outs, axis=1)
+
+            def _two_pass():
+                return _two_pass_attend(aq, akc, aks, akz, avc, avs, avz, g, scale, nsg=nsg)
+
+            tp = _timeit(_packed)
+            tu = _timeit(_unpacked)
+            tt = _timeit(_two_pass)
+            print(f"| {S_kv:5d} | {tp:9.3f} | {tu:11.3f} | {tt:11.3f} | {tu / tt:21.2f}x |")


### PR DESCRIPTION
## Summary

Closes the investigation for #307 and #308 — this is **documented groundwork with negative-but-informative performance results**, not a throughput win to merge for its own sake. Nothing in `mlx_lm`'s live decode path calls `scalar_fused_decode_attend` today, so this PR changes no runtime behavior; it's the kernel-level exploration the two issues asked for.

### #307 part 2 — GQA head-packing

Adds GQA support to `scalar_fused_decode_attend`: packs the `heads_per_kv` query heads sharing a kv head into one threadgroup so each K/V code decodes once instead of once per head. Correctness-verified (bit-identical MHA output, GQA parity against a numpy reference). **Measured 2.7–4.7x slower** than naive redundant redecode at realistic `S_kv` — packing collapses threadgroup count from `B*H_q*S_q` to `B*H_kv*S_q`, and GPU occupancy (not bandwidth) is the actual bottleneck at these shapes, per #259's roofline analysis. Confirmed architectural via MLX's own `sdpa_vector.h` (no cross-threadgroup on-chip sharing exists in Metal).

### #308 — SIMD-shuffle spike

Investigated whether `simd_shuffle` could get the same sharing benefit without sacrificing threadgroup count. It can't — `simd_shuffle` only exchanges data between lanes already co-resident in one threadgroup, and under full-occupancy dispatch each threadgroup only ever holds one query head's work. Caught this via design review before writing a kernel around a broken premise.

Implemented a genuinely different two-pass alternative instead: `scalar_decode_once` decodes K/V to fp16 exactly once (flat, occupancy-friendly dispatch), then `scalar_predecoded_attend` reruns the original full-occupancy per-head dispatch against the decoded buffer. Result is a **real S_kv-dependent crossover**: 1.06–3.2x faster than unpacked-redundant at `S_kv ≲ 2–3K`, 0.7–0.85x (slower) past that, consistent across three `H_q/H_kv` ratios tested.

### Disposition

Neither change is adopted for this repo's realistic long-context decode targets (both lose at the `S_kv` that matters). Both are kept as correct, tested code rather than reverted — real short-context win for #308, and both compose with **part 1 of #307** (cross-layer batched dispatch, still open), which is the actual next step for fixing occupancy at the root.

## Test plan

- [x] `pytest veloxquant_mlx/tests/metal/test_scalar_attend.py -v` — 54/54 pass (44 pre-existing + 10 new)
- [x] `ruff format --check` / `ruff check --select I001` clean on touched Python files
- [x] Full crossover table and root-cause analysis in `docs/KV_KERNEL_ROOFLINE_FINDINGS.md`

Refs #307, #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
