### PR TITLE
feat(landing): add X, LinkedIn, and Discord social links to footer

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -153,6 +153,18 @@ const config: Config = {
               href: 'https://github.com/rajveer43/veloxquant-mlx',
             },
             {
+              label: 'X (Twitter)',
+              href: 'https://x.com/Rajveer13Rathod',
+            },
+            {
+              label: 'LinkedIn',
+              href: 'https://www.linkedin.com/company/veloxquant',
+            },
+            {
+              label: 'Discord',
+              href: 'https://discord.gg/KDGQ9j6C7',
+            },
+            {
               label: 'Issues',
               href: 'https://github.com/rajveer43/veloxquant-mlx/issues',
             },

--- a/landing/assets/styles.css
+++ b/landing/assets/styles.css
@@ -5651,6 +5651,59 @@ details.faq-accordion-item[open] .faq-chevron {
   font-family: var(--font-mono, monospace);
 }
 
+.footer-social-links {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.footer-social-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #a1a1aa;
+  text-decoration: none;
+  transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+
+.footer-social-btn:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.25);
+  transform: translateY(-2px);
+}
+
+.footer-social-btn.footer-social-x:hover {
+  color: #ffffff;
+  border-color: #ffffff;
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.25);
+}
+
+.footer-social-btn.footer-social-linkedin:hover {
+  color: #70b5f9;
+  border-color: #0a66c2;
+  box-shadow: 0 0 12px rgba(10, 102, 194, 0.35);
+}
+
+.footer-social-btn.footer-social-discord:hover {
+  color: #cdd4fc;
+  border-color: #5865f2;
+  box-shadow: 0 0 12px rgba(88, 101, 242, 0.35);
+}
+
+.footer-social-btn.footer-social-github:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 12px rgba(var(--accent-rgb), 0.3);
+}
+
 .footer-col-title {
   font-size: 0.74rem;
   font-weight: 700;
@@ -5822,6 +5875,16 @@ details.faq-accordion-item[open] .faq-chevron {
   background: rgba(0, 0, 0, 0.04);
   border-color: rgba(0, 0, 0, 0.12);
   color: #09090b;
+}
+:root[data-theme="light"] .footer-social-btn {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.1);
+  color: #52525b;
+}
+:root[data-theme="light"] .footer-social-btn:hover {
+  color: #09090b;
+  background: rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.2);
 }
 :root[data-theme="light"] #hero.hero-redesign {
   background: #f8fafc;

--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -29,7 +29,7 @@
   <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
        third-party hop, no render-blocking preconnect. -->
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907c" />
 
   <script type="application/ld+json">
   {

--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -920,6 +920,20 @@
           <div class="footer-brand-title">VeloxQuant-MLX</div>
           <div class="footer-brand-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</div>
           <div class="footer-brand-meta">MIT License</div>
+          <div class="footer-social-links">
+            <a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener" class="footer-social-btn footer-social-github" aria-label="GitHub repository" title="GitHub">
+              <svg class="github-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+            </a>
+            <a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener" class="footer-social-btn footer-social-x" aria-label="Follow on X" title="Follow on X (@Rajveer13Rathod)">
+              <svg class="x-icon" viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener" class="footer-social-btn footer-social-linkedin" aria-label="VeloxQuant on LinkedIn" title="LinkedIn">
+              <svg class="linkedin-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            </a>
+            <a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener" class="footer-social-btn footer-social-discord" aria-label="Join Discord community" title="Discord">
+              <svg class="discord-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.929 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.893.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.028zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+            </a>
+          </div>
         </div>
         <div class="footer-links-col">
           <h4 class="footer-col-title">PRODUCT</h4>
@@ -951,6 +965,8 @@
             <li><a href="https://doi.org/10.5281/zenodo.20647294" target="_blank" rel="noopener">Cite this work (DOI)</a></li>
             <li><a href="https://medium.com/@rajveer.rathod1301" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener">Discord Community</a></li>
+            <li><a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener">X (@Rajveer13Rathod)</a></li>
+            <li><a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener">LinkedIn (VeloxQuant)</a></li>
             <li><a href="https://github.com/rajveer43/VeloxQuant-MLX/issues" target="_blank" rel="noopener">Issues</a></li>
             <li><a href="https://github.com/rajveer43" target="_blank" rel="noopener">Get in touch</a></li>
           </ul>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1271,6 +1271,20 @@
           <div class="footer-brand-title">VeloxQuant-MLX</div>
           <div class="footer-brand-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</div>
           <div class="footer-brand-meta">MIT License</div>
+          <div class="footer-social-links">
+            <a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener" class="footer-social-btn footer-social-github" aria-label="GitHub repository" title="GitHub">
+              <svg class="github-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+            </a>
+            <a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener" class="footer-social-btn footer-social-x" aria-label="Follow on X" title="Follow on X (@Rajveer13Rathod)">
+              <svg class="x-icon" viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener" class="footer-social-btn footer-social-linkedin" aria-label="VeloxQuant on LinkedIn" title="LinkedIn">
+              <svg class="linkedin-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            </a>
+            <a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener" class="footer-social-btn footer-social-discord" aria-label="Join Discord community" title="Discord">
+              <svg class="discord-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.929 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.893.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.028zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+            </a>
+          </div>
         </div>
         <div class="footer-links-col">
           <h4 class="footer-col-title">PRODUCT</h4>
@@ -1302,6 +1316,8 @@
             <li><a href="https://doi.org/10.5281/zenodo.20647294" target="_blank" rel="noopener">Cite this work (DOI)</a></li>
             <li><a href="https://medium.com/@rajveer.rathod1301" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener">Discord Community</a></li>
+            <li><a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener">X (@Rajveer13Rathod)</a></li>
+            <li><a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener">LinkedIn (VeloxQuant)</a></li>
             <li><a href="https://github.com/rajveer43/VeloxQuant-MLX/issues" target="_blank" rel="noopener">Issues</a></li>
             <li><a href="https://github.com/rajveer43" target="_blank" rel="noopener">Get in touch</a></li>
           </ul>

--- a/landing/index.html
+++ b/landing/index.html
@@ -33,7 +33,7 @@
   <meta name="twitter:image:alt" content="VeloxQuant-MLX Metal kernel benchmark summary: compression ratio and speedup charts" />
 
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907c" />
 
   <script type="application/ld+json">
   {

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -29,7 +29,7 @@
   <!-- Fonts are self-hosted in styles.css (assets/fonts/*.woff2) — no
        third-party hop, no render-blocking preconnect. -->
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907c" />
 
   <script type="application/ld+json">
   {

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -90,12 +90,12 @@
         </a>
         <a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener" class="pill-nav-github" aria-label="GitHub repository" title="GitHub Repository">
           <svg class="github-icon" viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-           <span>GITHUB</span>
-         </a>
-         <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
-           <span></span><span></span><span></span>
-         </button>
-       </div>
+          <span>GITHUB</span>
+        </a>
+        <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
     </nav>
   </header>
 
@@ -394,6 +394,20 @@
           <div class="footer-brand-title">VeloxQuant-MLX</div>
           <div class="footer-brand-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</div>
           <div class="footer-brand-meta">MIT License</div>
+          <div class="footer-social-links">
+            <a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener" class="footer-social-btn footer-social-github" aria-label="GitHub repository" title="GitHub">
+              <svg class="github-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+            </a>
+            <a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener" class="footer-social-btn footer-social-x" aria-label="Follow on X" title="Follow on X (@Rajveer13Rathod)">
+              <svg class="x-icon" viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener" class="footer-social-btn footer-social-linkedin" aria-label="VeloxQuant on LinkedIn" title="LinkedIn">
+              <svg class="linkedin-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            </a>
+            <a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener" class="footer-social-btn footer-social-discord" aria-label="Join Discord community" title="Discord">
+              <svg class="discord-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.929 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.893.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.028zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+            </a>
+          </div>
         </div>
         <div class="footer-links-col">
           <h4 class="footer-col-title">PRODUCT</h4>
@@ -425,6 +439,8 @@
             <li><a href="https://doi.org/10.5281/zenodo.20647294" target="_blank" rel="noopener">Cite this work (DOI)</a></li>
             <li><a href="https://medium.com/@rajveer.rathod1301" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener">Discord Community</a></li>
+            <li><a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener">X (@Rajveer13Rathod)</a></li>
+            <li><a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener">LinkedIn (VeloxQuant)</a></li>
             <li><a href="https://github.com/rajveer43/VeloxQuant-MLX/issues" target="_blank" rel="noopener">Issues</a></li>
             <li><a href="https://github.com/rajveer43" target="_blank" rel="noopener">Get in touch</a></li>
           </ul>

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -28,7 +28,7 @@
   <meta name="twitter:image:alt" content="VeloxQuant-MLX Metal kernel benchmark summary: compression ratio and speedup charts" />
 
   <link rel="preload" href="assets/fonts/inter-var.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="assets/styles.css?v=20260907b" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260907c" />
 
   <script type="application/ld+json">
   {

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -223,6 +223,8 @@
       <p>
         Questions, data-deletion requests, or anything else: open an issue on
         <a href="https://github.com/rajveer43/VeloxQuant-MLX/issues" target="_blank" rel="noopener">GitHub</a>,
+        reach out on <a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener">X (@Rajveer13Rathod)</a>
+        or <a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener">LinkedIn</a>,
         or email <a href="mailto:rathodrajveer1311@gmail.com">rathodrajveer1311@gmail.com</a>.
       </p>
     </section>
@@ -236,6 +238,20 @@
           <div class="footer-brand-title">VeloxQuant-MLX</div>
           <div class="footer-brand-tagline">BUILT FOR APPLE SILICON. ENGINEERED FOR SPEED.</div>
           <div class="footer-brand-meta">MIT License</div>
+          <div class="footer-social-links">
+            <a href="https://github.com/rajveer43/VeloxQuant-MLX" target="_blank" rel="noopener" class="footer-social-btn footer-social-github" aria-label="GitHub repository" title="GitHub">
+              <svg class="github-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+            </a>
+            <a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener" class="footer-social-btn footer-social-x" aria-label="Follow on X" title="Follow on X (@Rajveer13Rathod)">
+              <svg class="x-icon" viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener" class="footer-social-btn footer-social-linkedin" aria-label="VeloxQuant on LinkedIn" title="LinkedIn">
+              <svg class="linkedin-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            </a>
+            <a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener" class="footer-social-btn footer-social-discord" aria-label="Join Discord community" title="Discord">
+              <svg class="discord-icon" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.929 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.893.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.028zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+            </a>
+          </div>
         </div>
         <div class="footer-links-col">
           <h4 class="footer-col-title">PRODUCT</h4>
@@ -267,6 +283,8 @@
             <li><a href="https://doi.org/10.5281/zenodo.20647294" target="_blank" rel="noopener">Cite this work (DOI)</a></li>
             <li><a href="https://medium.com/@rajveer.rathod1301" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="https://discord.gg/KDGQ9j6C7" target="_blank" rel="noopener">Discord Community</a></li>
+            <li><a href="https://x.com/Rajveer13Rathod" target="_blank" rel="noopener">X (@Rajveer13Rathod)</a></li>
+            <li><a href="https://www.linkedin.com/company/veloxquant" target="_blank" rel="noopener">LinkedIn (VeloxQuant)</a></li>
             <li><a href="https://github.com/rajveer43/VeloxQuant-MLX/issues" target="_blank" rel="noopener">Issues</a></li>
             <li><a href="privacy.html" class="active" aria-current="page">Privacy Policy</a></li>
             <li><a href="https://github.com/rajveer43" target="_blank" rel="noopener">Get in touch</a></li>


### PR DESCRIPTION
## Summary
- Adds a `.footer-social-links` icon row (GitHub, X, LinkedIn, Discord) to the footer on `index.html`, `playground.html`, `benchmarks.html`, and `privacy.html`, with matching hover styles in `styles.css`.
- Adds matching text links for X and LinkedIn to the existing footer "More" community column on the same four pages (GitHub/Medium/Discord links were already there).
- Mirrors the same X/LinkedIn/Discord links into the docs-site footer's Community column in `docusaurus.config.ts`.
- Bumps `styles.css`'s `?v=` cache-busting query string on all four landing pages, since the new footer classes were added to `styles.css` — `/assets/*` is served with a one-year immutable `Cache-Control` header on Netlify, so skipping this bump would leave the icons unstyled for anyone with the old CSS already cached (this bit us on a previous release, see PR #324).

## Test plan
- [x] `grep` confirms `styles.css?v=20260907c` is consistent across all four landing pages
- [x] Visual review of the diff: new social links use the same icon/link patterns already established elsewhere on the pages (GitHub icon reused verbatim)
- [ ] Recommend a quick look at the deploy preview to confirm the new social icons render and link correctly before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)