### PR TITLE
style: apply ruff format to base.py and test_scalar_attend.py

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -949,6 +949,7 @@ class KVCacheBuilder:
             a plain fp16 KVCache so the list length always matches the layers.
             """
             return _native[i] if i < len(_native) else _PlainKVCache()
+
         # VLM wrappers (Qwen2-VL) have model.args.text_config only;
         # real attention config lives in model.language_model.args
         args = getattr(model, "args", None)

--- a/veloxquant_mlx/tests/metal/test_scalar_attend.py
+++ b/veloxquant_mlx/tests/metal/test_scalar_attend.py
@@ -914,9 +914,7 @@ def test_auto_nsg_default_matches_explicit_nsg_output():
     chosen = _auto_nsg(D, H_q // H_kv, B * H_kv * 1)
     auto = np.array(scalar_fused_decode_attend(*args, g, scale, nsg=None))
     pinned = np.array(scalar_fused_decode_attend(*args, g, scale, nsg=chosen))
-    assert np.array_equal(auto, pinned), (
-        f"nsg=None must be bit-identical to nsg={chosen}"
-    )
+    assert np.array_equal(auto, pinned), f"nsg=None must be bit-identical to nsg={chosen}"
 
 
 def test_scalar_attend_batched_threadgroup_memory_budget_unaffected_by_nl():


### PR DESCRIPTION
The ruff-format CI job was failing on master. Two files drifted out of format and CI caught them on the next PR:

  - cache/base.py:952 — missing blank line after the _fallback_for helper, introduced by the hybrid-attention cache fix (#319)
  - tests/metal/test_scalar_attend.py:917 — an assert message that fits on one line was wrapped across three

Formatting only; no logic changes. `ruff format --check .` now reports 696/696 files formatted, and the metal + cache suites pass (1225 passed, 1 skipped).

Note this is separate from the ~1100 `ruff check` lint violations, which CI deliberately does not enforce yet (tracked in #40).

## Summary

Brief description of what this PR changes and why.

## Related issue

Closes #

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
- [ ] New or updated unit tests cover the change
- [ ] Docs updated if user-facing behavior changed

## Number claims (if any)

Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.

- Script path:
- Results path:
- Metric type (check one):
  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
  - [ ] Full-KV accounting (keys + values + residual windows)
  - [ ] MLX peak memory (`mx.get_peak_memory`)
  - [ ] OS RSS / long-context OOM comparison
  - [ ] Throughput (tok/s)

Do not describe accounting ratios as resident RAM savings unless resident memory was measured.
