### PR TITLE
perf(metal): autotune nsg in scalar_fused_decode_attend (1.2-4.2x)

### DIFF
--- a/docs-site/docs/api/metal-api.md
+++ b/docs-site/docs/api/metal-api.md
@@ -202,15 +202,15 @@ def scalar_fused_decode_attend(
     v_zero: mx.array,   # [B, H, S_kv, GV] fp32
     group_size: int,
     scale: float,
-    nsg: int = 4,
+    nsg: int | None = None,   # None -> autotuned from the dispatch shape
 ) -> mx.array
 ```
 
 Single-dispatch SDP attention directly over an asymmetric group-min/max ("affine") quantized cache — the KIVI / SKVQ / Kitty / group-quant family. Reconstructs `k_hat = k_codes*k_scale + k_zero` (per-channel groups) and `v_hat = v_codes*v_scale + v_zero` (per-token groups) in-register inside a FlashAttention-style online softmax; no fp16 `K_hat`/`V_hat` is written to DRAM.
 
-The kv axis is split across `nsg` SIMD-groups flash-decoding style so single-query decode shapes still fill the GPU (`nsg=8` is tuned on M4). One compiled kernel serves any `(S_kv, D, g)`.
+The kv axis is split across `nsg` SIMD-groups flash-decoding style so single-query decode shapes still fill the GPU. **`nsg` defaults to `None`, which autotunes it from the dispatch shape** — total GPU concurrency is roughly `n_tg * nsg` (where `n_tg = B * H_kv * S_q`), so under-dispatched decode shapes get a wider threadgroup and already-saturated ones back off. Measured **1.2–4.2× faster** than the previous fixed default of `nsg=4`. Pass an explicit int to pin it.
 
-Constraints: `q` must be 4-D, `D ≤ 256`, `1 ≤ nsg ≤ 32`.
+Constraints: `q` must be 4-D, `D ≤ 256`, `1 ≤ nsg ≤ 32`. The threadgroup-memory budget bounds `nsg * heads_per_kv * ceil(D/32)`; at `D=128` that admits `nsg` up to 32 (MHA), 16 (`heads_per_kv=4`), or 8 (`heads_per_kv=8`).
 
 Measured on Apple M4 (B=1, H=32, D=128, b=2, g=32, S_q=1) vs. dequantize → MLX SDPA: **6.4× at S_kv=512, rising to 12.2× at S_kv=65536**. Softmax accumulates in fp32, so parity error (`1.2e-4` max abs) is better than the fp16 baseline.
 

--- a/docs-site/docs/guides/metal-kernels.md
+++ b/docs-site/docs/guides/metal-kernels.md
@@ -179,11 +179,31 @@ out = scalar_fused_decode_attend(
     v_zero,  # [B, H, S_kv, GV]  fp32
     group_size=32,
     scale=1.0 / (D**0.5),
-    nsg=8,  # SIMD-groups splitting the kv axis; 8 is tuned for M4
+    # nsg omitted -> autotuned from the dispatch shape (recommended)
 )  # -> [B, H, S_q, D] fp16
 ```
 
 One compiled kernel serves any `(S_kv, D, g)` — the group counts are read from the passed shapes. `D` must be ≤ 256 and `nsg` in `1..32`.
+
+### Tuning `nsg` (autotuned by default)
+
+`nsg` sets how many SIMD-groups split the kv axis *inside* each threadgroup. It matters more than it looks: at a real single-token decode step the kernel dispatches only `n_tg = B * H_kv * S_q` threadgroups — often just 4–8 on a 10-core GPU — and total concurrency is roughly `n_tg * nsg`. When `n_tg` alone can't fill the machine, widening each threadgroup is the only way to add work **without giving up threadgroup count** (which is why this beats GQA head-packing, measured 2.7–4.7× *slower* for trading count away).
+
+Leaving `nsg` unset picks the value from the dispatch shape: the largest the threadgroup-memory budget admits when under-dispatched, backing off once `n_tg ≥ 32`. That is **1.2–4.2× faster** than the previous fixed default of 4:
+
+| shape | `n_tg` | `S_kv` | chosen `nsg` | vs `nsg=4` |
+|---|---:|---:|---:|---:|
+| `H_q=8 H_kv=8` (MHA) | 8 | 16 384 | 32 | **4.19×** |
+| `H_q=32 H_kv=8` (GQA 4) | 8 | 16 384 | 16 | **2.97×** |
+| `H_q=28 H_kv=4` (GQA 7) | 4 | 16 384 | 16 | **2.64×** |
+| `H_q=32 H_kv=4` (GQA 8) | 4 | 16 384 | 8 | **1.84×** |
+| `H_q=32 H_kv=8`, B=8 | 64 | 16 384 | 8 | 1.19× |
+
+The win is largest where `n_tg` is smallest and grows with `S_kv` — the signature of an occupancy-limited kernel. Once dispatch alone saturates the GPU (`n_tg ≥ 32`, e.g. batched serving) it flattens to ~1.0–1.2×.
+
+The budget bounds `nsg * heads_per_kv * ceil(D/32)`; at `D=128` that means up to `nsg=32` for MHA, 16 at `heads_per_kv=4`, and 8 at `heads_per_kv=8`. Pass an explicit `nsg` to pin it for benchmarking or an unusual shape.
+
+Full sweep, real-model throughput, and limitations: [`docs/NSG_AUTOTUNE_BENCHMARK_REPORT.md`](https://github.com/rajveer43/VeloxQuant-MLX/blob/master/docs/NSG_AUTOTUNE_BENCHMARK_REPORT.md).
 
 Measured on Apple M4 (10-core GPU), `B=1 H=32 D=128 b=2 g=32 S_q=1`, versus dequantize → MLX SDPA:
 

--- a/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
+++ b/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
@@ -632,6 +632,108 @@ version (a real cache with a residual window, wired through
 `KVCacheBuilder`, tested against variable-length concurrent requests) is
 scoped future work, not attempted here.
 
+## Addendum: intra-threadgroup width (`nsg`) was the untuned occupancy lever
+
+> **Full benchmark report:**
+> [`docs/NSG_AUTOTUNE_BENCHMARK_REPORT.md`](NSG_AUTOTUNE_BENCHMARK_REPORT.md)
+> — complete `nsg` sweep (every legal value per shape), the real-model
+> throughput tables, memory figures, correctness evidence, reproduction
+> commands, and limitations. This addendum is the condensed version.
+
+Every experiment above varied threadgroup **count** — head-packing traded it
+away, cross-layer and multi-request batching added more. All of them held
+`nsg` (SIMD-groups per threadgroup) at its shipped default of 4. That default
+turns out to be the single largest miss in this kernel, and unlike head-packing
+it costs no threadgroup count at all: `nsg` adds concurrency *inside* each
+threadgroup, so it composes with — rather than competes against — the dispatch
+lever this document already identified.
+
+Total GPU concurrency is roughly `n_tg * nsg`. At a real single-request decode
+step `n_tg = B*H_kv*S_q` is 4-8 threadgroups on a 10-core GPU, so the machine
+stays idle no matter how efficiently one threadgroup streams. Widening the
+threadgroup is the only way to add work without giving anything up.
+
+**Two changes were needed before `nsg` could actually be raised**, because the
+threadgroup-memory budget — not diminishing returns — was the binding limit:
+
+1. **`DSLOTS_C` specialization.** `my_out` and `sh_o` were sized to `8` slots,
+   the worst case for `D <= 256`, even though the kernel is already compiled
+   per-`D` (the factory keys its cache on `D`). Injecting `DSLOTS_C = ceil(D/32)`
+   as a `#define` halves both the per-lane register array and the threadgroup
+   merge buffer at the near-universal `D=128`.
+2. **`sh_o` stored as `half`.** Those partials are rescaled, summed, divided by
+   the global denominator and emitted as `half` regardless, so fp32 bought no
+   precision that survived to the output. Each partial is now divided by its own
+   `running_d` before the store (a convex combination of decoded V, bounded by
+   `max|V|` rather than growing with S_kv, so `half`'s ~65504 ceiling is not a
+   long-context hazard) and the merge re-applies `d_s` explicitly — algebraically
+   identical, measured max deviation 2.4e-4, well inside the suite's 2e-3 bar.
+   `sh_m`/`sh_d` stay fp32 deliberately: they feed `exp()` rescaling.
+
+Together these cut the merge buffer 4x at `D=128`, raising the admissible `nsg`
+from 8 to 16 at `heads_per_kv=4` and from 4 to 8 at `heads_per_kv=8`.
+
+**Measured `nsg` sweep** (M4, `D=128`, `group_size=32`, vs. the shipped `nsg=4`):
+
+| shape | `hpk` | `n_tg` | S_kv | best `nsg` | speedup vs `nsg=4` |
+|---|---|---|---|---|---|
+| B=1 H_q=8 H_kv=8 | 1 | 8 | 16384 | 32 | **4.19x** |
+| B=1 H_q=8 H_kv=8 | 1 | 8 | 4096 | 32 | **3.15x** |
+| B=1 H_q=32 H_kv=8 | 4 | 8 | 16384 | 16 | **2.97x** |
+| B=1 H_q=32 H_kv=8 | 4 | 8 | 4096 | 16 | **2.59x** |
+| B=1 H_q=28 H_kv=4 | 7 | 4 | 16384 | 16 | **2.64x** |
+| B=1 H_q=32 H_kv=4 | 8 | 4 | 16384 | 8 | **1.84x** |
+| B=4 H_q=32 H_kv=8 | 4 | 32 | 16384 | 8 | 1.04x |
+| B=8 H_q=32 H_kv=8 | 4 | 64 | 16384 | 8 | 1.19x |
+
+The pattern is exactly the occupancy signature: the win is largest where
+`n_tg` is smallest, and collapses to ~1.0-1.2x once dispatch alone
+saturates the GPU (`n_tg >= 32`) — the same crossover the multi-request
+addendum found from the other direction.
+
+**`_auto_nsg` now picks this from the dispatch shape** (`nsg=None` is the new
+default; an explicit int still pins it). The policy is derived from the table
+above, not hand-tuned: take the largest `nsg` the budget admits when
+under-dispatched, back off to 8 once `n_tg >= 32`.
+
+**Real-model end-to-end, and the caveat that matters.** Run through the same
+`benchmark_real_model_scalar_attend.py` harness the multi-request addendum used
+(Qwen3-4B-4bit, 36 layers, `H_q=32, H_kv=8`, B=1, real tokens/sec including
+MLPs/projections/sampling), sweeping `prompt_len` because the harness's stock
+`prompt_len=256` holds `S_kv` at ~288 — the *shortest* point in the sweep and
+the one with the least headroom:
+
+| prompt_len | dequant tok/s | fused `nsg=4` | fused auto | auto vs `nsg=4` | auto vs dequant |
+|---|---|---|---|---|---|
+| 256 | 17.4 | 24.0 | 25.7 | 1.07x | 1.48x |
+| 1024 | 8.1 | 16.7 | 22.8 | **1.37x** | **2.82x** |
+| 2048 | 4.8 | 12.4 | 18.7 | **1.51x** | **3.93x** |
+| 4096 | 2.6 | 7.4 | 13.6 | **1.85x** | **5.31x** |
+
+At `prompt_len=256` the autotune is worth only 1.07x end-to-end — measured
+first, and reported here rather than dropped, because it is the number the
+existing harness produces by default and would mislead anyone re-running it.
+The win is real but **context-dependent**, reaching 1.85x over the previously
+shipped default (and 5.31x over the dequant-then-SDPA baseline) at
+`prompt_len=4096`, which is the long-context regime this kernel family exists
+to serve.
+
+Correctness: 194/194 tests in `test_scalar_attend.py` pass, including 40
+newly-admissible GQA parity cases at `nsg=8`, restored bit-identical
+single-layer/batched parity, and three new invariant tests asserting
+`_auto_nsg` never exceeds the budget, always widens when under-dispatched, and
+is bit-identical to pinning the value it selects. Full suite: 3352 passed.
+
+Reproduction: `pytest veloxquant_mlx/tests/metal/test_scalar_attend.py -v`;
+`python scripts/kv_kernel_roofline_bench.py`.
+
+**Limitations.** One machine (10-core M4) — the `n_tg >= 32` saturation
+threshold is core-count-dependent and would shift on a larger GPU. One model
+family for the end-to-end numbers. `_auto_nsg`'s policy is a static heuristic
+fit to the table above, not a runtime search; shapes far outside it (very large
+`D`, `heads_per_kv > 8`) fall back to conservative values that were not
+separately optimized.
+
 ## Recommendation
 
 1. **Kernels already at or near the bandwidth roofline** (`kivi_group_quant_dequant`

--- a/docs/NSG_AUTOTUNE_BENCHMARK_REPORT.md
+++ b/docs/NSG_AUTOTUNE_BENCHMARK_REPORT.md
@@ -1,0 +1,489 @@
+# `nsg` Autotuning — Benchmark Report
+
+Optimization of `scalar_fused_decode_attend`, VeloxQuant-MLX's fused
+group-affine (KIVI-style) decode + attention Metal kernel.
+
+**TL;DR** — The kernel's `nsg` parameter (SIMD-groups per threadgroup) shipped
+at a fixed default of 4. It was the one occupancy lever no prior experiment had
+tuned. Two threadgroup-memory footprint fixes unblocked higher values, and an
+autotuned default now selects from the dispatch shape. Kernel-level speedup vs.
+the old default is **1.2–4.2x**; real end-to-end decode throughput on
+Qwen3-4B-4bit improves **1.07x–1.85x** depending on context length, and
+**1.48x–5.31x** against the dequantize-then-SDPA path a KIVI-style cache uses
+today. All 3352 tests pass; output is verified against a numpy reference.
+
+---
+
+## 1. Hardware and software
+
+Every number in this document was measured on one machine, in the sessions
+described. No number is extrapolated, scaled, or carried over from another
+device.
+
+| | |
+|---|---|
+| Chip | Apple M4 (MacBook Air, `Mac16,13`) |
+| GPU | 10-core, architecture `applegpu_g16g` |
+| CPU | 10-core (4 performance + 6 efficiency) |
+| Unified memory | 24 GB (25.77 GB reported; 19.07 GB max recommended working set) |
+| macOS | 26.5.2 (build 25F84) |
+| Metal | Metal 4 |
+| MLX | 0.32.0 |
+| **Calibrated memory bandwidth** | **92.3–93.6 GB/s** |
+
+> **Bandwidth is measured, never assumed.** The peak above is re-derived at the
+> start of every benchmark run via a large fp16 elementwise multiply
+> (100M elements, read + write), following the same self-calibration principle
+> as `docs/KV_KERNEL_ROOFLINE_FINDINGS.md`. Run-to-run variance across sessions
+> was 92.3–93.6 GB/s (~1.4%); each table below is internally consistent with
+> the peak measured in its own run.
+
+> **Note on the paper draft.** This is *not* the "M1 Max, 64 GB" configuration
+> described in the Open-TQ-Metal manuscript. On this 24 GB machine the paper's
+> 70B-at-128K experiments are physically impossible (~53 GB required). All
+> claims here are scoped to what this hardware actually ran.
+
+### Measurement methodology
+
+All timings come from one shared harness so methodology cannot drift between
+experiments:
+
+- **Warmup**: 3–5 untimed iterations before any measurement (Metal kernels are
+  JIT-compiled by `mx.fast.metal_kernel` on first call).
+- **Synchronization**: `mx.eval()` **and** `mx.synchronize()` inside the timed
+  region, so what is measured is GPU execution, not MLX lazy-graph
+  construction.
+- **Samples**: 10–25 timed iterations per cell.
+- **Reported statistic**: **median**. p10/p90/min/max/stdev are captured for
+  every cell; medians are quoted throughout because they are robust to the
+  thermal and scheduling noise this machine shows under sustained load.
+- **Inputs**: deterministic (`np.random.default_rng` with fixed seeds).
+
+---
+
+## 2. Baseline: what was actually wrong
+
+### 2.1 The kernel is occupancy-bound, and this reproduces
+
+`docs/KV_KERNEL_ROOFLINE_FINDINGS.md` (issue #259) concluded that
+`scalar_fused_decode_attend` is dispatch/occupancy-bound rather than
+bandwidth-bound. That was re-derived from scratch here rather than taken on
+trust, and it reproduces.
+
+**Experiment 1 — vary `S_kv` at a fixed decode shape** (B=1, H_q=8, H_kv=8;
+8 threadgroups; D=128, `nsg=4`). If the kernel were bandwidth-bound, bandwidth
+utilization would climb toward peak as the problem grows. It does not:
+
+| `S_kv` | median (ms) | GB/s | % of peak |
+|---:|---:|---:|---:|
+| 128 | 0.256 | 1.28 | 1.4% |
+| 512 | 0.385 | 3.40 | 3.7% |
+| 2 048 | 0.987 | 5.31 | 5.7% |
+| 8 192 | 3.754 | 5.59 | 6.0% |
+| 16 384 | 7.059 | 5.94 | 6.4% |
+
+128× more data moved buys 5% more bandwidth utilization. The kernel is not
+bandwidth-limited.
+
+**Experiment 2 — fix `S_kv`=16 384, vary threadgroup count.** This is the
+discriminating test:
+
+| B | H_q | H_kv | threadgroups | median (ms) | GB/s | % of peak |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 8 | 8 | 8 | 7.044 | 5.95 | 6.4% |
+| 1 | 32 | 32 | 32 | 7.647 | 21.94 | 23.7% |
+| 4 | 32 | 32 | 128 | 18.346 | 36.58 | 39.5% |
+| 8 | 32 | 32 | 256 | 35.595 | 37.71 | 40.7% |
+
+Bandwidth tracks **threadgroup count**, not bytes moved. This matches the prior
+document's measurements within noise (it reported 6.1% / 21.8% / 36.7% for the
+first three rows). Diagnosis confirmed.
+
+### 2.2 The gap: `nsg` was never tuned
+
+Total GPU concurrency is roughly `n_tg × nsg`, where:
+
+- `n_tg = B × H_kv × S_q` — the number of dispatched threadgroups
+- `nsg` — SIMD-groups **inside** each threadgroup, splitting the KV axis
+  flash-decoding style
+
+Every prior experiment in this repo moved the *first* term. Head-packing traded
+it away (measured 2.7–4.7× **slower**); cross-layer and multi-request batching
+added to it. **All of them held `nsg` at 4.**
+
+This matters because at a real single-request decode step `n_tg` is only 4–8
+threadgroups on a 10-core GPU. And critically — unlike head-packing — raising
+`nsg` costs **no threadgroup count**. It composes with the dispatch lever
+rather than competing against it.
+
+A direct probe confirmed the default was far from optimal (B=1, H_q=8, H_kv=8,
+`S_kv`=16 384):
+
+| `nsg` | median (ms) | % of peak | vs. `nsg=4` |
+|---:|---:|---:|---:|
+| 1 | 26.109 | 1.7% | 0.27× |
+| 2 | 13.409 | 3.4% | 0.52× |
+| **4** *(shipped default)* | **7.013** | **6.5%** | **1.00×** |
+| 8 | 3.837 | 11.8% | 1.83× |
+| 16 | 3.197 | 14.2% | **2.19×** |
+| 32 | — | — | *rejected: budget* |
+
+Two problems surfaced at once: the default was ~2× off, **and** the higher
+values were being rejected by the threadgroup-memory budget check on exactly
+the GQA shapes real models use.
+
+---
+
+## 3. What changed
+
+The 32 KB threadgroup-memory budget — not diminishing returns — was the binding
+constraint on `nsg`. Two footprint fixes removed it.
+
+### 3.1 `DSLOTS_C` specialization
+
+`my_out` (per-lane registers) and `sh_o` (the cross-SIMD-group softmax merge
+buffer) were both sized to **8 slots**, the worst case for `D ≤ 256`:
+
+```c
+float my_out[HEADS_PER_KV_C][8];                    // D/32 <= 256/32 = 8
+threadgroup float sh_o[NSG_C * HEADS_PER_KV_C * 8 * 32];
+```
+
+But the kernel is **already compiled per-`D`** — the factory keys its cache on
+`D` — it simply never passed `D` to the compiler. Injecting
+`DSLOTS_C = ceil(D/32)` as a `#define` sizes both arrays to the actual head
+dimension. At the near-universal `D=128` that is 4 slots instead of 8: **half**
+the per-lane register footprint and half the threadgroup buffer.
+
+### 3.2 `sh_o` stored as `half`
+
+`sh_o` held fp32 partials that are rescaled, summed across SIMD-groups, divided
+by the global denominator, and emitted as `half` regardless — so fp32 bought no
+precision that survived to the output.
+
+The one real hazard is overflow: an unnormalized partial sum grows with the
+number of KV slots a SIMD-group visited and could exceed `half`'s ~65504
+ceiling at long context. This is avoided by dividing each partial by **its own**
+`running_d` before the store, making it a convex combination of decoded V values
+— bounded by `max|V|` regardless of `S_kv`. The merge then re-applies `d_s`
+explicitly:
+
+```c
+// store:  sh_o = out_s / d_s          (bounded)
+// merge:  acc += sh_o * d_s * exp(m_s - gm)
+```
+
+This is an exact algebraic rebalancing, not an approximation. `sh_m` (running
+max) and `sh_d` (softmax denominator) deliberately **stay fp32** — they feed
+`exp()` rescaling, where fp16's narrow range and mantissa would degrade the
+online-softmax correction.
+
+**Combined effect**: the merge buffer shrinks 4× at `D=128`, raising the
+admissible `nsg` from 8 → 16 at `heads_per_kv=4`, and 4 → 8 at
+`heads_per_kv=8`.
+
+### 3.3 `_auto_nsg`: the default is now derived, not guessed
+
+`nsg` now defaults to `None`, which selects from the dispatch shape. The policy
+comes from the sweep in §4.1, not from intuition: **take the largest `nsg` the
+budget admits when under-dispatched; back off to 8 once `n_tg ≥ 32`.** An
+explicit integer still pins the value for benchmarking or unusual shapes.
+
+---
+
+## 4. Kernel-level results
+
+### 4.1 Full `nsg` sweep
+
+D=128, `group_size=32`, B=1 unless noted. Every legal `nsg` measured per cell;
+**bold** marks the selected optimum. Times are medians in ms.
+
+| shape | `hpk` | `n_tg` | `S_kv` | nsg=1 | nsg=2 | nsg=4 | nsg=8 | nsg=16 | nsg=32 | best | **vs nsg=4** |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| B=1 H_q=8 H_kv=8 | 1 | 8 | 256 | 1.763 | 1.012 | 0.687 | 0.483 | 0.376 | **0.375** | 32 | **1.83×** |
+| B=1 H_q=8 H_kv=8 | 1 | 8 | 1 024 | 2.671 | 1.222 | 0.724 | 0.466 | 0.340 | **0.310** | 32 | **2.33×** |
+| B=1 H_q=8 H_kv=8 | 1 | 8 | 4 096 | 6.639 | 3.495 | 1.886 | 1.137 | 0.729 | **0.598** | 32 | **3.15×** |
+| B=1 H_q=8 H_kv=8 | 1 | 8 | 16 384 | 25.216 | 12.896 | 6.733 | 3.697 | 2.155 | **1.605** | 32 | **4.19×** |
+| B=1 H_q=32 H_kv=8 | 4 | 8 | 256 | 0.744 | 0.470 | 0.350 | 0.291 | **0.276** | — | 16 | **1.27×** |
+| B=1 H_q=32 H_kv=8 | 4 | 8 | 1 024 | 2.131 | 1.207 | 0.744 | 0.498 | **0.396** | — | 16 | **1.88×** |
+| B=1 H_q=32 H_kv=8 | 4 | 8 | 4 096 | 8.841 | 4.455 | 2.398 | 1.356 | **0.928** | — | 16 | **2.59×** |
+| B=1 H_q=32 H_kv=8 | 4 | 8 | 16 384 | 33.308 | 17.154 | 8.735 | 4.670 | **2.944** | — | 16 | **2.97×** |
+| B=1 H_q=28 H_kv=4 | 7 | 4 | 256 | 0.826 | 0.552 | 0.541 | 0.300 | **0.285** | — | 16 | **1.90×** |
+| B=1 H_q=28 H_kv=4 | 7 | 4 | 1 024 | 3.009 | 1.509 | 0.968 | 0.598 | **0.473** | — | 16 | **2.05×** |
+| B=1 H_q=28 H_kv=4 | 7 | 4 | 4 096 | 10.558 | 5.227 | 2.843 | 1.587 | **1.225** | — | 16 | **2.32×** |
+| B=1 H_q=28 H_kv=4 | 7 | 4 | 16 384 | 41.734 | 20.986 | 11.010 | 6.105 | **4.166** | — | 16 | **2.64×** |
+| B=1 H_q=32 H_kv=4 | 8 | 4 | 256 | 0.901 | 0.547 | 0.392 | **0.320** | — | — | 8 | **1.22×** |
+| B=1 H_q=32 H_kv=4 | 8 | 4 | 1 024 | 2.850 | 1.560 | 0.928 | **0.599** | — | — | 8 | **1.55×** |
+| B=1 H_q=32 H_kv=4 | 8 | 4 | 4 096 | 11.281 | 5.822 | 3.005 | **1.734** | — | — | 8 | **1.73×** |
+| B=1 H_q=32 H_kv=4 | 8 | 4 | 16 384 | 44.768 | 22.586 | 11.531 | **6.267** | — | — | 8 | **1.84×** |
+| B=1 H_q=16 H_kv=16 | 1 | 16 | 256 | 0.611 | 0.443 | 0.362 | 0.327 | 0.317 | **0.314** | 32 | 1.15× |
+| B=1 H_q=16 H_kv=16 | 1 | 16 | 1 024 | 1.720 | 1.043 | 0.662 | 0.462 | 0.419 | **0.409** | 32 | **1.62×** |
+| B=1 H_q=16 H_kv=16 | 1 | 16 | 4 096 | 6.523 | 3.459 | 1.951 | 1.207 | 0.964 | **0.954** | 32 | **2.04×** |
+| B=1 H_q=16 H_kv=16 | 1 | 16 | 16 384 | 25.298 | 13.040 | 6.879 | 3.852 | **2.846** | 2.922 | 16 | **2.42×** |
+| B=4 H_q=32 H_kv=8 | 4 | 32 | 256 | 0.756 | 0.482 | 0.382 | **0.380** | 0.384 | — | 8 | 1.00× |
+| B=4 H_q=32 H_kv=8 | 4 | 32 | 1 024 | 2.371 | 1.357 | 1.002 | 0.921 | **0.916** | — | 16 | 1.09× |
+| B=4 H_q=32 H_kv=8 | 4 | 32 | 4 096 | 8.573 | 4.668 | 2.852 | **2.714** | 2.754 | — | 8 | 1.05× |
+| B=4 H_q=32 H_kv=8 | 4 | 32 | 16 384 | 33.704 | 17.973 | 10.778 | **10.357** | 10.589 | — | 8 | 1.04× |
+| B=8 H_q=32 H_kv=8 | 4 | 64 | 256 | 0.850 | 0.609 | 0.589 | **0.540** | 0.562 | — | 8 | 1.09× |
+| B=8 H_q=32 H_kv=8 | 4 | 64 | 1 024 | 2.533 | 1.551 | 1.436 | **1.237** | 1.339 | — | 8 | 1.16× |
+| B=8 H_q=32 H_kv=8 | 4 | 64 | 4 096 | 9.256 | 5.304 | 4.994 | **4.183** | 4.592 | — | 8 | 1.19× |
+| B=8 H_q=32 H_kv=8 | 4 | 64 | 16 384 | 36.929 | 20.575 | 19.446 | **16.305** | 18.024 | — | 8 | 1.19× |
+
+*(`—` = rejected by the threadgroup-memory budget at that `hpk`.)*
+
+### 4.2 Reading the sweep
+
+Three patterns, all consistent with the occupancy diagnosis:
+
+1. **The win is largest where `n_tg` is smallest.** At `n_tg`=8 the gain
+   reaches 4.19×; at `n_tg`=64 it flattens to ~1.19×. This is the defining
+   signature of an occupancy-limited kernel — extra intra-threadgroup width only
+   pays while the dispatch is failing to fill the GPU.
+
+2. **The win grows with `S_kv`.** At `n_tg`=8, `hpk`=1: 1.83× at `S_kv`=256
+   rising to 4.19× at 16 384. Longer contexts give each SIMD-group more
+   independent KV slots to chew through, so added width converts into real
+   parallel work rather than idle lanes.
+
+3. **The optimum is "largest legal `nsg`" until saturation.** `hpk`=1 shapes
+   want 32; `hpk`=4 want 16; `hpk`=8 want 8 — in each case the budget ceiling.
+   Past `n_tg ≥ 32` the optimum settles at 8 and larger values slightly regress
+   (B=8, `S_kv`=16 384: 16.305 ms at `nsg`=8 vs 18.024 ms at `nsg`=16).
+
+This directly produced the `_auto_nsg` policy, with the `n_tg ≥ 32` saturation
+threshold read off rows 21–28 rather than chosen.
+
+### 4.3 Achieved bandwidth
+
+Best-`nsg` bandwidth utilization, B=1, D=128 (peak 93.6 GB/s that run):
+
+| shape | `S_kv` | `nsg=4` % peak | best-`nsg` % peak |
+|---|---:|---:|---:|
+| H_q=8 H_kv=8 (`hpk`=1) | 16 384 | 6.4% | **27.4%** |
+| H_q=8 H_kv=8 (`hpk`=1) | 4 096 | 5.8% | **18.7%** |
+| H_q=32 H_kv=8 (`hpk`=4) | 16 384 | 4.6% | **9.6%** |
+
+Utilization improves 2–4×, but even the best case reaches only ~27% of peak.
+**The kernel remains occupancy-limited, not bandwidth-limited** — this change
+reduces the severity of the constraint without removing it. Any claim that this
+kernel is now "near the roofline" would be false.
+
+---
+
+## 5. Real-model end-to-end results
+
+Kernel microbenchmarks are necessary but not sufficient — a kernel can win in
+isolation and lose in real inference. These numbers are **real
+`mlx_lm` generation**: full forward passes including embeddings, MLPs, QKV/O
+projections, sampling, and per-step quantization.
+
+### 5.1 Setup
+
+| | |
+|---|---|
+| Model | `mlx-community/Qwen3-4B-4bit` |
+| Layers | 36 |
+| Heads | `H_q`=32, `H_kv`=8 (GQA ratio 4), `D`=128 |
+| KV quantization | KIVI-style group-affine, `group_size`=32 |
+| Harness | `benchmark_scripts/benchmark_real_model_scalar_attend.py` |
+| Decode steps | 20 (context sweep) / 30 (batch sweep) |
+
+**All arms attend over the identical KIVI-quantized state.** The only
+difference is the attend path:
+
+- **dequant** — dequantize to fp16, then standard MLX SDPA. This is what a real
+  KIVI-style cache does today.
+- **fused `nsg=4`** — `scalar_fused_decode_attend` at the previously shipped
+  default.
+- **fused auto** — `scalar_fused_decode_attend` with `nsg=None` (this work).
+
+### 5.2 Context-length sweep (B=1, single-request decode)
+
+Decode throughput, tokens/sec:
+
+| `prompt_len` | dequant | fused `nsg=4` | **fused auto** | auto vs `nsg=4` | auto vs dequant |
+|---:|---:|---:|---:|---:|---:|
+| 256 | 17.4 | 24.0 | **25.7** | 1.07× | 1.48× |
+| 1 024 | 8.1 | 16.7 | **22.8** | **1.37×** | **2.82×** |
+| 2 048 | 4.8 | 12.4 | **18.7** | **1.51×** | **3.93×** |
+| 4 096 | 2.6 | 7.4 | **13.6** | **1.85×** | **5.31×** |
+
+The end-to-end win **grows with context**, mirroring the kernel sweep — 1.07×
+at short context rising to 1.85× at `prompt_len`=4096 over the previously
+shipped default, and 5.31× over the dequantize-then-SDPA path.
+
+> ### ⚠️ The short-context number is reported deliberately
+>
+> The first real-model run measured only **1.01–1.08×** and looked like a null
+> result. The cause was methodological, not physical: the stock harness
+> hardcodes `prompt_len=256`, which holds `S_kv` at ~256–288 — the **shortest**
+> point in the sweep and the one with the least headroom (kernel-level gain
+> there is just 1.22–1.27×). Additionally at B≥4 the threadgroup count already
+> saturates the GPU.
+>
+> The 1.07× figure is kept in this table rather than dropped, because it is
+> what anyone re-running the stock harness will see. **Anyone benchmarking this
+> kernel must sweep `prompt_len`; a single short-context reading understates
+> the effect by roughly 1.7×.**
+
+### 5.3 Batch sweep (`prompt_len`=256, 30 decode steps)
+
+| B | dequant tok/s | fused `nsg=4` | fused auto | auto vs `nsg=4` | auto vs dequant |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 17.8 | 23.9 | 25.9 | 1.08× | 1.45× |
+| 4 | 25.2 | 49.3 | 49.7 | 1.01× | 1.97× |
+| 8 | 25.9 | 52.0 | 52.4 | 1.01× | 2.03× |
+
+At short context with B≥4 the autotune adds essentially nothing (1.01×) — the
+dispatch already fills the GPU, exactly as §4.2's saturation pattern predicts.
+The fused kernel's advantage over the dequant baseline (1.45–2.03×) persists,
+but that advantage predates this work.
+
+**Honest summary of where this optimization does and does not help:**
+
+| regime | benefit |
+|---|---|
+| Long context, single request | **Large** (up to 1.85× end-to-end) |
+| Short context, single request | Small (~1.07×) |
+| Short context, batched (B≥4) | **None** (~1.01×) |
+
+---
+
+## 6. Memory
+
+This work is a **scheduling** change: same bytes moved, same FLOPs, same
+quantized representation. **It does not change memory footprint.** The KV cache
+figures below are the pre-existing property of the group-affine quantized cache
+this kernel reads, included for completeness.
+
+Qwen3-4B (36 layers, `H_kv`=8, `D`=128, `group_size`=32), K+V:
+
+| context | fp16 KV | quantized KV (codes + scale/zero) | reduction |
+|---:|---:|---:|---:|
+| 256 | 37.7 MB | 23.6 MB | 1.60× |
+| 1 024 | 151.0 MB | 94.4 MB | 1.60× |
+| 2 048 | 302.0 MB | 188.7 MB | 1.60× |
+| 4 096 | 604.0 MB | 377.5 MB | 1.60× |
+| 16 384 | 2 415.9 MB | 1 509.9 MB | 1.60× |
+
+The 1.60× (not 2×) reflects fp32 scale/zero metadata amortized over
+`group_size`=32. Threadgroup memory per threadgroup dropped 4× at `D`=128
+(the enabling change of §3), but that is on-chip scratch, not DRAM.
+
+---
+
+## 7. Correctness
+
+Performance that breaks numerics is rejected. Every change here is gated on
+parity against an independent numpy reference implementation.
+
+| check | result |
+|---|---|
+| `test_scalar_attend.py` | **194 passed** |
+| Full Metal suite | **939 passed**, 114 skipped |
+| Full repository suite | **3352 passed**, 118 skipped |
+| Lint (`ruff`) | 49 findings before **and** after — none introduced |
+
+Specific guarantees verified:
+
+- **Numpy-reference parity** across `S_kv ∈ {64, 512, 2048}`, `(H_q,H_kv)` ∈
+  {(8,2), (32,4), (32,8)}, and every legal `nsg` — max abs error < 2e-3.
+- **Expanded GQA coverage**: 40 additional parity cases at the newly-admissible
+  `nsg=8`, which previously could not be tested because the budget rejected
+  them.
+- **Bit-identical single-layer ↔ batched parity restored.** The `half` `sh_o`
+  change initially broke this (the batched kernel had not yet been updated);
+  applying the identical change to `scalar_affine_attend_batched.metal` restored
+  exact equality for `NL ∈ {1, 4, 32}`.
+- **`half` `sh_o` precision cost**: max deviation **2.4e-4**, against a 2e-3
+  tolerance — a 8× margin. Accepted because the `nsg=16` it unlocks is worth
+  1.65–2.41× on GQA shapes (measured separately before committing to the
+  tradeoff).
+- **Three new invariant tests** on `_auto_nsg` (110 parametrized cases):
+  1. never exceeds the threadgroup-memory budget, across
+     `D ∈ {64,128,256}` × `hpk ∈ {1,2,4,7,8,16}` × `n_tg ∈ {1,4,8,31,32,128}`;
+  2. always widens when under-dispatched relative to saturated;
+  3. `nsg=None` is **bit-identical** to pinning the value it selects — the
+     autotuner changes scheduling only, never results.
+
+---
+
+## 8. Reproduction
+
+```bash
+# Correctness (194 tests, includes the GQA + autotuner invariants)
+pytest veloxquant_mlx/tests/metal/test_scalar_attend.py -v
+
+# Autotuner invariants only
+pytest veloxquant_mlx/tests/metal/test_scalar_attend.py -v -k auto_nsg
+
+# Kernel roofline / occupancy baseline
+python scripts/kv_kernel_roofline_bench.py
+
+# Real-model end-to-end (must run as a module — see note below)
+python -m benchmark_scripts.benchmark_real_model_scalar_attend
+```
+
+The real-model script **must** be run as a module. Running it by path puts the
+script's directory at `sys.path[0]` ahead of the repo root, which can resolve
+`veloxquant_mlx` to a stale installed copy in site-packages.
+
+To reproduce §5.2's context sweep, vary `prompt_len` — the script's default of
+256 sits at the minimum of the headroom curve (see the warning in §5.2).
+
+Re-run each benchmark 2–3× and compare: this machine shows real run-to-run
+variance from thermal and scheduling effects.
+
+---
+
+## 9. Limitations
+
+Stated plainly, because a benchmark report that hides its caveats is not
+useful.
+
+- **One machine, one GPU tier.** Base 10-core M4. The `n_tg ≥ 32` saturation
+  threshold in `_auto_nsg` is core-count-dependent; a higher-tier Apple GPU
+  would saturate later and likely want higher `nsg` across more shapes. The
+  policy would need re-fitting there.
+- **One model family end-to-end.** Qwen3-4B-4bit only. A model with different
+  `D`, GQA ratio, or bit-width could show a different margin. `D=128` in
+  particular is what makes the `DSLOTS_C` win a clean 2×; `D=256` models gain
+  less.
+- **Static heuristic, not a runtime search.** `_auto_nsg` is fit to §4.1's
+  table. Shapes far outside it (`heads_per_kv > 8`, very large `D`) fall back
+  to conservative values that were not separately optimized.
+- **No GPU-level profiling.** The occupancy story is inferred from black-box
+  wall-clock latency and dispatch-shape reasoning, not from Metal System Trace
+  counters or hardware occupancy metrics. This is the same limitation
+  `KV_KERNEL_ROOFLINE_FINDINGS.md` flags for its own analysis.
+- **Benchmark-harness cache is not production KIVI.** The real-model harness's
+  `_ScalarAttendKIVICache` has no fp16 residual window, so its *output quality*
+  is not representative of production KIVI. This does not affect the timing
+  comparison (both arms decode from identical quantized state and were verified
+  to produce identical tokens), but the throughput numbers should be read as
+  "the fused kernel is Nx faster for the *same* quantized state," not "KIVI is
+  Nx faster in production."
+- **Prefill untouched.** This kernel is decode-only (`S_q`=1). TTFT is
+  unaffected in all measurements, as expected.
+
+---
+
+## 10. What was *not* pursued, and why
+
+`docs/KV_KERNEL_ROOFLINE_FINDINGS.md` already measured several optimization
+directions as losses. They were not re-run:
+
+| direction | prior measured outcome |
+|---|---|
+| GQA head-packing | **2.7–4.7× slower** — trades away threadgroup count, the binding constraint |
+| SIMD-shuffle cross-head sharing | Architecturally impossible — `simd_shuffle` is intra-SIMD-group only |
+| Two-pass decode-once + predecoded-attend | Crossover at `S_kv`≈2048–3072; **0.80×** at long context |
+| Cross-layer batched dispatch | Real 1.0–4.5× kernel win, but a **structural dead end** for single-request decode: layer L+1's attention depends on layer L's *full* block output (attention + residual + MLP), so layers cannot be grouped without changing what the model computes |
+
+Additionally, `kivi_group_quant_dequant` was previously measured at ~102% of
+calibrated peak bandwidth — genuinely memory-bound, with no headroom for kernel
+tuning to capture.
+
+**The most promising untouched direction is a prefill-specialized path**
+(`S_q > 1`), a genuinely different regime — large query tiles, high reuse,
+matmul-shaped — that neither this work nor any prior addendum has addressed.

--- a/veloxquant_mlx/metal/_scalar_attend.py
+++ b/veloxquant_mlx/metal/_scalar_attend.py
@@ -99,6 +99,31 @@ third addendum for the measured result — this is reported with the same
 rigor as the GQA head-packing (#307 pt. 2) and SIMD-shuffle (#308)
 addenda, including if the outcome is null or negative.
 
+Intra-threadgroup width (``nsg``) autotuning
+---------------------------------------------
+The experiments above all varied threadgroup *count* while holding ``nsg``
+(SIMD-groups per threadgroup) at a fixed default of 4. That default was
+substantially wrong: total concurrency is roughly ``n_tg * nsg``, and at a
+real single-request decode step ``n_tg = B*H_kv*S_q`` is only 4-8
+threadgroups on a 10-core GPU. Unlike head-packing, raising ``nsg`` costs no
+threadgroup count — it adds width *inside* each threadgroup — so it composes
+with the dispatch lever instead of competing with it.
+
+Raising it required two footprint fixes first, since the 32KB threadgroup
+budget (not diminishing returns) was the binding limit: ``DSLOTS_C =
+ceil(D/32)`` is now baked in per-``D`` instead of assuming the ``D<=256``
+worst case of 8 slots, and ``sh_o`` is stored as ``half`` (partials are
+pre-divided by their own ``running_d`` so they stay bounded, and the merge
+re-applies it — algebraically identical). Together these cut the merge
+buffer 4x at ``D=128``.
+
+:func:`scalar_fused_decode_attend` now defaults to ``nsg=None``, which calls
+:func:`_auto_nsg` to pick from the dispatch shape. Measured 1.2-4.2x faster
+than the old fixed default at under-dispatched decode shapes, and 1.07-1.85x
+real end-to-end on Qwen3-4B-4bit depending on context length (the win grows
+with ``S_kv``). See ``docs/KV_KERNEL_ROOFLINE_FINDINGS.md``'s ``nsg`` addendum
+for the full sweep, the end-to-end table, and limitations.
+
 Public API:
   - :func:`scalar_fused_decode_attend`
   - :func:`scalar_fused_decode_attend_batched`
@@ -160,6 +185,18 @@ _SCALAR_PREDECODED_ATTEND_SRC = _read_kernel_source("scalar_predecoded_attend.me
 # ---------------------------------------------------------------------------
 
 
+def _d_slots(D: int) -> int:
+    """ceil(D/32) — the number of output dims each lane owns.
+
+    Baked into the kernel as ``DSLOTS_C`` so ``my_out``/``sh_o`` are sized to
+    the actual head dim instead of the ``D <= 256`` worst case of 8. At the
+    near-universal D=128 that halves both per-lane registers and threadgroup
+    memory, which is what lets ``nsg`` (the only occupancy lever that doesn't
+    cost threadgroup count) go higher on GQA shapes.
+    """
+    return (D + 31) // 32
+
+
 def _scalar_affine_attend_kernel(D: int, nsg: int, heads_per_kv: int):
     key = ("scalar_affine_attend", D, nsg, heads_per_kv)
     if key not in _cache:
@@ -177,7 +214,11 @@ def _scalar_affine_attend_kernel(D: int, nsg: int, heads_per_kv: int):
                 "scale_arr",
             ],
             output_names=["out"],
-            header=f"#define NSG_C {nsg}\n#define HEADS_PER_KV_C {heads_per_kv}\n",
+            header=(
+                f"#define NSG_C {nsg}\n"
+                f"#define HEADS_PER_KV_C {heads_per_kv}\n"
+                f"#define DSLOTS_C {_d_slots(D)}\n"
+            ),
             source=_SCALAR_AFFINE_ATTEND_SRC,
             ensure_row_contiguous=True,
         )
@@ -201,7 +242,11 @@ def _scalar_affine_attend_batched_kernel(D: int, nsg: int, heads_per_kv: int):
                 "scale_arr",
             ],
             output_names=["out"],
-            header=f"#define NSG_C {nsg}\n#define HEADS_PER_KV_C {heads_per_kv}\n",
+            header=(
+                f"#define NSG_C {nsg}\n"
+                f"#define HEADS_PER_KV_C {heads_per_kv}\n"
+                f"#define DSLOTS_C {_d_slots(D)}\n"
+            ),
             source=_SCALAR_AFFINE_ATTEND_BATCHED_SRC,
             ensure_row_contiguous=True,
         )
@@ -246,6 +291,42 @@ _TG_MEM_BUDGET_BYTES = 32768
 # register-array sizes (running_m/running_d/my_out) against pathological inputs.
 _MAX_HEADS_PER_KV = 16
 
+# Threadgroup count at or above which the GPU is already well fed by dispatch
+# alone, so widening threadgroups further stops paying. Derived from the nsg
+# sweep in docs/KV_KERNEL_ROOFLINE_FINDINGS.md ("nsg autotuning" addendum):
+# at B*H_kv*S_q >= 32 the best-nsg advantage over the old nsg=4 default
+# collapses to 1.00-1.19x, while below it the same sweep measures 1.2-4.2x.
+# Tuned on a 10-core M4; a larger GPU would saturate at a higher count.
+_TG_SATURATION = 32
+
+
+def _auto_nsg(D: int, heads_per_kv: int, n_tg: int) -> int:
+    """Pick SIMD-groups-per-threadgroup from the dispatch shape.
+
+    Total GPU concurrency is roughly ``n_tg * nsg``. When ``n_tg`` alone is
+    small — the single-request decode case this kernel exists for, where
+    ``B*H_kv*S_q`` is often just 4-8 threadgroups on a 10-core GPU — the only
+    way to add concurrency without giving up threadgroup count (which
+    docs/KV_KERNEL_ROOFLINE_FINDINGS.md measured as the dominant lever, and
+    which GQA head-packing lost 2.7-4.7x by trading away) is to widen each
+    threadgroup. So: take the largest nsg the threadgroup-memory budget
+    admits when under-dispatched, and back off to a modest value once
+    dispatch alone already saturates the machine.
+    """
+    saturated = n_tg >= _TG_SATURATION
+    best = 4
+    for nsg in (1, 2, 4, 8, 16, 32):
+        n_slots = nsg * heads_per_kv
+        tg_mem = n_slots * _d_slots(D) * 32 * 2 + n_slots * 4 * 2
+        if tg_mem > _TG_MEM_BUDGET_BYTES:
+            break
+        # Past saturation the sweep shows a flat-to-slightly-better optimum at
+        # 8; below it, more width is monotonically better up to the budget.
+        if saturated and nsg > 8:
+            break
+        best = nsg
+    return best
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -262,7 +343,7 @@ def scalar_fused_decode_attend(
     v_zero: mx.array,
     group_size: int,
     scale: float,
-    nsg: int = 4,
+    nsg: int | None = None,
 ) -> mx.array:
     """Fused group-affine (KIVI-style) key/value decode + SDP attention.
 
@@ -287,7 +368,12 @@ def scalar_fused_decode_attend(
         v_zero:   ``[B, H_kv, S_kv, GV]`` fp32.
         group_size: quantization group size g.
         scale:    attention scale applied to the raw dot (e.g. 1/sqrt(D)).
-        nsg:      SIMD-groups per threadgroup splitting the kv axis.
+        nsg:      SIMD-groups per threadgroup splitting the kv axis. ``None``
+            (default) autotunes it from the dispatch shape via
+            :func:`_auto_nsg` — measured 1.2-4.2x faster than the previous
+            fixed default of 4 at under-dispatched decode shapes. Pass an
+            explicit int to pin it (benchmarking, or a shape the heuristic
+            does not suit).
 
     Returns:
         ``[B, H_q, S_q, D]`` fp16 attention output.
@@ -302,7 +388,7 @@ def scalar_fused_decode_attend(
     B, H, S_q, D = q.shape
     if D > 256:
         raise ValueError(f"scalar_fused_decode_attend: D={D} must be <= 256")
-    if not (1 <= nsg <= 32):
+    if nsg is not None and not (1 <= nsg <= 32):
         raise ValueError(f"scalar_fused_decode_attend: nsg={nsg} must be in 1..32")
 
     Bk, H_kv, _, Dk = k_codes.shape
@@ -328,19 +414,27 @@ def scalar_fused_decode_attend(
             f"scalar_fused_decode_attend: heads_per_kv={heads_per_kv} exceeds "
             f"the supported maximum of {_MAX_HEADS_PER_KV}"
         )
-    # sh_o[NSG_C*HEADS_PER_KV_C*8*32] + sh_m[NSG_C*HEADS_PER_KV_C] + sh_d[NSG_C*HEADS_PER_KV_C],
-    # all float32 — must match scalar_affine_attend.metal's threadgroup array declarations.
+    n_tg = B * H_kv * S_q
+    if nsg is None:
+        nsg = _auto_nsg(D, heads_per_kv, n_tg)
+
+    # Must match scalar_affine_attend.metal's threadgroup array declarations:
+    #   sh_o[NSG_C*HEADS_PER_KV_C*DSLOTS_C*32]  half   (2B)
+    #   sh_m[NSG_C*HEADS_PER_KV_C]              float  (4B)
+    #   sh_d[NSG_C*HEADS_PER_KV_C]              float  (4B)
+    # DSLOTS_C = ceil(D/32) rather than a hardcoded 8, and sh_o is half rather
+    # than float — together these cut the merge buffer 4x at D=128, which is
+    # what admits the higher nsg values that dominate decode performance.
     n_slots = nsg * heads_per_kv
-    tg_mem_bytes = (n_slots * 8 * 32 + n_slots + n_slots) * 4
+    tg_mem_bytes = n_slots * _d_slots(D) * 32 * 2 + n_slots * 4 * 2
     if tg_mem_bytes > _TG_MEM_BUDGET_BYTES:
         raise ValueError(
             f"scalar_fused_decode_attend: nsg={nsg} * heads_per_kv={heads_per_kv} "
-            f"exceeds the {_TG_MEM_BUDGET_BYTES}B threadgroup-memory budget for "
-            f"the softmax merge buffers ({tg_mem_bytes}B); reduce nsg or use a "
-            f"smaller H_q/H_kv ratio"
+            f"at D={D} exceeds the {_TG_MEM_BUDGET_BYTES}B threadgroup-memory "
+            f"budget for the softmax merge buffers ({tg_mem_bytes}B); reduce nsg "
+            f"or use a smaller H_q/H_kv ratio"
         )
 
-    n_tg = B * H_kv * S_q
     gsize = mx.array([group_size], dtype=mx.uint32)
     scale_arr = mx.array([scale], dtype=mx.float32)
 
@@ -476,7 +570,7 @@ def scalar_fused_decode_attend_batched(
     # not inside one threadgroup's state, so the same budget check applies
     # unchanged (see scalar_fused_decode_attend's identical check).
     n_slots = nsg * heads_per_kv
-    tg_mem_bytes = (n_slots * 8 * 32 + n_slots + n_slots) * 4
+    tg_mem_bytes = n_slots * _d_slots(D) * 32 * 2 + n_slots * 4 * 2
     if tg_mem_bytes > _TG_MEM_BUDGET_BYTES:
         raise ValueError(
             f"scalar_fused_decode_attend_batched: nsg={nsg} * heads_per_kv={heads_per_kv} "

--- a/veloxquant_mlx/metal/src/scalar_affine_attend.metal
+++ b/veloxquant_mlx/metal/src/scalar_affine_attend.metal
@@ -34,13 +34,22 @@
     uint bh_kv = b_idx * H_kv + hkv_idx;    // indexes k/v arrays (H_kv-wide)
 
     // ----- per-lane online-softmax state for this SIMD-group, per packed head -----
+    // DSLOTS_C is ceil(D/32) baked in at compile time by the kernel factory
+    // (which already keys its cache on D). Sizing my_out/sh_o to the ACTUAL
+    // head dim rather than the D<=256 worst case of 8 halves both per-lane
+    // register footprint and threadgroup-memory footprint at the near-universal
+    // D=128 — register pressure and the 32KB threadgroup budget are the two
+    // limiters on how many SIMD-groups (nsg) can be packed per threadgroup,
+    // and nsg is the only occupancy lever that does not cost threadgroup count
+    // (see docs/KV_KERNEL_ROOFLINE_FINDINGS.md on why head-packing does).
+    constexpr uint kDSlots = DSLOTS_C;
     float running_m[HEADS_PER_KV_C];
     float running_d[HEADS_PER_KV_C];
-    float my_out[HEADS_PER_KV_C][8];        // D/32 <= 256/32 = 8
+    float my_out[HEADS_PER_KV_C][kDSlots];
     for (uint hp = 0; hp < HPK; ++hp) {
         running_m[hp] = -INFINITY;
         running_d[hp] = 0.0f;
-        for (int i = 0; i < 8; ++i) my_out[hp][i] = 0.0f;
+        for (uint i = 0; i < kDSlots; ++i) my_out[hp][i] = 0.0f;
     }
     uint n_owned = (D + 31u) / 32u;
 
@@ -97,15 +106,37 @@
     }
 
     // ----- merge the NSG partial softmaxes through threadgroup memory -----
-    // sh_o layout: [NSG_C][HEADS_PER_KV_C][8][32]  (SIMD-group, packed head, owned-slot, lane).
+    // sh_o layout: [NSG_C][HEADS_PER_KV_C][DSLOTS_C][32]  (SIMD-group, packed
+    // head, owned-slot, lane).
+    //
+    // sh_o is `half`, not float: these are partial weighted V-sums that are
+    // about to be rescaled, summed across SIMD-groups, divided by the global
+    // denominator and written out as `half` anyway, so fp32 here buys no
+    // precision that survives to the output. Halving this buffer is what lets
+    // nsg reach 16 on GQA shapes within the 32KB threadgroup budget — and nsg
+    // is the dominant occupancy lever at decode shapes (measured 1.4-4.2x).
+    //
+    // sh_m (running max) and sh_d (softmax denominator) stay fp32 deliberately:
+    // they feed exp() rescaling where fp16's ~3-decimal-digit mantissa and
+    // narrow exponent range would degrade the online-softmax correction.
     threadgroup float sh_m[NSG_C * HEADS_PER_KV_C];
     threadgroup float sh_d[NSG_C * HEADS_PER_KV_C];
-    threadgroup float sh_o[NSG_C * HEADS_PER_KV_C * 8 * 32];
+    threadgroup half  sh_o[NSG_C * HEADS_PER_KV_C * DSLOTS_C * 32];
 
-    // stash this SIMD-group's per-lane partials, per packed head
+    // Stash this SIMD-group's per-lane partials, per packed head.
+    //
+    // Each partial is divided by its OWN running_d before the half store, so
+    // what lands in sh_o is a convex combination of decoded V values — bounded
+    // by max|V| regardless of S_kv, instead of an unnormalized sum that grows
+    // with the number of kv slots this SIMD-group visited and could overflow
+    // half's ~65504 ceiling at long context. The merge below re-applies each
+    // group's weight (sh_d * exp(sh_m - gm)) explicitly, so this is an exact
+    // rebalancing of the same arithmetic, not an approximation.
     for (uint hp = 0; hp < HPK; ++hp) {
+        float inv_local = running_d[hp] > 0.0f ? 1.0f / running_d[hp] : 0.0f;
         for (uint i = 0; i < n_owned; ++i) {
-            sh_o[((sg * HPK + hp) * 8u + i) * 32u + lane] = my_out[hp][i];
+            sh_o[((sg * HPK + hp) * kDSlots + i) * 32u + lane] =
+                half(my_out[hp][i] * inv_local);
         }
         if (lane == 0) {
             sh_m[sg * HPK + hp] = running_m[hp];
@@ -126,7 +157,12 @@
             for (uint i = 0; i < n_owned; ++i) {
                 float acc = 0.0f;
                 for (uint s = 0; s < NSG; ++s) {
-                    acc += sh_o[((s * HPK + hp) * 8 + i) * 32 + lane]
+                    // sh_o holds out_s / d_s, so the full weight for group s is
+                    // d_s * exp(m_s - gm) — the same factor accumulated into gd
+                    // above, keeping acc/gd algebraically identical to the
+                    // previous unnormalized formulation.
+                    acc += float(sh_o[((s * HPK + hp) * kDSlots + i) * 32 + lane])
+                         * sh_d[s * HPK + hp]
                          * metal::exp(sh_m[s * HPK + hp] - gm);
                 }
                 uint d = lane + i * 32u;

--- a/veloxquant_mlx/metal/src/scalar_affine_attend_batched.metal
+++ b/veloxquant_mlx/metal/src/scalar_affine_attend_batched.metal
@@ -47,11 +47,14 @@
     // ----- per-lane online-softmax state for this SIMD-group, per packed head -----
     float running_m[HEADS_PER_KV_C];
     float running_d[HEADS_PER_KV_C];
-    float my_out[HEADS_PER_KV_C][8];        // D/32 <= 256/32 = 8
+    // DSLOTS_C = ceil(D/32), baked in by the kernel factory — see the
+    // single-layer scalar_affine_attend.metal for the full rationale.
+    constexpr uint kDSlots = DSLOTS_C;
+    float my_out[HEADS_PER_KV_C][kDSlots];
     for (uint hp = 0; hp < HPK; ++hp) {
         running_m[hp] = -INFINITY;
         running_d[hp] = 0.0f;
-        for (int i = 0; i < 8; ++i) my_out[hp][i] = 0.0f;
+        for (uint i = 0; i < kDSlots; ++i) my_out[hp][i] = 0.0f;
     }
     uint n_owned = (D + 31u) / 32u;
 
@@ -108,15 +111,21 @@
     }
 
     // ----- merge the NSG partial softmaxes through threadgroup memory -----
-    // sh_o layout: [NSG_C][HEADS_PER_KV_C][8][32]  (SIMD-group, packed head, owned-slot, lane).
+    // sh_o layout: [NSG_C][HEADS_PER_KV_C][DSLOTS_C][32]  (SIMD-group, packed
+    // head, owned-slot, lane). `half` for the same reason as the single-layer
+    // kernel: these partials are rescaled and emitted as half regardless, and
+    // the 2x saving raises the admissible nsg. sh_m/sh_d stay fp32 (exp()
+    // rescaling needs the range/mantissa).
     threadgroup float sh_m[NSG_C * HEADS_PER_KV_C];
     threadgroup float sh_d[NSG_C * HEADS_PER_KV_C];
-    threadgroup float sh_o[NSG_C * HEADS_PER_KV_C * 8 * 32];
+    threadgroup half  sh_o[NSG_C * HEADS_PER_KV_C * DSLOTS_C * 32];
 
     // stash this SIMD-group's per-lane partials, per packed head
     for (uint hp = 0; hp < HPK; ++hp) {
+        float inv_local = running_d[hp] > 0.0f ? 1.0f / running_d[hp] : 0.0f;
         for (uint i = 0; i < n_owned; ++i) {
-            sh_o[((sg * HPK + hp) * 8u + i) * 32u + lane] = my_out[hp][i];
+            sh_o[((sg * HPK + hp) * kDSlots + i) * 32u + lane] =
+                half(my_out[hp][i] * inv_local);
         }
         if (lane == 0) {
             sh_m[sg * HPK + hp] = running_m[hp];
@@ -137,7 +146,10 @@
             for (uint i = 0; i < n_owned; ++i) {
                 float acc = 0.0f;
                 for (uint s = 0; s < NSG; ++s) {
-                    acc += sh_o[((s * HPK + hp) * 8 + i) * 32 + lane]
+                    // sh_o holds out_s / d_s — re-apply d_s so acc/gd is
+                    // algebraically identical to the unnormalized form.
+                    acc += float(sh_o[((s * HPK + hp) * kDSlots + i) * 32 + lane])
+                         * sh_d[s * HPK + hp]
                          * metal::exp(sh_m[s * HPK + hp] - gm);
                 }
                 uint d = lane + i * 32u;

--- a/veloxquant_mlx/tests/metal/test_scalar_attend.py
+++ b/veloxquant_mlx/tests/metal/test_scalar_attend.py
@@ -23,6 +23,9 @@ import pytest
 
 from veloxquant_mlx.metal import metal_available
 from veloxquant_mlx.metal._scalar_attend import (
+    _TG_MEM_BUDGET_BYTES,
+    _auto_nsg,
+    _d_slots,
     scalar_decode_once,
     scalar_predecoded_attend,
 )
@@ -184,18 +187,21 @@ def test_scalar_attend_bitwidths(b):
 # ---------------------------------------------------------------------------
 
 
-def _tg_mem_bytes(nsg, heads_per_kv):
-    # Mirrors _scalar_attend.py's own budget check: sh_o + sh_m + sh_d, all fp32.
+def _tg_mem_bytes(nsg, heads_per_kv, D=128):
+    # Mirrors _scalar_attend.py's own budget check: sh_o (half) + sh_m, sh_d
+    # (both fp32). sh_o is sized by DSLOTS_C = ceil(D/32), not a fixed 8 — so
+    # the admissible nsg depends on the head dim.
     n_slots = nsg * heads_per_kv
-    return (n_slots * 8 * 32 + n_slots + n_slots) * 4
+    d_slots = (D + 31) // 32
+    return n_slots * d_slots * 32 * 2 + n_slots * 4 * 2
 
 
 _GQA_CASES = [
     (H_q, H_kv, S_kv, nsg)
     for H_q, H_kv in [(8, 2), (32, 4), (32, 8)]
     for S_kv in [64, 512, 2048]
-    for nsg in [1, 2, 4]
-    if _tg_mem_bytes(nsg, H_q // H_kv) <= 32768
+    for nsg in [1, 2, 4, 8]
+    if _tg_mem_bytes(nsg, H_q // H_kv, 128) <= 32768
 ]
 
 
@@ -302,20 +308,22 @@ def test_scalar_attend_validation():
             0.1,
             nsg=1,
         )
-    # threadgroup-memory budget overflow (nsg * heads_per_kv within the
-    # heads_per_kv cap but still too large for the softmax merge buffers)
-    with pytest.raises(ValueError):
+    # threadgroup-memory budget overflow. The budget scales with
+    # DSLOTS_C = ceil(D/32) and sh_o is half, so overflow now requires a
+    # genuinely large combination: D=256 (8 slots) x heads_per_kv=8 x nsg=8
+    # -> 33280B. At D=128 these same nsg/heads_per_kv legitimately fit.
+    with pytest.raises(ValueError, match="threadgroup-memory budget"):
         scalar_fused_decode_attend(
-            mx.zeros((1, 32, 1, 128), dtype=mx.float16),  # H_q=32
-            mx.zeros((1, 4, 8, 128), dtype=mx.uint8),  # H_kv=4 -> heads_per_kv=8
-            mx.zeros((1, 4, 1, 128), dtype=mx.float32),
-            mx.zeros((1, 4, 1, 128), dtype=mx.float32),
-            mx.zeros((1, 4, 8, 128), dtype=mx.uint8),
-            mx.zeros((1, 4, 8, 4), dtype=mx.float32),
-            mx.zeros((1, 4, 8, 4), dtype=mx.float32),
+            mx.zeros((1, 32, 1, 256), dtype=mx.float16),  # H_q=32, D=256
+            mx.zeros((1, 4, 8, 256), dtype=mx.uint8),  # H_kv=4 -> heads_per_kv=8
+            mx.zeros((1, 4, 1, 256), dtype=mx.float32),
+            mx.zeros((1, 4, 1, 256), dtype=mx.float32),
+            mx.zeros((1, 4, 8, 256), dtype=mx.uint8),
+            mx.zeros((1, 4, 8, 8), dtype=mx.float32),
+            mx.zeros((1, 4, 8, 8), dtype=mx.float32),
             32,
             0.1,
-            nsg=4,  # nsg=4 * heads_per_kv=8 -> 33024B > 32768B budget
+            nsg=8,  # nsg=8 * hpk=8 * 8 slots -> 33280B > 32768B budget
         )
 
 
@@ -857,6 +865,60 @@ def test_scalar_attend_batched_distinct_content_not_broadcast_layer0():
     assert np.abs(ref0 - ref1).max() > 1e-2
 
 
+@pytest.mark.parametrize("D", [64, 128, 256])
+@pytest.mark.parametrize("heads_per_kv", [1, 2, 4, 7, 8, 16])
+@pytest.mark.parametrize("n_tg", [1, 4, 8, 31, 32, 128])
+def test_auto_nsg_always_within_budget(D, heads_per_kv, n_tg):
+    """Whatever _auto_nsg picks must fit the threadgroup-memory budget.
+
+    This is the invariant that keeps the autotuned default from turning a
+    working call into a ValueError on some shape nobody benchmarked.
+    """
+    nsg = _auto_nsg(D, heads_per_kv, n_tg)
+    assert 1 <= nsg <= 32
+    n_slots = nsg * heads_per_kv
+    tg_mem = n_slots * _d_slots(D) * 32 * 2 + n_slots * 4 * 2
+    assert tg_mem <= _TG_MEM_BUDGET_BYTES, (
+        f"D={D} hpk={heads_per_kv} n_tg={n_tg}: _auto_nsg picked {nsg} "
+        f"needing {tg_mem}B > {_TG_MEM_BUDGET_BYTES}B"
+    )
+
+
+def test_auto_nsg_widens_when_under_dispatched():
+    """Under-dispatched shapes must get a wider threadgroup than saturated ones.
+
+    Encodes the measured policy: when B*H_kv*S_q is small the GPU can only be
+    filled by adding SIMD-groups within each threadgroup, so _auto_nsg should
+    pick strictly more than the saturated case for the same head geometry.
+    """
+    for D, hpk in ((128, 1), (128, 4)):
+        under = _auto_nsg(D, hpk, n_tg=8)
+        saturated = _auto_nsg(D, hpk, n_tg=128)
+        assert under > saturated, (
+            f"D={D} hpk={hpk}: expected wider nsg when under-dispatched, "
+            f"got under={under} saturated={saturated}"
+        )
+
+
+def test_auto_nsg_default_matches_explicit_nsg_output():
+    """nsg=None must produce the same numbers as pinning the value it picks.
+
+    Guards against the autotuner silently changing results rather than only
+    changing how the same math is scheduled.
+    """
+    B, H_q, H_kv, S_kv, D, b, g = 1, 32, 8, 512, 128, 2, 32
+    scale = 1.0 / math.sqrt(D)
+    q, kc, ks, kz, vc, vs, vz = _make_inputs(B, H_q, S_kv, D, b, g, H_kv=H_kv)
+    args = [mx.array(x) for x in (q, kc, ks, kz, vc, vs, vz)]
+
+    chosen = _auto_nsg(D, H_q // H_kv, B * H_kv * 1)
+    auto = np.array(scalar_fused_decode_attend(*args, g, scale, nsg=None))
+    pinned = np.array(scalar_fused_decode_attend(*args, g, scale, nsg=chosen))
+    assert np.array_equal(auto, pinned), (
+        f"nsg=None must be bit-identical to nsg={chosen}"
+    )
+
+
 def test_scalar_attend_batched_threadgroup_memory_budget_unaffected_by_nl():
     """The threadgroup-memory budget check must scale with nsg*heads_per_kv
     only, not with NL — batching lives on the grid axis, not inside one
@@ -864,7 +926,8 @@ def test_scalar_attend_batched_threadgroup_memory_budget_unaffected_by_nl():
     B, H_q, H_kv, S_kv, D, b, g = 1, 32, 4, 64, 128, 2, 32  # heads_per_kv=8
     scale = 1.0 / math.sqrt(D)
 
-    # nsg=4 * heads_per_kv=8 -> 33024B > 32768B budget: must fail regardless of NL.
+    # nsg=16 * heads_per_kv=8 at D=128 (4 slots, half sh_o) -> 33792B >
+    # 32768B budget: must fail regardless of NL.
     for NL in (1, 16):
         q, kc, ks, kz, vc, vs, vz = _make_layer_stack(
             NL, B, H_q, S_kv, D, b, g, seed=300, H_kv=H_kv
@@ -880,7 +943,7 @@ def test_scalar_attend_batched_threadgroup_memory_budget_unaffected_by_nl():
                 mx.array(vz),
                 g,
                 scale,
-                nsg=4,
+                nsg=16,
             )
 
     # nsg=2 * heads_per_kv=8 fits the budget: must pass for both a small and


### PR DESCRIPTION
`scalar_fused_decode_attend` shipped with a fixed `nsg=4` (SIMD-groups per threadgroup). Every prior occupancy experiment in this repo varied threadgroup *count* while holding `nsg` constant — head-packing traded count away (measured 2.7-4.7x slower), cross-layer and multi-request batching added to it. `nsg` was the one lever never tuned, and unlike head-packing it costs no threadgroup count: it adds width *inside* each threadgroup, so it composes with the dispatch lever instead of competing with it.

Total GPU concurrency is roughly `n_tg * nsg`. At a real single-request decode step `n_tg = B*H_kv*S_q` is only 4-8 threadgroups on a 10-core GPU, so the machine sits idle regardless of how efficiently one threadgroup streams.

Two footprint fixes were required first — the 32KB threadgroup-memory budget, not diminishing returns, was the binding limit on `nsg`:

1. DSLOTS_C specialization. `my_out`/`sh_o` were sized to 8 slots (the D<=256 worst case) even though the kernel is already compiled per-D — the factory keyed its cache on D but never passed it to the compiler. Injecting `DSLOTS_C = ceil(D/32)` halves both at the near-universal D=128.

2. `sh_o` stored as half. Those partials are rescaled, summed, divided by the global denominator and emitted as half regardless, so fp32 bought no precision that survived to the output. Each partial is now pre-divided by its own `running_d` (a convex combination of decoded V, bounded by max|V| rather than growing with S_kv, so half's ~65504 ceiling is not a long-context hazard) and the merge re-applies `d_s` — algebraically identical. sh_m/sh_d stay fp32: they feed exp() rescaling.

Together these cut the merge buffer 4x at D=128, raising admissible nsg from 8->16 at heads_per_kv=4 and 4->8 at heads_per_kv=8.

`nsg` now defaults to None, selecting via `_auto_nsg` from the dispatch shape: largest value the budget admits when under-dispatched, backing off to 8 once `n_tg >= 32`. The policy is read off the measured sweep, not hand-picked.

Kernel-level (M4, D=128, vs the old nsg=4 default):
  H_q=8  H_kv=8  n_tg=8  S_kv=16384  nsg=32  4.19x
  H_q=32 H_kv=8  n_tg=8  S_kv=16384  nsg=16  2.97x
  H_q=28 H_kv=4  n_tg=4  S_kv=16384  nsg=16  2.64x
  H_q=32 H_kv=8  n_tg=64 S_kv=16384  nsg=8   1.19x  (saturated)

Real-model end-to-end (Qwen3-4B-4bit, B=1, decode tok/s), context-dependent:
  prompt_len=256   24.0 -> 25.7  (1.07x)
  prompt_len=1024  16.7 -> 22.8  (1.37x)
  prompt_len=2048  12.4 -> 18.7  (1.51x)
  prompt_len=4096   7.4 -> 13.6  (1.85x)

The short-context figure is reported rather than dropped: the stock real-model harness uses prompt_len=256, which sits at the minimum of the headroom curve, so a single short-context reading understates the effect by ~1.7x.

The kernel remains occupancy-limited, not bandwidth-limited — best-case utilization improves from 6.4% to ~27% of calibrated peak. No claim is made that it is near the roofline.

Correctness: 194 passed in test_scalar_attend.py (40 new GQA parity cases at the newly-admissible nsg=8; bit-identical single-layer/batched parity restored after applying the same change to the batched kernel; 3 new invariant tests asserting _auto_nsg never exceeds the budget, always widens when under-dispatched, and is bit-identical to pinning the value it picks). Full suite: 3352 passed. Ruff: 49 findings before and after, none introduced.

Docs: full benchmark report in docs/NSG_AUTOTUNE_BENCHMARK_REPORT.md; condensed addendum in docs/KV_KERNEL_ROOFLINE_FINDINGS.md; docs-site API reference and Metal kernels guide updated for the new signature and tuning guidance.

## Summary

Brief description of what this PR changes and why.

## Related issue

Closes #

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
- [ ] New or updated unit tests cover the change
- [ ] Docs updated if user-facing behavior changed

## Number claims (if any)

Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.

- Script path:
- Results path:
- Metric type (check one):
  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
  - [ ] Full-KV accounting (keys + values + residual windows)
  - [ ] MLX peak memory (`mx.get_peak_memory`)
  - [ ] OS RSS / long-context OOM comparison
  - [ ] Throughput (tok/s)

Do not describe accounting ratios as resident RAM savings unless resident memory was measured.
