### PR TITLE
landing: replace Studio downloads with private-beta coming soon

### DIFF
--- a/landing/assets/main.js
+++ b/landing/assets/main.js
@@ -433,7 +433,11 @@ function initAnnouncementBanner() {
   const closeBtn = document.getElementById('announcement-banner-close');
   if (!banner || !closeBtn) return;
 
-  const dismissKey = 'vq-announcement-dismissed-studio-v0.1.0';
+  // Bumped when the banner's message changes: the v0.1.0 key was for the
+  // "download the app" announcement, and someone who dismissed that has not
+  // seen this beta-recruitment message. Must stay in sync with the pre-paint
+  // visibility check in index.html's <head>.
+  const dismissKey = 'vq-announcement-dismissed-studio-beta';
   closeBtn.addEventListener('click', () => {
     document.documentElement.removeAttribute('data-show-announcement');
     try { localStorage.setItem(dismissKey, '1'); } catch (e) { /* storage unavailable */ }

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -4230,6 +4230,48 @@ span.anchor-alias {
   color: #ffffff;
 }
 
+/* Studio "coming soon" line. Sits between the CTAs and the license meta,
+   deliberately quieter than a button so it reads as status, not an action —
+   the app has no download until beta validation completes. */
+.hero-studio-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 0 0 0.9rem;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.82);
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+}
+
+.hero-studio-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-shadow: none;
+}
+
+.hero-studio-status a {
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.45);
+  transition: border-color 0.15s ease;
+}
+
+.hero-studio-status a:hover {
+  border-bottom-color: #ffffff;
+}
+
 .hero-license-meta {
   font-size: 0.84rem;
   color: rgba(255, 255, 255, 0.78);
@@ -5713,6 +5755,22 @@ details.faq-accordion-item[open] .faq-chevron {
 :root[data-theme="light"] .hero-license-meta {
   color: #64748b;
   text-shadow: none;
+}
+:root[data-theme="light"] .hero-studio-status {
+  color: #475569;
+  text-shadow: none;
+}
+:root[data-theme="light"] .hero-studio-badge {
+  border-color: rgba(0, 0, 0, 0.16);
+  background: rgba(0, 0, 0, 0.05);
+  color: #334155;
+}
+:root[data-theme="light"] .hero-studio-status a {
+  color: #09090b;
+  border-bottom-color: rgba(0, 0, 0, 0.35);
+}
+:root[data-theme="light"] .hero-studio-status a:hover {
+  border-bottom-color: #09090b;
 }
 :root[data-theme="light"] .btn-primary-white {
   background: #09090b;
@@ -8456,6 +8514,38 @@ details.faq-accordion-item[open] .faq-chevron {
   transform: translateY(0);
 }
 
+/* The macOS card ships no binary yet, so its button is outlined rather than
+   solid-white: it must not compete visually with the SDK cards, which link to
+   real installable packages. */
+.eco-action-btn-soon {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: none;
+}
+
+.eco-action-btn-soon:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.45);
+  box-shadow: none;
+}
+
+.eco-soon-tag {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+  vertical-align: middle;
+}
+
 .eco-btn-arr,
 .eco-copy-icon {
   flex-shrink: 0;
@@ -8494,4 +8584,26 @@ details.faq-accordion-item[open] .faq-chevron {
   background: #18181b;
   color: #ffffff;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+}
+
+/* Must follow the solid .eco-action-btn light rules above to keep the
+   coming-soon button outlined in both themes. */
+:root[data-theme="light"] .eco-action-btn-soon {
+  background: transparent;
+  color: #334155;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  box-shadow: none;
+}
+
+:root[data-theme="light"] .eco-action-btn-soon:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: #09090b;
+  border-color: rgba(0, 0, 0, 0.32);
+  box-shadow: none;
+}
+
+:root[data-theme="light"] .eco-soon-tag {
+  border-color: rgba(0, 0, 0, 0.14);
+  background: rgba(0, 0, 0, 0.05);
+  color: #475569;
 }

--- a/landing/index.html
+++ b/landing/index.html
@@ -33,7 +33,7 @@
   <meta name="twitter:image:alt" content="VeloxQuant-MLX Metal kernel benchmark summary: compression ratio and speedup charts" />
 
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260906b" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260905c" />
 
   <script type="application/ld+json">
   {
@@ -138,7 +138,7 @@
     // first-time visit since the banner is undismissed by default).
     (function () {
       try {
-        if (!localStorage.getItem('vq-announcement-dismissed-studio-v0.1.0')) {
+        if (!localStorage.getItem('vq-announcement-dismissed-studio-beta')) {
           document.documentElement.setAttribute('data-show-announcement', '1');
         }
       } catch (e) { /* storage unavailable — leave it hidden */ }
@@ -155,17 +155,19 @@
 <body>
 
   <!-- ── ANNOUNCEMENT BANNER ──
-       VeloxQuant Studio v0.1.0 (macOS app) shipped — see #download below.
+       VeloxQuant Studio (macOS app) is pre-release: the public download is
+       pulled until beta validation is done, so this recruits testers to the
+       Studio repo's issue tracker rather than linking a .dmg — see #download.
        Dismissible, persisted in localStorage like the theme toggle, so a
        returning visitor who already dismissed it doesn't see it again
        (see initAnnouncementBanner in main.js). Hidden entirely if JS is
        disabled or localStorage throws, rather than defaulting to shown,
        since a banner that can never be dismissed is worse than none. -->
   <div id="announcement-banner" class="announcement-banner">
-    <a href="https://github.com/rajveer43/VeloxQuant-Studio/releases/latest/download/VeloxQuant-Studio-0.1.1.dmg" class="announcement-banner-link">
-      <span class="announcement-banner-badge">New</span>
-      <span>VeloxQuant Studio for macOS is here — a native app for this library.</span>
-      <span class="announcement-banner-cta">Download it free <span data-icon>→</span></span>
+    <a href="https://github.com/rajveer43/VeloxQuant-Studio/issues/new?title=Beta%20access%20request%3A%20VeloxQuant%20Studio&body=Mac%20model%20%2F%20chip%3A%0AmacOS%20version%3A%0AModels%20you%20run%20locally%3A%0A" target="_blank" rel="noopener" class="announcement-banner-link">
+      <span class="announcement-banner-badge">Beta</span>
+      <span>VeloxQuant Studio for macOS is in private beta — a native app for this library.</span>
+      <span class="announcement-banner-cta">Request access <span data-icon>→</span></span>
     </a>
     <button type="button" class="announcement-banner-close" id="announcement-banner-close" aria-label="Dismiss announcement">×</button>
   </div>
@@ -217,8 +219,11 @@
       </p>
 
       <div class="hero-cta-group">
-        <a href="https://github.com/rajveer43/VeloxQuant-Studio/releases/latest/download/VeloxQuant-Studio-0.1.1.dmg" class="btn-primary-white" id="hero-download-btn">
-          <span>Download VeloxQuant Studio for Apple Mac</span>
+        <!-- The Studio .dmg is withheld pending beta validation. The primary
+             CTA is the library itself (which IS shipping); the app is a
+             "coming soon" chip below rather than a dead download button. -->
+        <a href="#install" class="btn-primary-white" id="hero-install-btn">
+          <span>Get started — pip install veloxquant-mlx</span>
           <svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor"><path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
         </a>
         <a href="#why" class="btn-secondary-dark">
@@ -226,6 +231,12 @@
           <svg viewBox="0 0 20 20" width="14" height="14" fill="currentColor"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
         </a>
       </div>
+
+      <p class="hero-studio-status">
+        <span class="hero-studio-badge">Coming soon</span>
+        <span>VeloxQuant&nbsp;Studio, the native Mac app, is in private beta.</span>
+        <a href="https://github.com/rajveer43/VeloxQuant-Studio/issues/new?title=Beta%20access%20request%3A%20VeloxQuant%20Studio&body=Mac%20model%20%2F%20chip%3A%0AmacOS%20version%3A%0AModels%20you%20run%20locally%3A%0A" target="_blank" rel="noopener">Request beta access →</a>
+      </p>
 
       <p class="hero-license-meta">
         Open source · MIT License · Apple Silicon M1+
@@ -933,7 +944,7 @@
       <div class="ecosystem-header text-center">
         <div class="pill-badge mb-3">EVERYWHERE YOU BUILD</div>
         <h2 class="ecosystem-title">Run VeloxQuant across your entire workflow</h2>
-        <p class="ecosystem-sub">Available as a native macOS app, intelligent VS Code extension, and official NPM, Rust, and Go SDK runtimes.</p>
+        <p class="ecosystem-sub">Official NPM, Rust, and Go SDK runtimes and a VS Code extension available today — with a native macOS app in private beta.</p>
       </div>
 
       <div class="ecosystem-grid">
@@ -972,10 +983,12 @@
             </div>
           </div>
           <div class="eco-card-meta">
-            <h3 class="eco-card-title">VeloxQuant for macOS</h3>
+            <h3 class="eco-card-title">VeloxQuant for macOS <span class="eco-soon-tag">Coming soon</span></h3>
           </div>
-          <a href="https://github.com/rajveer43/VeloxQuant-Studio/releases" target="_blank" rel="noopener" class="eco-action-btn">
-            Download for macOS
+          <!-- Not a download: the app is gated on beta validation, so this
+               routes to tester signup instead of a release asset. -->
+          <a href="https://github.com/rajveer43/VeloxQuant-Studio/issues/new?title=Beta%20access%20request%3A%20VeloxQuant%20Studio&body=Mac%20model%20%2F%20chip%3A%0AmacOS%20version%3A%0AModels%20you%20run%20locally%3A%0A" target="_blank" rel="noopener" class="eco-action-btn eco-action-btn-soon">
+            Join the beta
           </a>
         </div>
 
@@ -1174,7 +1187,7 @@
   </footer>
 
   <script src="assets/calc.js?v=20260905" defer></script>
-  <script src="assets/main.js?v=20260906" defer></script>
+  <script src="assets/main.js?v=20260905c" defer></script>
 
   <!-- GoatCounter: privacy-friendly, cookieless page counts. Client-side, so
        it records browsers rather than crawlers — expect it to read lower than


### PR DESCRIPTION
VeloxQuant Studio needs beta-user validation before a public release, so the landing page should not hand out the .dmg. Removes all four download touchpoints and replaces them with beta recruitment:

- Announcement banner: "Download it free" -> "Request access", pointing at a prefilled issue template (Mac model / macOS version / models run) instead of the release asset.
- Hero: the primary CTA was the Studio download. Promotes the library's own install as the primary action and demotes the app to a quieter "Coming soon" status line, so the hero still has a live primary CTA.
- Ecosystem card: "Download for macOS" -> "Join the beta", styled as an outlined button so it does not compete with the SDK cards that link to genuinely installable packages. Adds a "Coming soon" tag to its title.
- Ecosystem subheading no longer claims the macOS app is "available".

Also bumps the banner's localStorage dismiss key (studio-v0.1.0 -> studio-beta): the message changed meaning, and anyone who dismissed the download announcement has not seen the beta one. The key is duplicated in index.html's pre-paint visibility check and main.js, so both move together. Bumps the styles.css/main.js cache-bust strings for the same reason -- a returning visitor on a cached main.js would read the old key.

The #download anchor alias is kept so existing inbound links still resolve.

## Summary

Brief description of what this PR changes and why.

## Related issue

Closes #

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
- [ ] New or updated unit tests cover the change
- [ ] Docs updated if user-facing behavior changed

## Number claims (if any)

Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.

- Script path:
- Results path:
- Metric type (check one):
  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
  - [ ] Full-KV accounting (keys + values + residual windows)
  - [ ] MLX peak memory (`mx.get_peak_memory`)
  - [ ] OS RSS / long-context OOM comparison
  - [ ] Throughput (tok/s)

Do not describe accounting ratios as resident RAM savings unless resident memory was measured.
