### PR TITLE
chore(seo): PyPI keywords/classifiers + docs-site page metadata (additive only)

### DIFF
--- a/docs-site/docs/algorithms/a2ats.md
+++ b/docs-site/docs/algorithms/a2ats.md
@@ -3,6 +3,8 @@ id: a2ats
 title: A2ATS-adapted
 sidebar_label: A2ATS-adapted
 slug: /algorithms/a2ats
+description: A2ATS-adapted quantizes every token via a calibrated codebook while applying windowed RoPE — exact positions for recent tokens, an approximate stand-in for older ones — trading accuracy on distant tokens (up to 8x worse) for a smaller theoretical footprint.
+keywords: [a2ats, windowed rope, query-aware vector quantization, codebook calibration, retrieval-based compression, acl 2025]
 ---
 
 # A2ATS-adapted

--- a/docs-site/docs/algorithms/adakv.md
+++ b/docs-site/docs/algorithms/adakv.md
@@ -3,6 +3,8 @@ id: adakv
 title: AdaKV-proxy — Per-Head Adaptive Bit Allocation
 sidebar_label: AdaKV-proxy
 slug: /algorithms/adakv
+description: AdaKV-proxy is a calibration-free per-head adaptive bit allocator layered on KIVI-style key quantization, ranking heads by norm-variance or attention-entropy importance to hit a target average bit-width while keeping values at fp16.
+keywords: [adakv, per-head adaptive bits, kivi, norm variance, attention entropy, key-only quantization]
 ---
 
 # AdaKV-proxy — Per-Head Adaptive Bit Allocation

--- a/docs-site/docs/algorithms/age-tiered.md
+++ b/docs-site/docs/algorithms/age-tiered.md
@@ -3,6 +3,8 @@ id: age-tiered
 title: AgeTieredKV
 sidebar_label: AgeTieredKV
 slug: /algorithms/age-tiered
+description: AgeTieredKV assigns tokens to 8/4/2-bit precision tiers purely by age, and this page's own measured benchmark finds the default split loses badly to a uniform INT4 baseline due to a steep 2-bit error cliff.
+keywords: [age-tiered kv cache, position-based quantization, multi-tier precision, perplexity benchmark, uniform int4 comparison, kivi]
 ---
 
 # AgeTieredKV

--- a/docs-site/docs/algorithms/amc.md
+++ b/docs-site/docs/algorithms/amc.md
@@ -3,6 +3,8 @@ id: amc
 title: AMC-adapted
 sidebar_label: AMC-adapted
 slug: /algorithms/amc
+description: AMC-adapted scores every token by activation saliency and routes it into a High/Mid/Low tier that jointly sets rank and bit-width, never evicting tokens, and its own benchmark shows an 8x MSE win on sparse-outlier data but 100x worse on uniform-magnitude data.
+keywords: [amc, saliency-driven quantization, tiered rank precision, activation magnitude scoring, zero-eviction, calibration required]
 ---
 
 # AMC-adapted — Saliency-Driven Tiered Rank + Precision

--- a/docs-site/docs/algorithms/anchorkv.md
+++ b/docs-site/docs/algorithms/anchorkv.md
@@ -3,6 +3,8 @@ id: anchorkv
 title: AnchorKV-adapted
 sidebar_label: AnchorKV-adapted
 slug: /algorithms/anchorkv
+description: AnchorKV-adapted compresses without eviction by representing most tokens as a nearest-anchor index plus one coefficient, spending a theta-controlled residual byte budget on the highest attention-impact tokens, with no verified peer-reviewed venue.
+keywords: [anchorkv, anchor-residual compression, no eviction, anchorkv_theta, residual budget, unpublished preprint]
 ---
 
 # AnchorKV-adapted — Anchor-Residual Compression, No Eviction

--- a/docs-site/docs/algorithms/cachegen.md
+++ b/docs-site/docs/algorithms/cachegen.md
@@ -1,3 +1,10 @@
+---
+id: cachegen
+title: CacheGen — Entropy-Coded KV Cache Storage
+description: CacheGen encodes the reversible per-token delta of group-quantized KV codes and models its Shannon entropy (per channel, capped at fixed-width size) to estimate a lossless storage-size reduction of roughly 17% on token-correlated 3-bit data and 0% on iid data, without changing the reconstructed fp16 values.
+keywords: [cachegen, kv cache, entropy coding, storage compression, quantization, token delta]
+---
+
 # CacheGen — Entropy-Coded KV Cache Storage
 
 **Method id:** `cachegen` · **New in 0.16.0**

--- a/docs-site/docs/algorithms/cam.md
+++ b/docs-site/docs/algorithms/cam.md
@@ -1,3 +1,10 @@
+---
+id: cam
+title: CaM — Cache Merging (Merge Evicted Tokens Instead of Dropping)
+description: Extends H2O-style eviction with a Bernoulli-gated cosine-similarity blend that merges each evicted loser into its most similar surviving token instead of discarding it, cutting output-perturbation cosine distance from 0.955 to 0.708 at 16x compression on the synthetic benchmark.
+keywords: [cam, kv cache, token eviction, cache merging, h2o, cosine similarity]
+---
+
 # CaM — Cache Merging (Merge Evicted Tokens Instead of Dropping)
 
 **Method id:** `cam` · **New in 0.26.0**

--- a/docs-site/docs/algorithms/chunkkv.md
+++ b/docs-site/docs/algorithms/chunkkv.md
@@ -1,3 +1,10 @@
+---
+id: chunkkv
+title: "ChunkKV — Chunk-Level (Semantic-Block) Eviction"
+description: Evicts KV cache in contiguous chunks of chunk_size tokens (mean-pooled attention-mass or key-norm score) instead of single tokens, keeping semantic spans intact, and supports layer-wise index reuse that cut eviction pass time ~12.7x (5.9s to 0.46s) at chunk_size=16 in the offline harness.
+keywords: [chunkkv, kv cache, token eviction, chunk eviction, attention, index reuse]
+---
+
 # ChunkKV — Chunk-Level (Semantic-Block) Eviction
 
 **Method id:** `chunkkv` · **New in 0.25.0** (index reuse in a later release) · *Inspired by* [ChunkKV (arXiv:2502.00299)](https://arxiv.org/abs/2502.00299)

--- a/docs-site/docs/algorithms/commvq.md
+++ b/docs-site/docs/algorithms/commvq.md
@@ -3,6 +3,8 @@ id: commvq
 title: CommVQ
 sidebar_label: CommVQ
 slug: /algorithms/commvq
+description: CommVQ is a RoPE-commutative residual vector quantizer that encodes rotated keys so rotary position embeddings can be applied to quantized codes at decode time without dequantizing first, via a fused Metal kernel.
+keywords: [commvq, rope-commutative quantization, residual vq, rotary position embeddings, metal kernel, quantizer-level api]
 ---
 
 # CommVQ

--- a/docs-site/docs/algorithms/cross-model-transfer.md
+++ b/docs-site/docs/algorithms/cross-model-transfer.md
@@ -3,6 +3,8 @@ id: cross-model-transfer
 title: Cross-Model KV Transfer
 sidebar_label: Cross-Model KV Transfer
 slug: /algorithms/cross-model-transfer
+description: Cross-Model KV Transfer fits an offline per-head ridge regression to map a source model's prefilled KV cache to a target model's, letting model swaps reuse prefill compute instead of shrinking cache bytes, with a fused Metal RoPE-recode kernel.
+keywords: [cross-model kv transfer, ridge regression mapping, prefill reuse, rope recode, model cascading, not a compression method]
 ---
 
 # Cross-Model KV Transfer — Reuse One Model's Prefill in Another

--- a/docs-site/docs/algorithms/curdkv.md
+++ b/docs-site/docs/algorithms/curdkv.md
@@ -3,6 +3,8 @@ id: curdkv
 title: CurDKV-adapted
 sidebar_label: CurDKV-adapted
 slug: /algorithms/curdkv
+description: CurDKV-adapted evicts KV cache tokens using a value-aware leverage score computed via SVD over the joint key-and-value block, so two tokens with identical keys but divergent values get different retention scores.
+keywords: [curdkv, kv cache eviction, leverage score, value-aware, cur decomposition, h2o]
 ---
 
 # CurDKV-adapted — Value-Aware Leverage-Score Eviction

--- a/docs-site/docs/algorithms/gear.md
+++ b/docs-site/docs/algorithms/gear.md
@@ -3,6 +3,8 @@ id: gear
 title: GEAR
 sidebar_label: GEAR
 slug: /algorithms/gear
+description: GEAR is an add-on that recovers accuracy lost to ultra-low-bit KV cache quantization by decomposing the quantization error into a low-rank correction plus a sparse outlier term, winning big at prefill but losing to fp16 at single-token decode.
+keywords: [gear, kv cache compression, low-rank residual, sparse outliers, error feedback, kcvt]
 ---
 
 # GEAR

--- a/docs-site/docs/algorithms/h2o.md
+++ b/docs-site/docs/algorithms/h2o.md
@@ -1,3 +1,10 @@
+---
+id: h2o
+title: H2O — Cumulative Attention-Mass Heavy-Hitter Oracle Eviction
+description: H2O-adapted evicts the lowest running-sum-of-attention-mass token at every step once over h2o_budget, using h2o_grace (default 16) and h2o_decay (default 0.98) fixes so the kept window advances past the prompt (e.g. tracking [297..415] instead of freezing at [4..74] after 400 decode steps) while a deeper eviction-quality gap at tight budgets remains open.
+keywords: [h2o, kv cache, token eviction, cumulative attention, heavy hitters, decay]
+---
+
 # H2O — Cumulative Attention-Mass Heavy-Hitter Oracle Eviction
 
 **Method id:** `h2o` · **New in 0.21.0** · *Inspired by* [H2O (arXiv:2306.14048)](https://arxiv.org/abs/2306.14048)

--- a/docs-site/docs/algorithms/keyformer.md
+++ b/docs-site/docs/algorithms/keyformer.md
@@ -1,3 +1,10 @@
+---
+id: keyformer
+title: Keyformer — Gumbel-Regularized Heavy-Hitter Eviction
+description: Adds a frozen, annealed Gumbel-noise regularizer to H2O-style cumulative attention-mass eviction so borderline "late riser" tokens survive, measured to rescue survival rate from 0.00 to ~0.75 in synthetic late-riser geometry and giving a ~2-3x end-to-end Metal-kernel speedup.
+keywords: [keyformer, kv cache, token eviction, gumbel noise, h2o, rope remap]
+---
+
 # Keyformer — Gumbel-Regularized Heavy-Hitter Eviction
 
 **Method id:** `keyformer` · **New in 0.32.0**, annealing/RoPE-remap/Metal

--- a/docs-site/docs/algorithms/kitty.md
+++ b/docs-site/docs/algorithms/kitty.md
@@ -3,6 +3,8 @@ id: kitty
 title: Kitty — Dynamic Channel-wise Mixed-Precision
 sidebar_label: Kitty
 slug: /algorithms/kitty
+description: Kitty ranks key channels by online variance each step and routes the top fraction to 4-bit while the rest get 2-bit, reaching an average of 2.5 bits per element for a 6.4x key bandwidth reduction with no calibration.
+keywords: [kitty, channel-wise mixed precision, dynamic bit allocation, variance ranking, online calibration, kv cache keys]
 ---
 
 # Kitty — Dynamic Channel-wise Mixed-Precision Keys

--- a/docs-site/docs/algorithms/kivi-sink.md
+++ b/docs-site/docs/algorithms/kivi-sink.md
@@ -1,3 +1,10 @@
+---
+id: kivi-sink
+title: KVSink-Adapted Sink Protection
+description: Layers dynamic top-k key-L2-norm sink detection on top of KIVI group quantization, keeping high-norm sink tokens in fp16 and excluding them from group min/max calibration so they don't inflate quantization scale for neighboring tokens.
+keywords: [kivi_sink, kv cache, quantization, attention sinks, key norm, kivi]
+---
+
 # KVSink-Adapted Sink Protection
 
 **Method id:** `kivi_sink` · **New in 0.9.0** · *Inspired by* [KVSink (Su & Yuan,

--- a/docs-site/docs/algorithms/kivi.md
+++ b/docs-site/docs/algorithms/kivi.md
@@ -3,6 +3,8 @@ id: kivi
 title: KIVI
 sidebar_label: KIVI
 slug: /algorithms/kivi
+description: KIVI is VeloxQuant-MLX's calibration-free, deterministic reference baseline that asymmetrically quantizes keys per-channel and values per-token with a group-aligned fp16 residual window, reaching about 5.46x key compression on Apple M4.
+keywords: [kivi, kv cache quantization, asymmetric quantization, 2-bit quantization, residual window, baseline]
 ---
 
 # KIVI

--- a/docs-site/docs/algorithms/knorm.md
+++ b/docs-site/docs/algorithms/knorm.md
@@ -1,3 +1,10 @@
+---
+id: knorm
+title: "L2Norm — Intrinsic Key-Norm Eviction"
+description: Evicts KV cache tokens by ranking the intrinsic L2 norm of each key (keeping lowest-norm ones per the EMNLP 2024 finding), needing no per-token attention scoring and measured 100-800x faster than H2O-adapted eviction while landing between Q-Filters' calibrated and fallback arms on real-model perplexity.
+keywords: [knorm, l2norm, kv cache, token eviction, key norm, calibration-free]
+---
+
 # L2Norm — Intrinsic Key-Norm Eviction
 
 **Method id:** `knorm` · **New in 0.29.0** · *Inspired by* ["A Simple and

--- a/docs-site/docs/algorithms/kvquant.md
+++ b/docs-site/docs/algorithms/kvquant.md
@@ -3,6 +3,8 @@ id: kvquant
 title: KVQuant-NUQ — Non-Uniform Quantization + Outlier Isolation
 sidebar_label: KVQuant-NUQ
 slug: /algorithms/kvquant
+description: KVQuant-NUQ fits non-uniform Lloyd-Max quantization levels to the actual key/value distribution, isolates magnitude outliers to an fp16 side-channel, and keeps attention-sink tokens exact, reaching about 3.5 effective bits at long context.
+keywords: [kvquant, non-uniform quantization, lloyd-max, outlier isolation, attention sink, dense-and-sparse]
 ---
 
 # KVQuant-NUQ — Non-Uniform Quantization + Outlier Isolation

--- a/docs-site/docs/algorithms/kvtc.md
+++ b/docs-site/docs/algorithms/kvtc.md
@@ -3,6 +3,8 @@ id: kvtc
 title: KVTC-adapted
 sidebar_label: KVTC-adapted
 slug: /algorithms/kvtc
+description: KVTC-adapted compresses the KV cache using local PCA, a dynamic-programming-optimal per-component bit allocation that can zero out low-variance components, and a real order-0 Huffman entropy-coding stage on top of the quantized codes.
+keywords: [kvtc, dynamic programming, bit allocation, pca, entropy coding, huffman coding]
 ---
 
 # KVTC-adapted — Local PCA + DP-Optimal Bit Allocation + Entropy Coding

--- a/docs-site/docs/algorithms/kvzip.md
+++ b/docs-site/docs/algorithms/kvzip.md
@@ -1,3 +1,10 @@
+---
+id: kvzip
+title: KVzip — Context-Reconstruction Reliance Retention
+description: Ranks stored tokens by query-agnostic reconstruction reliance (max proxy-attention received from a reconstruction probe over the live keep set, recomputed each step) rather than a query, retaining reconstruction-critical tokens at ~0.609 vs ~0.017 for cumulative H2O scoring on the synthetic reconstruction-shift benchmark.
+keywords: [kvzip, kv cache, token eviction, query-agnostic, reconstruction probe, h2o]
+---
+
 # KVzip — Context-Reconstruction Reliance Retention
 
 **Method id:** `kvzip` · **New in 0.34.0** · *Inspired by* ["KVzip:

--- a/docs-site/docs/algorithms/minicache.md
+++ b/docs-site/docs/algorithms/minicache.md
@@ -1,3 +1,10 @@
+---
+id: minicache
+title: "MiniCache — Cross-Layer Depth-Dimension Merging"
+description: Merges adjacent middle-to-deep layer pairs by SLERP-interpolating their KV directions into one shared unit vector while each layer keeps its own per-token magnitude, retaining high-divergence token pairs unmerged (measured 0.0002 MSE at 0.9995 layer-direction cosine, 0% retention).
+keywords: [minicache, kv cache, cross-layer compression, slerp, direction merging, token retention]
+---
+
 # MiniCache — Cross-Layer Depth-Dimension Merging
 
 **Method id:** `minicache` · **New in 0.16.0** · *Inspired by* [MiniCache (arXiv:2405.14366,

--- a/docs-site/docs/algorithms/morphkv.md
+++ b/docs-site/docs/algorithms/morphkv.md
@@ -1,3 +1,10 @@
+---
+id: morphkv
+title: MorphKV — Recent-Window Correlation Retention
+description: MorphKV evicts the token with lowest mean proxy-attention correlation to a sliding morphkv_window of recent keys rather than cumulative history, recovering axis-B relevance at ~0.39-0.74 with window 8/32 versus ~0.15-0.37 at window=1 (which collapses bit-for-bit onto TOVA) in a synthetic topic-shift benchmark where H2O-style cumulative scoring retains ~0%.
+keywords: [morphkv, kv cache, token eviction, sliding window, attention proxy, early-token bias]
+---
+
 # MorphKV — Recent-Window Correlation Retention
 
 **Method id:** `morphkv` · **New in 0.33.0** · *Inspired by* ["Dialogue Without

--- a/docs-site/docs/algorithms/nestedkv.md
+++ b/docs-site/docs/algorithms/nestedkv.md
@@ -3,6 +3,8 @@ id: nestedkv
 title: NestedKV-adapted
 sidebar_label: NestedKV-adapted
 slug: /algorithms/nestedkv
+description: NestedKV-adapted evicts prefill tokens using three parallel key-only memory scales (stable, episodic, current) combined via a head-adaptive blend and surprise-gated route, with an unbounded decode-phase cache and no verified peer-reviewed venue.
+keywords: [nestedkv, prefill eviction, multi-scale ensembling, head-adaptive blend, surprise gate, unpublished preprint]
 ---
 
 # NestedKV-adapted — Multi-Scale Ensembled Prefill Eviction

--- a/docs-site/docs/algorithms/nsnquant.md
+++ b/docs-site/docs/algorithms/nsnquant.md
@@ -1,3 +1,10 @@
+---
+id: nsnquant
+title: "NSNQuant — Calibration-Free Universal-Codebook VQ"
+description: Reshapes K/V token vectors toward a standard normal distribution via a Normalize-Shift-Normalize transform plus Hadamard rotation, then quantizes with a fixed offline Gaussian-trained codebook at 1-2 bits/element, reconstructing at 0.96-0.98 mean cosine at 2-bit versus KIVI-2bit's 0.66-0.88 on the same synthetic sweep.
+keywords: [nsnquant, kv cache, vector quantization, hadamard transform, calibration-free, codebook]
+---
+
 # NSNQuant — Calibration-Free Universal-Codebook VQ
 
 **Method id:** `nsnquant` · **New in 0.28.0** · *Inspired by* [NSNQuant

--- a/docs-site/docs/algorithms/overview.md
+++ b/docs-site/docs/algorithms/overview.md
@@ -3,6 +3,8 @@ id: overview
 title: Algorithm Overview
 sidebar_label: Overview
 slug: /algorithms/overview
+description: An index and decision guide comparing all 43 KV cache compression algorithms in VeloxQuant-MLX by bit-width, calibration cost, compression ratio, and best-fit workload.
+keywords: [algorithm overview, kv cache compression, comparison table, decision guide, method selection]
 ---
 
 # Algorithm Overview

--- a/docs-site/docs/algorithms/palu.md
+++ b/docs-site/docs/algorithms/palu.md
@@ -1,3 +1,10 @@
+---
+id: palu
+title: "PALU — True Low-Rank Latent Storage for Keys *and* Values"
+description: Stores both keys and values as group-head low-rank latent codes ([S, r]) with mixed-bit quantization (top-25% channels at 4-bit, rest at 2-bit), reaching roughly 0.6 effective bits/element versus SVDq's keys-only compression.
+keywords: [palu, kv cache, low-rank, svd, quantization, group-head decomposition]
+---
+
 # PALU — True Low-Rank Latent Storage for Keys *and* Values
 
 **Method id:** `palu` · **New in 0.15.0** · *Inspired by* [PALU (arXiv:2407.21118,

--- a/docs-site/docs/algorithms/polarquant.md
+++ b/docs-site/docs/algorithms/polarquant.md
@@ -3,6 +3,8 @@ id: polarquant
 title: PolarQuant
 sidebar_label: PolarQuant
 slug: /algorithms/polarquant
+description: PolarQuant rotates key vectors and recursively decomposes them into quantized angles rather than Cartesian coordinates, making it best suited to models whose keys form spherical or normalized geometric clusters.
+keywords: [polarquant, polar coordinate decomposition, spherical key geometry, angle quantization, recursive codebook, normalized attention]
 ---
 
 # PolarQuant

--- a/docs-site/docs/algorithms/pyramidkv.md
+++ b/docs-site/docs/algorithms/pyramidkv.md
@@ -1,3 +1,10 @@
+---
+id: pyramidkv
+title: PyramidKV — Layer-Adaptive Budget Attention-Mass Eviction
+description: Reuses H2O's cumulative attention-mass eviction but replaces its uniform per-layer budget with a linear pyramid schedule (large budget in early layers, small in deep layers) that keeps the same mean budget as a uniform baseline, collapsing to exact H2O when beta=1.0.
+keywords: [pyramidkv, kv cache, token eviction, per-layer budget, h2o, attention mass]
+---
+
 # PyramidKV — Layer-Adaptive Budget Attention-Mass Eviction
 
 **Method id:** `pyramidkv` · **New in 0.23.0** · *Inspired by* [PyramidKV (arXiv:2406.02069)](https://arxiv.org/abs/2406.02069)

--- a/docs-site/docs/algorithms/qfilters.md
+++ b/docs-site/docs/algorithms/qfilters.md
@@ -1,3 +1,10 @@
+---
+id: qfilters
+title: Q-Filters — Query-Agnostic Projection Eviction
+description: Q-Filters ranks cached keys by their projection onto a frozen per-head direction (calibrated from query-SVD, or a key-SVD fallback) with no per-step attention computation, closing 52%/37%/20% of the fp16 perplexity gap at budgets 256/128/64 on Llama-3.2-1B when calibrated, versus a sign-ambiguous fallback that performs near chance.
+keywords: [qfilters, kv cache, token eviction, projection scorer, query-svd, calibration]
+---
+
 # Q-Filters — Query-Agnostic Projection Eviction
 
 **Method id:** `qfilters` · **New in 0.31.0** · *Inspired by* ["Q-Filters:

--- a/docs-site/docs/algorithms/qjl.md
+++ b/docs-site/docs/algorithms/qjl.md
@@ -3,6 +3,8 @@ id: qjl
 title: QJL
 sidebar_label: QJL
 slug: /algorithms/qjl
+description: QJL uses a random Johnson-Lindenstrauss projection to reduce each key to a 1-bit sign sketch, requiring no calibration or codebook while giving a theoretical bound on inner product error.
+keywords: [qjl, johnson-lindenstrauss, 1-bit quantization, random projection, sign sketch, kv cache]
 ---
 
 # QJL

--- a/docs-site/docs/algorithms/rabitq.md
+++ b/docs-site/docs/algorithms/rabitq.md
@@ -3,6 +3,8 @@ id: rabitq
 title: RaBitQ
 sidebar_label: RaBitQ
 slug: /algorithms/rabitq
+description: RaBitQ compresses keys to 1 bit via a randomised Hadamard transform, IVF clustering, and binary sign packing, scoring attention with Metal-accelerated Hamming distance for roughly 6x total KV compression.
+keywords: [rabitq, 1-bit quantization, hadamard transform, ivf clustering, hamming distance, binary quantization]
 ---
 
 # RaBitQ

--- a/docs-site/docs/algorithms/ratequant.md
+++ b/docs-site/docs/algorithms/ratequant.md
@@ -3,6 +3,8 @@ id: ratequant
 title: RateQuant
 sidebar_label: RateQuant
 slug: /algorithms/ratequant
+description: RateQuant is a per-layer bit allocator, not a cache method itself, that probes layer sensitivity and applies reverse-waterfilling to produce a per-layer bit-width list fed into TurboQuant RVQ or another underlying quantizer.
+keywords: [ratequant, mixed-precision allocation, reverse-waterfilling, layer sensitivity calibration, bit allocation, per-layer quantization]
 ---
 
 # RateQuant

--- a/docs-site/docs/algorithms/rocketkv.md
+++ b/docs-site/docs/algorithms/rocketkv.md
@@ -3,6 +3,8 @@ id: rocketkv
 title: RocketKV-adapted
 sidebar_label: RocketKV-adapted
 slug: /algorithms/rocketkv
+description: RocketKV-adapted runs a two-stage compression pipeline — coarse SnapKV prefill eviction followed by per-step Hybrid Sparse Attention combining paged sequence-dimension and head-dimension top-k selection — to close the accuracy gap eviction-only methods hit at low token budgets.
+keywords: [rocketkv, two-stage compression, hybrid sparse attention, snapkv eviction, dynamic top-k selection, icml 2025]
 ---
 
 # RocketKV-adapted — Two-Stage Compression (SnapKV Eviction + Hybrid Sparse Attention)

--- a/docs-site/docs/algorithms/rvq.md
+++ b/docs-site/docs/algorithms/rvq.md
@@ -3,6 +3,8 @@ id: rvq
 title: TurboQuant RVQ
 sidebar_label: TurboQuant RVQ
 slug: /algorithms/rvq
+description: TurboQuant RVQ is VeloxQuant-MLX's default calibration-free method, using Hadamard rotation plus Gaussian and Laplacian residual codebooks to reach 7.5x key compression with measured 12.8% lower peak memory than fp16.
+keywords: [turboquant rvq, residual vector quantization, hadamard rotation, gaussian codebook, laplacian residual, kv cache compression]
 ---
 
 # TurboQuant RVQ

--- a/docs-site/docs/algorithms/skvq.md
+++ b/docs-site/docs/algorithms/skvq.md
@@ -1,3 +1,10 @@
+---
+id: skvq
+title: SKVQ — Sliding-Window Reorder + Clip Quantization
+description: SKVQ reorders head-dim channels by dynamic range and applies a per-group grid-searched clip factor before low-bit group quantization, behind an fp16 sliding window and sink filter, cutting key MSE a further 16.9% via reordering plus 14.0% via clip search on heterogeneous-channel data (versus a measured -0.3%, i.e. no effect, on homogeneous channels).
+keywords: [skvq, kv cache, quantization, channel reordering, clipped quantization, sliding window]
+---
+
 # SKVQ — Sliding-Window Reorder + Clip Quantization
 
 **Method id:** `skvq` · **New in 0.30.0** · *Inspired by* ["SKVQ:

--- a/docs-site/docs/algorithms/snapkv.md
+++ b/docs-site/docs/algorithms/snapkv.md
@@ -1,3 +1,10 @@
+---
+id: snapkv
+title: SnapKV — Prefill Observation-Window Token Eviction
+description: SnapKV-adapted scores prefix tokens once at the end of prefill using the trailing snap_obs_window key rows as proxy queries, then permanently keeps only the top snap_budget positions (plus sinks) in fp16 while decode tokens are always appended, never evicted.
+keywords: [snapkv, kv cache, token eviction, prefill compression, attention proxy]
+---
+
 # SnapKV — Prefill Observation-Window Token Eviction
 
 **Method id:** `snapkv` · **New in 0.19.0** · *Inspired by* [SnapKV (arXiv:2404.14469)](https://arxiv.org/abs/2404.14469)

--- a/docs-site/docs/algorithms/spectral.md
+++ b/docs-site/docs/algorithms/spectral.md
@@ -3,6 +3,8 @@ id: spectral
 title: SpectralQuant
 sidebar_label: SpectralQuant
 slug: /algorithms/spectral
+description: SpectralQuant rotates keys and values into an SVD-derived PCA basis to split high-variance signal dimensions from low-variance noise before quantizing, targeting high fidelity at long (8k+) context lengths.
+keywords: [spectralquant, svd rotation, participation ratio, qjl sign-sketch, water-filling bit allocation, long context]
 ---
 
 # SpectralQuant

--- a/docs-site/docs/algorithms/squeeze.md
+++ b/docs-site/docs/algorithms/squeeze.md
@@ -1,3 +1,10 @@
+---
+id: squeeze
+title: "SqueezeAttention — 2D Layer×Token Data-Driven Budget Eviction"
+description: Reallocates a fixed total KV cache budget across layers using each layer's measured key-set cosine-similarity concentration (broad layers get more, concentrated layers get less), reducing to plain uniform H2O eviction exactly when squeeze_strength=0.
+keywords: [squeeze, squeezeattention, kv cache, token eviction, per-layer budget, attention concentration]
+---
+
 # SqueezeAttention — 2D Layer×Token Data-Driven Budget Eviction
 
 **Method id:** `squeeze` · **New in 0.24.0** · *Inspired by* [SqueezeAttention (arXiv:2404.04793)](https://arxiv.org/abs/2404.04793)

--- a/docs-site/docs/algorithms/streaming_llm.md
+++ b/docs-site/docs/algorithms/streaming_llm.md
@@ -1,3 +1,10 @@
+---
+id: streaming_llm
+title: "StreamingLLM — Sink + Recency-Window Token Eviction"
+description: Keeps only the first stream_n_sink attention-sink tokens plus a sliding FIFO window of stream_window_size recent tokens, giving constant decode-phase memory (stream_n_sink + window_size) with no scoring or calibration.
+keywords: [streaming_llm, kv cache, attention sinks, sliding window, constant memory, positional eviction]
+---
+
 # StreamingLLM — Sink + Recency-Window Token Eviction
 
 **Method id:** `streaming_llm` · **New in 0.20.0** · *Inspired by* [StreamingLLM (arXiv:2309.17453)](https://arxiv.org/abs/2309.17453)

--- a/docs-site/docs/algorithms/svdq.md
+++ b/docs-site/docs/algorithms/svdq.md
@@ -1,3 +1,10 @@
+---
+id: svdq
+title: SVDq — Sub-2-bit Key Cache via Offline SVD
+description: Projects keys into a low-rank latent space via per-sequence truncated SVD, then applies the paper's fixed 8-group mixed-precision bit schedule to reach an effective key bit-width of about 1.0-1.25 bits/element while leaving values at fp16.
+keywords: [svdq, kv cache, quantization, low-rank projection, svd, mixed precision]
+---
+
 # SVDq — Sub-2-bit Key Cache via Offline SVD
 
 **Method id:** `svdq` · **New in 0.10.0** · *Inspired by* [SVDq (arXiv:2502.15304,

--- a/docs-site/docs/algorithms/tova.md
+++ b/docs-site/docs/algorithms/tova.md
@@ -1,3 +1,10 @@
+---
+id: tova
+title: TOVA — Current-Step Attention-Weight Eviction (Memoryless)
+description: TOVA-adapted evicts, at every step, the non-sink token with the lowest current-step (memoryless) key-as-query attention weight, keeping the cache bounded to tova_budget — measured compression equals seq_len / budget exactly (e.g. 2048 tokens at budget 64 -> 32x).
+keywords: [tova, kv cache, token eviction, attention, memoryless scoring]
+---
+
 # TOVA — Current-Step Attention-Weight Eviction (Memoryless)
 
 **Method id:** `tova` · **New in 0.22.0** · *Inspired by* [TOVA / "Transformers are Multi-State RNNs" (arXiv:2401.06104)](https://arxiv.org/abs/2401.06104)

--- a/docs-site/docs/algorithms/vecinfer.md
+++ b/docs-site/docs/algorithms/vecinfer.md
@@ -3,6 +3,8 @@ id: vecinfer
 title: VecInfer
 sidebar_label: VecInfer
 slug: /algorithms/vecinfer
+description: VecInfer is VeloxQuant-MLX's highest-compression algorithm, combining smooth-scaled product vector quantization with a Walsh-Hadamard transform and Metal GPU kernels for nearest-centroid lookup.
+keywords: [vecinfer, product quantization, vector quantization, walsh-hadamard transform, metal kernels, smooth scaling]
 ---
 
 # VecInfer

--- a/docs-site/docs/algorithms/xkv.md
+++ b/docs-site/docs/algorithms/xkv.md
@@ -1,3 +1,10 @@
+---
+id: xkv
+title: xKV — Cross-Layer Shared-Subspace Compression
+description: xKV jointly factorizes a fixed-size contiguous group of layers' key matrices into one shared low-rank SVD basis via a fan-in/fan-out coordinator, landing within ~1% of independent per-layer SVD's reconstruction MSE while cutting bytes 8-20% (0.80-0.92x) depending on group size.
+keywords: [xkv, kv cache, cross-layer compression, low-rank svd, shared subspace, quantization]
+---
+
 # xKV — Cross-Layer Shared-Subspace Compression
 
 **Method id:** `xkv` · **New in 0.27.0** · *Inspired by* [xKV (arXiv:2503.18893,

--- a/docs-site/docs/algorithms/xquant.md
+++ b/docs-site/docs/algorithms/xquant.md
@@ -3,6 +3,8 @@ id: xquant
 title: XQuant — Cross-Layer KV Cache Reuse
 sidebar_label: XQuant
 slug: /algorithms/xquant
+description: XQuant is VeloxQuant-MLX's first cross-layer method, pairing transformer layers into anchor/reuse groups so reuse layers share the anchor's quantized codes and store only their own scale/zero, reaching roughly 1.0-1.4 effective key bits.
+keywords: [xquant, cross-layer kv cache reuse, anchor reuse groups, layer coordinator, effective bit-width, sub-2-bit keys]
 ---
 
 # XQuant — Cross-Layer KV Cache Reuse

--- a/docs-site/docs/algorithms/zipcache.md
+++ b/docs-site/docs/algorithms/zipcache.md
@@ -1,3 +1,10 @@
+---
+id: zipcache
+title: ZipCache — Saliency-Adaptive Per-Token Mixed Precision
+description: Uses per-token key L2-norm as a saliency proxy to route the top hi_fraction of tokens to a finer hi_bits quantization and the rest to a coarser lo_bits quantization, keeping both tiers quantized (never fp16) for a tunable average bit-width.
+keywords: [zipcache, kv cache, quantization, mixed precision, key norm, saliency]
+---
+
 # ZipCache — Saliency-Adaptive Per-Token Mixed Precision
 
 **Method id:** `zipcache` · **New in 0.18.0** · *Inspired by* [ZipCache (arXiv:2405.14256)](https://arxiv.org/abs/2405.14256)

--- a/docs-site/docs/api/allocators.md
+++ b/docs-site/docs/api/allocators.md
@@ -3,6 +3,8 @@ id: allocators
 title: Allocators API
 sidebar_label: Allocators
 slug: /api/allocators
+description: Python API reference for veloxquant_mlx.allocators, covering RateQuant's calibrate_layer_sensitivities/fit_distortion_curve/allocate_bits_ratequant functions and VecInfer's calibrate_smooth_factors/train_codebook and related utility functions for bit-allocation calibration.
+keywords: [allocators, RateQuant, VecInfer, "API reference", "python api", bit allocation, calibration, codebook]
 ---
 
 # Allocators API

--- a/docs-site/docs/api/auto-config-api.md
+++ b/docs-site/docs/api/auto-config-api.md
@@ -3,6 +3,8 @@ id: auto-config-api
 title: Auto Config API
 sidebar_label: Auto Config
 slug: /api/auto-config-api
+description: Python API reference for veloxquant_mlx.config, covering WorkloadSpec, HardwareInfo, detect_hardware_info, AutoConfigResult, and the select_kv_cache_config function that hardware-aware picks a KV-cache method, bit-width, and group size.
+keywords: [auto config, select_kv_cache_config, WorkloadSpec, "API reference", "python api", HardwareInfo, hardware-aware configuration]
 ---
 
 # Auto Config API

--- a/docs-site/docs/api/cache.md
+++ b/docs-site/docs/api/cache.md
@@ -3,6 +3,8 @@ id: cache
 title: Cache API
 sidebar_label: Cache
 slug: /api/cache
+description: Python API reference for veloxquant_mlx.cache, covering the KVCacheConfig dataclass, the KVCacheFactory and KVCacheBuilder classes, and the concrete cache implementations TurboQuantRVQKVCache, VecInferKVCache, SpectralQuantKVCache, PolarQuantKVCache, QJLKVCache, and SlidingWindowKVCache.
+keywords: [cache, KVCacheConfig, KVCacheBuilder, "API reference", "python api", KVCacheFactory, KV cache]
 ---
 
 # Cache API

--- a/docs-site/docs/api/cacheroute-api.md
+++ b/docs-site/docs/api/cacheroute-api.md
@@ -3,6 +3,8 @@ id: cacheroute-api
 title: CacheRoute API
 sidebar_label: CacheRoute
 slug: /api/cacheroute-api
+description: Python API reference for veloxquant_mlx.routing, covering the SessionRate and RoutingTable dataclasses plus the CacheRoutePlanner and RateEstimator classes for rate-aware session admission and shard placement over a shared KV block pool.
+keywords: [cacheroute, routing, CacheRoutePlanner, "API reference", "python api", RoutingTable, RateEstimator, shard placement]
 ---
 
 # CacheRoute API

--- a/docs-site/docs/api/core-api.md
+++ b/docs-site/docs/api/core-api.md
@@ -3,6 +3,8 @@ id: core-api
 title: Core Abstractions API
 sidebar_label: Core
 slug: /api/core-api
+description: Python API reference for veloxquant_mlx.core, covering the Quantizer, KVCache, Preconditioner, and Codebook abstract base classes, the EncodedVector/QuantizationContext/TransformResult context types, the QuantizerRegistry, and the precompute/benchmark CLI commands.
+keywords: [core abstractions, Quantizer, KVCache, "API reference", "python api", QuantizerRegistry, EncodedVector, CLI]
 ---
 
 # Core Abstractions API

--- a/docs-site/docs/api/exceptions-api.md
+++ b/docs-site/docs/api/exceptions-api.md
@@ -3,6 +3,8 @@ id: exceptions-api
 title: Exceptions API
 sidebar_label: Exceptions
 slug: /api/exceptions-api
+description: Python API reference for veloxquant_mlx.core.exceptions, covering the VeloxQuantError base class and its subclasses such as ArtifactNotFoundError, CodebookDimensionMismatch, QuantizerConfigError, MetalUnavailableError, BlockPoolExhaustedError, and OwnerAlreadyActiveError.
+keywords: [exceptions, VeloxQuantError, "API reference", "python api", error handling, BlockPoolExhaustedError]
 ---
 
 # Exceptions API

--- a/docs-site/docs/api/memory-api.md
+++ b/docs-site/docs/api/memory-api.md
@@ -3,6 +3,8 @@ id: memory-api
 title: Memory (Block Pool) API
 sidebar_label: Memory / Block Pool
 slug: /api/memory-api
+description: Python API reference for veloxquant_mlx.memory, covering PoolConfig, BlockPoolAllocator, Block, AllocationStats, MLXBlockStorage, PooledKVCache, and PoolBackedKVCache for fixed-size block allocation and reuse in KV-cache storage.
+keywords: [memory, block pool, BlockPoolAllocator, "API reference", "python api", PooledKVCache, PoolBackedKVCache, PoolConfig]
 ---
 
 # Memory (Block Pool) API

--- a/docs-site/docs/api/metal-api.md
+++ b/docs-site/docs/api/metal-api.md
@@ -3,6 +3,8 @@ id: metal-api
 title: Metal Kernels API
 sidebar_label: Metal Kernels
 slug: /api/metal-api
+description: Python API reference for veloxquant_mlx.metal, covering low-level Apple Silicon Metal kernels for VecInfer, RaBitQ, KIVI-style group-affine attention, CommVQ, cross-model RoPE recoding, scalar quantization, RVQ fusion, prefill attention, KV-cache eviction, fused SDPA, bit packing, and QJL.
+keywords: [metal kernels, Metal, "API reference", "python api", Apple Silicon, fused SDPA, GPU kernels]
 ---
 
 # Metal Kernels API

--- a/docs-site/docs/api/observers-api.md
+++ b/docs-site/docs/api/observers-api.md
@@ -3,6 +3,8 @@ id: observers-api
 title: Observers API
 sidebar_label: Observers
 slug: /api/observers-api
+description: Python API reference for veloxquant_mlx.observers, covering the QuantizationEvent dataclass and the DistortionObserver, LatencyObserver, MemoryObserver, and KeyNormObserver classes for tracking quantization distortion, timing, memory, and key-norm statistics.
+keywords: [observers, DistortionObserver, QuantizationEvent, "API reference", "python api", LatencyObserver, MemoryObserver, KeyNormObserver]
 ---
 
 # Observers API

--- a/docs-site/docs/api/profiling-api.md
+++ b/docs-site/docs/api/profiling-api.md
@@ -3,6 +3,8 @@ id: profiling-api
 title: Profiling API
 sidebar_label: Profiling
 slug: /api/profiling-api
+description: Python API reference for veloxquant_mlx.profiling, covering KVCacheProfiler and MLXCacheProfiler wrapper classes, the LayerProfile and ProfileReport dataclasses, and the profile_layers/format_profile_table helper functions for kernel-level timing and memory profiling.
+keywords: [profiling, KVCacheProfiler, MLXCacheProfiler, "API reference", "python api", LayerProfile, ProfileReport, benchmarking]
 ---
 
 # Profiling API

--- a/docs-site/docs/api/quantizers.md
+++ b/docs-site/docs/api/quantizers.md
@@ -3,6 +3,8 @@ id: quantizers
 title: Quantizers API
 sidebar_label: Quantizers
 slug: /api/quantizers
+description: Python API reference for veloxquant_mlx.quantizers, covering the QuantizerFactory and quantizer implementations including TurboQuantRVQ, TurboQuantMSE, TurboQuantProd, RaBitQQuantizer, CommVQQuantizer, PolarQuantizer, QJLQuantizer, and CompositeQuantizer.
+keywords: [quantizers, TurboQuantRVQ, QuantizerFactory, "API reference", "python api", RaBitQ, CommVQ, PolarQuant, QJL]
 ---
 
 # Quantizers API

--- a/docs-site/docs/api/spectral-api.md
+++ b/docs-site/docs/api/spectral-api.md
@@ -3,6 +3,8 @@ id: spectral-api
 title: SpectralQuant API
 sidebar_label: SpectralQuant
 slug: /api/spectral-api
+description: Python API reference for veloxquant_mlx.spectral, covering the SpectralQuantizer eigenvector-rotated quantizer, calibration functions for computing per-layer PCA rotations, and water-filling bit allocation helpers.
+keywords: [spectral, spectralquant, SpectralQuantizer, "API reference", "python api", water-filling, PCA rotation]
 ---
 
 # SpectralQuant API

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -3,6 +3,8 @@ id: changelog
 title: Changelog
 sidebar_label: Changelog
 slug: /changelog
+description: Version history and release notes for VeloxQuant-MLX, documenting new quantization/eviction methods, Metal kernel additions, bug fixes, and honest-scope caveats for each release.
+keywords: [changelog, release notes, version history, veloxquant-mlx]
 ---
 
 # Changelog

--- a/docs-site/docs/getting-started/comparison.md
+++ b/docs-site/docs/getting-started/comparison.md
@@ -3,6 +3,8 @@ id: comparison
 title: VeloxQuant-MLX vs. llama.cpp vs. plain mlx_lm
 sidebar_label: vs. llama.cpp / mlx_lm
 slug: /getting-started/comparison
+description: Compares VeloxQuant-MLX's 42 selectable KV cache compression methods against llama.cpp's fixed q4_0/q8_0 quantization and plain mlx_lm's uncompressed fp16 cache, with measured compression and speedup numbers.
+keywords: [llama.cpp comparison, mlx_lm, kv cache quantization, gguf, q4_0, compression benchmarks]
 ---
 
 # VeloxQuant-MLX vs. llama.cpp vs. plain mlx_lm

--- a/docs-site/docs/getting-started/concepts.md
+++ b/docs-site/docs/getting-started/concepts.md
@@ -3,6 +3,8 @@ id: concepts
 title: Core Concepts
 sidebar_label: Core Concepts
 slug: /getting-started/concepts
+description: Introduces the foundational ideas behind VeloxQuant-MLX, including what a KV cache is, why and how it is compressed, vector and residual quantization, calibration, and Metal GPU kernels.
+keywords: [kv cache, vector quantization, residual vq, rate-distortion, calibration, metal kernels]
 ---
 
 # Core Concepts

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -3,6 +3,8 @@ id: installation
 title: Installation
 sidebar_label: Installation
 slug: /getting-started/installation
+description: Covers installing VeloxQuant-MLX from PyPI or source on Apple Silicon, verifying Metal GPU availability, installing mlx_lm, and troubleshooting common setup errors.
+keywords: [installation, pip install, apple silicon, metal gpu, troubleshooting, mlx_lm]
 ---
 
 # Installation

--- a/docs-site/docs/getting-started/intro.md
+++ b/docs-site/docs/getting-started/intro.md
@@ -3,6 +3,8 @@ id: intro
 title: What is VeloxQuant-MLX?
 sidebar_label: Introduction
 slug: /getting-started/intro
+description: Introduces VeloxQuant-MLX, a KV cache compression library for Apple Silicon with 43 quantization, eviction, and cross-layer merging methods, and summarizes its key performance metrics.
+keywords: [veloxquant-mlx, apple silicon, kv cache compression, mlx, unified memory, llm inference]
 ---
 
 # What is VeloxQuant-MLX?

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -3,6 +3,8 @@ id: quickstart
 title: 5-Minute Quickstart
 sidebar_label: Quickstart
 slug: /getting-started/quickstart
+description: Walks through loading a model with mlx_lm, attaching a TurboQuant RVQ compressed KV cache via patch_model_kv_cache, generating text, and inspecting memory savings with MemoryObserver.
+keywords: [quickstart, mlx_lm, turboquant_rvq, patch_model_kv_cache, memoryobserver, kvcacheconfig]
 ---
 
 # 5-Minute Quickstart

--- a/docs-site/docs/guides/auto-config.md
+++ b/docs-site/docs/guides/auto-config.md
@@ -3,6 +3,8 @@ id: auto-config
 title: Hardware-Aware Auto Configuration
 sidebar_label: Auto Config
 slug: /guides/auto-config
+description: Explains select_kv_cache_config(), which automatically picks a compression method, bit-width, and group size from a WorkloadSpec and detected hardware memory pressure, with a matching CLI.
+keywords: [auto config, select_kv_cache_config, workloadspec, hardware detection, veloxquant auto-config]
 ---
 
 # Hardware-aware auto configuration

--- a/docs-site/docs/guides/benchmarking.md
+++ b/docs-site/docs/guides/benchmarking.md
@@ -3,6 +3,8 @@ id: benchmarking
 title: Benchmarking Guide
 sidebar_label: Benchmarking
 slug: /guides/benchmarking
+description: Documents the veloxquant_mlx benchmark CLI and walks through worked, reproducible examples for VecInfer, KIVI, and KVSink protection, including how to interpret compression ratio and throughput results.
+keywords: [benchmarking, vecinfer, kivi, kvsink, compression ratio, throughput]
 ---
 
 # Benchmarking Guide

--- a/docs-site/docs/guides/cacheroute.md
+++ b/docs-site/docs/guides/cacheroute.md
@@ -3,6 +3,8 @@ id: cacheroute
 title: CacheRoute — Rate-Aware Session Admission and Placement
 sidebar_label: CacheRoute
 slug: /guides/cacheroute
+description: Explains CacheRoute, a rate-aware session admission and shard placement planner adapted from the CacheRoute paper for multi-tenant KV block pool serving in a single VeloxQuant-MLX process.
+keywords: [cacheroute, multi-tenant serving, session admission, shard placement, block pool allocator, routing table]
 ---
 
 # CacheRoute: rate-aware session admission and shard placement

--- a/docs-site/docs/guides/calibration.md
+++ b/docs-site/docs/guides/calibration.md
@@ -3,6 +3,8 @@ id: calibration
 title: Calibration Guide
 sidebar_label: Calibration
 slug: /guides/calibration
+description: Details which VeloxQuant-MLX algorithms require calibration and how to collect, save, and reload calibration artifacts for VecInfer, RateQuant, and SpectralQuant using each method's real functions.
+keywords: [calibration, vecinfer, ratequant, spectralquant, artifact store, precompute cli]
 ---
 
 # Calibration Guide

--- a/docs-site/docs/guides/control-panel.md
+++ b/docs-site/docs/guides/control-panel.md
@@ -3,6 +3,8 @@ id: control-panel
 title: Control Panel
 sidebar_label: Control Panel
 slug: /guides/control-panel
+description: Explains how to run VeloxQuant's local Gradio-style control panel and OpenAI-compatible server to pick a model and compression method and chat with it, with no Python code required.
+keywords: [control panel, veloxquant panel, openai-compatible server, veloxquant serve, local web ui]
 ---
 
 # Control Panel

--- a/docs-site/docs/guides/mac-recommender.md
+++ b/docs-site/docs/guides/mac-recommender.md
@@ -3,6 +3,8 @@ id: mac-recommender
 title: Mac Method Recommender
 sidebar_label: Mac Recommender
 slug: /guides/mac-recommender
+description: Explains the veloxquant recommend CLI, which picks a compression method based on your Mac's chip, unified RAM, model size class, and goal, and clarifies key accounting versus resident memory savings.
+keywords: [mac recommender, veloxquant recommend, chip ram heuristics, model size class, key accounting]
 ---
 
 # Mac chip + RAM method recommender

--- a/docs-site/docs/guides/metal-kernels.md
+++ b/docs-site/docs/guides/metal-kernels.md
@@ -3,6 +3,8 @@ id: metal-kernels
 title: Metal GPU Kernels
 sidebar_label: Metal Kernels
 slug: /guides/metal-kernels
+description: Catalogs VeloxQuant-MLX's runtime-compiled Metal GPU kernels for quantization, fused attention, KV-cache eviction, and cross-model transfer, with performance numbers and fallback behavior.
+keywords: [metal kernels, metal_kernel, fused sdpa, rabitq, kivi, gpu quantization]
 ---
 
 # Metal GPU Kernels

--- a/docs-site/docs/guides/mixed-precision.md
+++ b/docs-site/docs/guides/mixed-precision.md
@@ -3,6 +3,8 @@ id: mixed-precision
 title: Mixed-Precision Guide
 sidebar_label: Mixed Precision
 slug: /guides/mixed-precision
+description: Explains how to assign different bit-widths per transformer layer using RateQuant automatic allocation or manual bit_width_inlier lists, plus outlier handling and the adaptive codebook variant.
+keywords: [mixed precision, ratequant, bit_width_inlier, per-layer quantization, kvcachebuilder, keynormobserver]
 ---
 
 # Mixed-Precision Guide

--- a/docs-site/docs/guides/mlx-lm-integration.md
+++ b/docs-site/docs/guides/mlx-lm-integration.md
@@ -3,6 +3,8 @@ id: mlx-lm-integration
 title: mlx_lm Integration
 sidebar_label: mlx_lm Integration
 slug: /guides/mlx-lm-integration
+description: Covers the integration patterns for wiring VeloxQuant-MLX into mlx_lm and mlx-vlm — KVCacheBuilder, the monkey-patch, fused SDPA, and PrefixCache for multi-call prefix reuse across turns.
+keywords: [mlx_lm integration, kvcachebuilder, patch_model_kv_cache, fused sdpa, prefixcache, mlx-vlm]
 ---
 
 # mlx_lm Integration

--- a/docs-site/docs/guides/observers.md
+++ b/docs-site/docs/guides/observers.md
@@ -3,6 +3,8 @@ id: observers
 title: Observers
 sidebar_label: Observers
 slug: /guides/observers
+description: Documents the four QuantizationObserver classes — DistortionObserver, LatencyObserver, MemoryObserver, and KeyNormObserver — and how to feed them QuantizationEvent objects to collect runtime metrics.
+keywords: [observers, quantizationobserver, distortionobserver, latencyobserver, memoryobserver, keynormobserver]
 ---
 
 # Observers

--- a/docs-site/docs/guides/profiling.md
+++ b/docs-site/docs/guides/profiling.md
@@ -3,6 +3,8 @@ id: profiling
 title: KV-Cache Profiling
 sidebar_label: Profiling
 slug: /guides/profiling
+description: Shows how to use KVCacheProfiler and MLXCacheProfiler to measure per-layer quantize/dequantize latency and memory, both for standalone caches and for real mlx_lm.generate() runs via the veloxquant profile CLI.
+keywords: [profiling, kvcacheprofiler, mlxcacheprofiler, per-layer latency, veloxquant profile cli]
 ---
 
 # KV-Cache Profiling

--- a/docs-site/docs/guides/sliding-window.md
+++ b/docs-site/docs/guides/sliding-window.md
@@ -3,6 +3,8 @@ id: sliding-window
 title: Sliding Window Cache
 sidebar_label: Sliding Window
 slug: /guides/sliding-window
+description: Documents SlidingWindowKVCache, a FIFO token-eviction wrapper that bounds memory for long generations by rebuilding the inner compressed cache once the window fills.
+keywords: [sliding window, fifo eviction, slidingwindowkvcache, bounded memory, per-token cache]
 ---
 
 # Sliding Window Cache

--- a/docs-site/docs/guides/validation-report.md
+++ b/docs-site/docs/guides/validation-report.md
@@ -3,6 +3,8 @@ id: validation-report
 title: Validation Report
 sidebar_label: Validation Report
 slug: /guides/validation-report
+description: Defines the KV cache and quantization formulas precisely, and shows how to reproduce compression and throughput numbers honestly with scripts/validate_kv_memory.py on measured Apple Silicon results.
+keywords: [validation report, kv memory formula, compression claim, accounting bytes, validate_kv_memory]
 ---
 
 # Validation Report: KV Cache Quantization on Apple Silicon

--- a/docs-site/docs/intro.mdx
+++ b/docs-site/docs/intro.mdx
@@ -2,6 +2,8 @@
 id: intro
 title: VeloxQuant-MLX Documentation
 slug: /
+description: Landing page for the VeloxQuant-MLX documentation site that redirects visitors to the getting-started introduction guide.
+keywords: [veloxquant-mlx, documentation, getting started, redirect]
 ---
 
 import {Redirect} from '@docusaurus/router';

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -16,7 +16,15 @@ const config: Config = {
       attributes: {
         name: 'keywords',
         content:
-          'KV cache compression, KV cache quantization, LLM memory optimization, Apple Silicon, MLX framework, mlx_lm, local LLM inference, on-device AI, long context inference, key-value cache, Metal kernels, token eviction, KIVI, GEAR, KVQuant, RaBitQ, VecInfer, TurboQuant RVQ, H2O, SnapKV, StreamingLLM, SpectralQuant, CommVQ, RateQuant, CacheRoute, low-bit quantization, Llama, Mistral, Qwen, Gemma',
+          'KV cache compression, KV cache quantization, LLM memory optimization, Apple Silicon, MLX framework, mlx_lm, local LLM inference, on-device AI, long context inference, key-value cache, Metal kernels, token eviction, KIVI, GEAR, KVQuant, RaBitQ, VecInfer, TurboQuant RVQ, H2O, SnapKV, StreamingLLM, SpectralQuant, CommVQ, RateQuant, CacheRoute, low-bit quantization, Llama, Mistral, Qwen, Gemma, run larger LLMs on Mac, reduce LLM memory usage Mac, fit bigger model in Mac RAM, Apple Silicon LLM inference, context length extension, attention cache quantization',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'description',
+        content:
+          'Documentation for VeloxQuant-MLX: 43 KV-cache compression methods for MLX on Apple Silicon, up to 16x smaller cache with near-lossless quality, in three lines of code.',
       },
     },
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ keywords = [
     "turboquant", "ratequant", "rvq", "polarquant", "qjl",
     "rabitq", "commvq", "spectralquant", "vecinfer",
     "inference", "compression", "mixed-precision",
+    "kv cache compression", "llm memory reduction", "apple silicon llm",
+    "long context inference", "attention cache quantization",
+    "metal kernels", "on-device llm", "local llm inference",
+    "context length extension", "mlx-lm", "token eviction",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -37,6 +41,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: System :: Hardware",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Libraries",
+    "Natural Language :: English",
 ]
 dependencies = [
     "mlx>=0.18",


### PR DESCRIPTION
## Summary
- **pyproject.toml**: appended 10 intent-search keywords (e.g. "kv cache compression", "apple silicon llm", "on-device llm") to `project.keywords`, plus 2 real Trove classifiers (`Topic :: Software Development :: Libraries`, `Natural Language :: English`). `project.description` untouched.
- **docs-site/docusaurus.config.ts**: appended intent phrases to the existing site-wide keywords meta tag; added a new site-wide `<meta name="description">` tag (Docusaurus's `metadata` top-level config key doesn't exist in this version — used a `headTags` entry instead, matching the existing keywords tag's pattern). `title`/`tagline`/favicon and all existing keyword terms untouched.
- **docs-site/docs/**: added `description` + `keywords` frontmatter to 78 pages — 22 `docs/algorithms/*.md` pages that had zero frontmatter (title copied verbatim from each page's H1, nothing else in the body touched), and 56 pages with existing frontmatter that were missing these two fields (only appended, `id`/`title`/`slug`/`sidebar_label` untouched everywhere).

Every description was written from that page's actual content — verified via built `<head>` output that pages now render distinct per-page descriptions instead of all silently falling back to the site tagline (the bug this fixes: dozens of algorithm pages previously shared one identical, generic search snippet).

**Not done, on purpose**: considered swapping `themeConfig.image` from the favicon to `static/img/docusaurus-social-card.jpg` for a real social-share image, but that file is unmodified Docusaurus template boilerplate (the stock green dinosaur graphic), not project branding — shipping it would make link previews worse, not better. Left as-is; a real social card is a separate follow-up if wanted.

`blog/` was not touched — it already has correct per-post `title`/`description` frontmatter.

## Test plan
- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — TOML still valid
- [x] `npm run build` in `docs-site/` succeeds (only pre-existing, unrelated blog-truncation-marker warnings)
- [x] `git diff` review: `project.description`, `title`, `tagline`, and all existing keyword/classifier/frontmatter values confirmed byte-for-byte unchanged — 0 deletions across all 78 docs files
- [x] Spot-checked built `<head>` for `algorithms/tova`, `algorithms/h2o`, `api/cache`, and the docs homepage — each shows a distinct, page-specific description/keywords meta tag, with the new site-wide description correctly serving as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)