### PR TITLE
feat(landing): promote Kotlin package to a live JitPack link, redesign ecosystem banner

### DIFF
--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -8250,8 +8250,8 @@ details.faq-accordion-item[open] .faq-chevron {
    ========================================================================== */
 
 .ecosystem-section {
-  padding: 4.5rem 1.5rem 2rem;
-  max-width: 1240px;
+  padding: 4.5rem 1.5rem 3.5rem;
+  max-width: 1160px;
   margin: 0 auto;
   position: relative;
   z-index: 1;
@@ -8259,6 +8259,8 @@ details.faq-accordion-item[open] .faq-chevron {
 
 .ecosystem-container {
   width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
 }
 
 .ecosystem-header {
@@ -8282,31 +8284,41 @@ details.faq-accordion-item[open] .faq-chevron {
   color: rgba(255, 255, 255, 0.65);
   line-height: 1.6;
   margin: 0 auto;
-  max-width: 600px;
+  max-width: 640px;
 }
 
-/* Responsive Ecosystem Grid (3 columns on desktop) */
+/* Responsive Ecosystem Grid:
+   Row 1: Flagship macOS banner (full-width, centered)
+   Row 2: 3 cards (VS Code, Swift, NPM)
+   Row 3: 3 cards (Rust, Go, Kotlin)
+*/
 .ecosystem-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  justify-content: center;
 }
 
 .eco-card {
   grid-column: auto;
 }
 
-/* Featured Top Banner: macOS App spans entire single top row */
+/* Featured Top Banner: macOS App spans entire single top row with centered presentation */
 .eco-card-featured {
   grid-column: 1 / -1;
-  display: grid;
-  grid-template-columns: 1.15fr 1fr;
-  gap: 2.25rem;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  padding: 24px;
+  text-align: center;
+  gap: 1.75rem;
+  padding: 16px 16px 28px;
   background: linear-gradient(135deg, #0c0d15 0%, #12121e 100%);
   border: 1px solid rgba(99, 102, 241, 0.28);
   box-shadow: 0 24px 48px rgba(0, 0, 0, 0.6), 0 0 32px rgba(99, 102, 241, 0.12);
+  border-radius: 20px;
 }
 
 .eco-card-featured:hover {
@@ -8316,19 +8328,26 @@ details.faq-accordion-item[open] .faq-chevron {
 }
 
 .eco-card-featured .eco-mockup-wrap {
-  height: 310px;
+  width: 100%;
+  height: 330px;
 }
 
 .eco-featured-content {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  text-align: center;
   gap: 14px;
-  padding: 6px 14px 6px 4px;
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 0 12px;
+  width: 100%;
 }
 
 .eco-featured-badge-row {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   flex-wrap: wrap;
 }
@@ -8341,25 +8360,31 @@ details.faq-accordion-item[open] .faq-chevron {
 
 .eco-featured-title {
   font-family: var(--font-sans);
-  font-size: clamp(1.4rem, 2.2vw, 1.85rem);
+  font-size: clamp(1.45rem, 2.4vw, 2rem);
   font-weight: 700;
   letter-spacing: -0.025em;
   color: #ffffff;
   margin: 0;
   line-height: 1.2;
+  text-align: center;
 }
 
 .eco-featured-desc {
-  font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.7);
-  line-height: 1.6;
-  margin: 0;
+  font-size: 0.94rem;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.65;
+  margin: 0 auto;
+  max-width: 660px;
+  text-align: center;
 }
 
 .eco-featured-perks {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
   margin: 2px 0 4px;
 }
 
@@ -8367,7 +8392,7 @@ details.faq-accordion-item[open] .faq-chevron {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.84rem;
+  font-size: 0.86rem;
   font-weight: 500;
   color: rgba(255, 255, 255, 0.88);
 }
@@ -8405,30 +8430,39 @@ details.faq-accordion-item[open] .faq-chevron {
 
 .eco-featured-btn {
   width: fit-content;
-  padding: 0 24px;
-  margin-top: 2px;
+  min-width: 250px;
+  padding: 0 32px;
+  margin: 4px auto 0;
 }
 
 @media (max-width: 960px) {
-  .eco-card-featured {
+  .ecosystem-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+  }
+  .eco-card-featured .eco-mockup-wrap {
+    height: 290px;
+  }
+}
+
+@media (max-width: 640px) {
+  .ecosystem-grid {
     grid-template-columns: 1fr;
-    gap: 1.5rem;
-    padding: 16px;
+  }
+  .eco-card-featured {
+    padding: 20px 16px;
+    gap: 1.25rem;
+  }
+  .eco-card-featured .eco-mockup-wrap {
+    height: 260px;
+  }
+  .eco-featured-perks {
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
   }
   .eco-featured-btn {
     width: 100%;
-  }
-}
-
-@media (max-width: 1024px) {
-  .ecosystem-grid {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  }
-}
-
-@media (max-width: 680px) {
-  .ecosystem-grid {
-    grid-template-columns: 1fr;
   }
 }
 
@@ -8861,6 +8895,11 @@ details.faq-accordion-item[open] .faq-chevron {
 /* Card Meta & Bottom Action Button */
 .eco-card-meta {
   padding: 4px 6px 2px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .eco-card-title {
@@ -8870,6 +8909,11 @@ details.faq-accordion-item[open] .faq-chevron {
   letter-spacing: -0.02em;
   color: #ffffff;
   margin: 0;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 .eco-action-btn {

--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -29,7 +29,7 @@
   <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
        third-party hop, no render-blocking preconnect. -->
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260906i" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
 
   <script type="application/ld+json">
   {
@@ -942,7 +942,7 @@
             <li><a href="https://www.npmjs.com/package/@veloxquant/sdk" target="_blank" rel="noopener">NPM SDK</a></li>
             <li><a href="https://crates.io/search?q=veloxquant" target="_blank" rel="noopener">Rust SDK</a></li>
             <li><a href="https://open-vsx.org/extension/veloxquant-mlx/veloxquant-vscode" target="_blank" rel="noopener">VS Code Extension</a></li>
-            <li><a href="/#apps">Kotlin Package (Coming soon)</a></li>
+            <li><a href="https://jitpack.io/#rajveer43/veloxquant-kotlin" target="_blank" rel="noopener">Kotlin Package</a></li>
           </ul>
         </div>
         <div class="footer-links-col">

--- a/landing/index.html
+++ b/landing/index.html
@@ -33,7 +33,7 @@
   <meta name="twitter:image:alt" content="VeloxQuant-MLX Metal kernel benchmark summary: compression ratio and speedup charts" />
 
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260906i" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
 
   <script type="application/ld+json">
   {
@@ -964,7 +964,7 @@
       <div class="ecosystem-header text-center">
         <div class="pill-badge mb-3">EVERYWHERE YOU BUILD</div>
         <h2 class="ecosystem-title">Run VeloxQuant across your entire workflow</h2>
-        <p class="ecosystem-sub">Official Swift, NPM, Rust, and Go SDK runtimes and a VS Code extension available today — with native macOS app and Kotlin package coming soon.</p>
+        <p class="ecosystem-sub">Official Swift, Kotlin, NPM, Rust, and Go SDK runtimes and a VS Code extension available today — with native macOS app coming soon.</p>
       </div>
 
       <div class="ecosystem-grid">
@@ -1239,10 +1239,11 @@
             </div>
           </div>
           <div class="eco-card-meta">
-            <h3 class="eco-card-title">Kotlin Package <span class="eco-soon-tag">Early access</span></h3>
+            <h3 class="eco-card-title">Kotlin Package</h3>
           </div>
           <a href="https://jitpack.io/#rajveer43/veloxquant-kotlin" target="_blank" rel="noopener" class="eco-action-btn">
             View on JitPack
+            <svg class="eco-btn-arr" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M7 17L17 7M17 7H7M17 7V17"/></svg>
           </a>
         </div>
       </div>
@@ -1279,7 +1280,7 @@
             <li><a href="https://www.npmjs.com/package/@veloxquant/sdk" target="_blank" rel="noopener">NPM SDK</a></li>
             <li><a href="https://crates.io/search?q=veloxquant" target="_blank" rel="noopener">Rust SDK</a></li>
             <li><a href="https://open-vsx.org/extension/veloxquant-mlx/veloxquant-vscode" target="_blank" rel="noopener">VS Code Extension</a></li>
-            <li><a href="#apps">Kotlin Package (Coming soon)</a></li>
+            <li><a href="https://jitpack.io/#rajveer43/veloxquant-kotlin" target="_blank" rel="noopener">Kotlin Package</a></li>
           </ul>
         </div>
         <div class="footer-links-col">

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -29,7 +29,7 @@
   <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
        third-party hop, no render-blocking preconnect. -->
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260906i" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
 
   <script type="application/ld+json">
   {
@@ -416,7 +416,7 @@
             <li><a href="https://www.npmjs.com/package/@veloxquant/sdk" target="_blank" rel="noopener">NPM SDK</a></li>
             <li><a href="https://crates.io/search?q=veloxquant" target="_blank" rel="noopener">Rust SDK</a></li>
             <li><a href="https://open-vsx.org/extension/veloxquant-mlx/veloxquant-vscode" target="_blank" rel="noopener">VS Code Extension</a></li>
-            <li><a href="/#apps">Kotlin Package (Coming soon)</a></li>
+            <li><a href="https://jitpack.io/#rajveer43/veloxquant-kotlin" target="_blank" rel="noopener">Kotlin Package</a></li>
           </ul>
         </div>
         <div class="footer-links-col">

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -26,7 +26,7 @@
   <meta name="twitter:image:alt" content="VeloxQuant-MLX Metal kernel benchmark summary: compression ratio and speedup charts" />
 
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260906i" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
 
   <script type="application/ld+json">
   {
@@ -256,7 +256,7 @@
             <li><a href="https://www.npmjs.com/package/@veloxquant/sdk" target="_blank" rel="noopener">NPM SDK</a></li>
             <li><a href="https://crates.io/search?q=veloxquant" target="_blank" rel="noopener">Rust SDK</a></li>
             <li><a href="https://open-vsx.org/extension/veloxquant-mlx/veloxquant-vscode" target="_blank" rel="noopener">VS Code Extension</a></li>
-            <li><a href="/#apps">Kotlin Package (Coming soon)</a></li>
+            <li><a href="https://jitpack.io/#rajveer43/veloxquant-kotlin" target="_blank" rel="noopener">Kotlin Package</a></li>
           </ul>
         </div>
         <div class="footer-links-col">


### PR DESCRIPTION
## Summary
- Kotlin SDK is published on JitPack now — replaced the "Coming soon"/"Early access" labels on the ecosystem card and footer link with a direct link to https://jitpack.io/#rajveer43/veloxquant-kotlin.
- Redesigned the featured macOS-app banner and ecosystem grid: centered layout, tighter card spacing, consistent 3-per-row grid, and adjusted mobile breakpoints so the newly-live Kotlin card sits consistently with the rest at every width.
- Bumped `styles.css`'s cache-busting version (`?v=20260907b`) so the CSS change actually reaches visitors — `/assets/*` is served with an immutable, year-long `Cache-Control` in `netlify.toml`, so a style-only change needs its own version bump or it won't show up for anyone with the old asset cached.

## Test plan
- [ ] After merge/deploy, visit the landing page and confirm the ecosystem section renders correctly (macOS banner centered, 3-column grid, Kotlin card links to JitPack with no "coming soon" tag)
- [ ] Confirm mobile breakpoints (2-column, then 1-column) still look correct
- [ ] Confirm footer's Kotlin Package link goes to JitPack, not `#apps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)