### PR TITLE
perf(landing): fix CLS, lazy-load Zendesk, minify CSS/JS at build

### DIFF
--- a/landing/assets/main.js
+++ b/landing/assets/main.js
@@ -411,24 +411,19 @@ function initThemeToggle() {
 }
 
 // ── ANNOUNCEMENT BANNER (dismissible, persisted in localStorage) ──
+// Visibility itself is decided pre-paint by the inline script in <head>
+// (sets data-show-announcement="1" on <html>), so it never pops in after
+// layout has settled. This just wires up the dismiss button.
 function initAnnouncementBanner() {
   const banner = document.getElementById('announcement-banner');
-  if (!banner) return;
+  const closeBtn = document.getElementById('announcement-banner-close');
+  if (!banner || !closeBtn) return;
 
   const dismissKey = 'vq-announcement-dismissed-studio-v0.1.0';
-  try {
-    if (localStorage.getItem(dismissKey)) return;
-  } catch (e) { /* storage unavailable — fall through and show it */ }
-
-  banner.hidden = false;
-
-  const closeBtn = document.getElementById('announcement-banner-close');
-  if (closeBtn) {
-    closeBtn.addEventListener('click', () => {
-      banner.hidden = true;
-      try { localStorage.setItem(dismissKey, '1'); } catch (e) { /* storage unavailable */ }
-    });
-  }
+  closeBtn.addEventListener('click', () => {
+    document.documentElement.removeAttribute('data-show-announcement');
+    try { localStorage.setItem(dismissKey, '1'); } catch (e) { /* storage unavailable */ }
+  });
 }
 
 // ── TOAST ──

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -215,12 +215,15 @@ body {
 /* ===== ANNOUNCEMENT BANNER ===== */
 /* Sits above the sticky nav in normal flow, so it scrolls away with the
    page and nav then sticks at top:0 on its own — no extra offset math
-   needed between the two. Shown/hidden via main.js (initAnnouncementBanner),
-   default [hidden] so a no-JS visitor never sees a banner they can't
-   dismiss. */
-.announcement-banner[hidden] { display: none; }
+   needed between the two. Hidden by default (so a no-JS visitor, or one who
+   already dismissed it, never sees it) and revealed only when the pre-paint
+   script in <head> sets data-show-announcement="1" on <html> — done there
+   rather than in main.js (deferred, runs after first paint) so an
+   undismissed banner doesn't pop in and shift the nav/hero down after
+   layout has already settled (a measurable CLS hit). */
+.announcement-banner { display: none; }
 
-.announcement-banner {
+:root[data-show-announcement="1"] .announcement-banner {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/landing/index.html
+++ b/landing/index.html
@@ -130,6 +130,19 @@
         }
       } catch (e) { /* storage unavailable */ }
     })();
+
+    // Reveal the announcement banner before first paint too, so a
+    // not-yet-dismissed visitor never sees a layout shift when it appears
+    // (this used to run in main.js, after deferred scripts execute post-paint,
+    // shifting everything below the nav down — a measurable CLS hit on every
+    // first-time visit since the banner is undismissed by default).
+    (function () {
+      try {
+        if (!localStorage.getItem('vq-announcement-dismissed-studio-v0.1.0')) {
+          document.documentElement.setAttribute('data-show-announcement', '1');
+        }
+      } catch (e) { /* storage unavailable — leave it hidden */ }
+    })();
   </script>
 
   <!-- Privacy-friendly analytics by Plausible -->
@@ -148,7 +161,7 @@
        (see initAnnouncementBanner in main.js). Hidden entirely if JS is
        disabled or localStorage throws, rather than defaulting to shown,
        since a banner that can never be dismissed is worse than none. -->
-  <div id="announcement-banner" class="announcement-banner" hidden>
+  <div id="announcement-banner" class="announcement-banner">
     <a href="#download" class="announcement-banner-link">
       <span class="announcement-banner-badge">New</span>
       <span>VeloxQuant Studio for macOS is here — a native app for this library.</span>
@@ -965,7 +978,30 @@ pip install -e ".[dev]"</span></pre>
   <script data-goatcounter="https://veloxquant.goatcounter.com/count"
           async src="//gc.zgo.at/count.js"></script>
 
-  <!-- Zendesk Web Widget: live chat / support for product questions -->
-  <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=4e096002-a5bc-474f-9534-08aca170627c"></script>
+  <!-- Zendesk Web Widget: live chat / support for product questions.
+       Loaded lazily — the snippet pulls in its own iframe/CSS and was
+       measurable main-thread + network weight on every page load for a
+       widget almost no first-time visitor opens immediately. Deferred to
+       first interaction (or ~5s idle, so it's still there for someone who
+       never scrolls/moves the mouse) rather than removed. -->
+  <script>
+    (function () {
+      var loaded = false;
+      function loadZendesk() {
+        if (loaded) return;
+        loaded = true;
+        var s = document.createElement('script');
+        s.id = 'ze-snippet';
+        s.src = 'https://static.zdassets.com/ekr/snippet.js?key=4e096002-a5bc-474f-9534-08aca170627c';
+        document.body.appendChild(s);
+        events.forEach(function (ev) { window.removeEventListener(ev, loadZendesk, opts); });
+        clearTimeout(idleTimer);
+      }
+      var events = ['scroll', 'mousemove', 'keydown', 'touchstart', 'click'];
+      var opts = { passive: true };
+      events.forEach(function (ev) { window.addEventListener(ev, loadZendesk, opts); });
+      var idleTimer = setTimeout(loadZendesk, 5000);
+    })();
+  </script>
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,11 @@
     cd docs-site && npm install && npm run build && cd .. &&
     mkdir -p dist/docs &&
     cp -r docs-site/build/* dist/docs/ &&
-    cp -r landing/* dist/
+    cp -r landing/* dist/ &&
+    npx -y csso-cli dist/assets/styles.css -o dist/assets/styles.css &&
+    npx -y terser dist/assets/main.js -c -m -o dist/assets/main.js &&
+    npx -y terser dist/assets/calc.js -c -m -o dist/assets/calc.js &&
+    npx -y terser dist/assets/playground.js -c -m -o dist/assets/playground.js
   """
   publish = "dist"
 


### PR DESCRIPTION
## Summary

- Fixes CLS (0.082 → ~0): the announcement banner's visibility is now decided pre-paint (in the existing `<head>` script that already prevents a theme flash) instead of post-paint in deferred `main.js`, so it no longer pops in and shifts the nav/hero down.
- Lazy-loads the Zendesk widget on first interaction or ~5s idle instead of blocking/loading unconditionally on every page load.
- Adds a minify step to the Netlify build command (`csso-cli` for CSS, `terser` for JS) that only touches the `dist/` build artifact — `landing/` source stays untouched and human-readable for the manual netlify.com/drop path.

Closes #313

## Test plan

- [x] Verified locally: served `landing/` and confirmed `data-show-announcement` markup/attribute wiring is intact
- [x] Ran the new minify pipeline against a copy of `landing/assets/*` — `node --check` passes on minified JS, CSS brace count balances, new `data-show-announcement` selector survives minification
- [x] Confirmed size wins: `styles.css` 105KB → 72KB raw (gzip ~22.9KB → ~13.8KB); `main.js`/`calc.js`/`playground.js` each 40–60% smaller
- [ ] Re-run Lighthouse against the deployed preview to confirm the score/CLS improvement in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)