### PR TITLE
fix(panel): surface method-discovery failures and validate serve options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "mlx>=0.18",
     "mlx-lm>=0.31.3",
     "numpy>=1.26",
+    "scipy>=1.11",
 ]
 
 [project.optional-dependencies]
@@ -57,7 +58,6 @@ plots = [
 dev = [
     "pytest>=8.0",
     "pytest-xdist",
-    "scipy>=1.11",
     "psutil>=5.9",
     "build>=1.2",
     "twine>=5.0",

--- a/veloxquant_mlx/tests/cache/panel-methods.test.cjs
+++ b/veloxquant_mlx/tests/cache/panel-methods.test.cjs
@@ -1,0 +1,73 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+const source = fs.readFileSync(process.env.PANEL_JS || path.resolve(__dirname, '../../ui/static/panel.js'), 'utf8');
+
+function harness(methods, defaultMethod = 'kivi') {
+  const elements = new Map();
+  const element = () => ({ value: '', innerHTML: '', children: [], appendChild(child) { this.children.push(child); } });
+  const context = vm.createContext({
+    METHODS: [], methodDiscoveryError: null,
+    FIELDS: { model: 'f-model', method: 'f-method' },
+    $: (id) => { if (!elements.has(id)) elements.set(id, element()); return elements.get(id); },
+    document: { createElement: element },
+    api: async () => ({ methods, default_serve_method: defaultMethod }),
+    onMethodChange() {}, renderMethodTable() {}, onHostChange() {}, showError(message) { context.error = message; },
+  });
+  vm.runInContext(source.slice(source.indexOf('function availabilityLabel'), source.indexOf('function onMethodChange')), context);
+  vm.runInContext(source.slice(source.indexOf('function applyConfig'), source.indexOf('/* ── Method knobs')), context);
+  return { context, elements };
+}
+
+test('missing dependency keeps options disabled, clears selection, and exposes repair details', async () => {
+  const { context, elements } = harness([{ name: 'kivi', family: 'quantization', is_servable: false, unsupported_reason: "cache construction failed: ModuleNotFoundError: No module named 'scipy'" }]);
+  await context.loadMethods();
+  context.applyConfig({ method: 'kivi', model: 'test-model' });
+  assert.equal(elements.get('f-method').value, '');
+  const option = elements.get('f-method').children[0].children[0];
+  assert.equal(option.disabled, true);
+  assert.match(option.textContent, /dependency error/);
+  assert.match(context.error, /scipy/);
+  assert.match(context.error, /restart/);
+  assert.equal(elements.get('f-model').value, 'test-model');
+});
+
+test('unsupported saved/default method falls back to a supported option', async () => {
+  const { context, elements } = harness([
+    { name: 'polar', family: 'quantization', is_servable: false },
+    { name: 'kivi', family: 'quantization', is_servable: true },
+    { name: 'snapkv', family: 'eviction', is_servable: true },
+  ], 'polar');
+  await context.loadMethods();
+  context.applyConfig({ method: 'polar' });
+  assert.equal(elements.get('f-method').value, 'kivi');
+  context.applyConfig({ method: 'snapkv' });
+  assert.equal(elements.get('f-method').value, 'snapkv');
+  assert.equal(context.error, null);
+  assert.equal(elements.get('f-method').children[0].children[1].disabled, false);
+  assert.match(elements.get('f-method').children[0].children[0].textContent, /unsupported for serving/);
+});
+
+test('malformed discovery data is rejected instead of interpreted as unsupported', async () => {
+  const { context } = harness([{ name: 'kivi' }]);
+  await assert.rejects(context.loadMethods(), /Invalid method-discovery response/);
+});
+
+test('empty catalog gives an actionable error and no selection', async () => {
+  const { context, elements } = harness([]);
+  await context.loadMethods();
+  assert.equal(elements.get('f-method').value, '');
+  assert.match(context.error, /No serving methods/);
+});
+
+test('status polling cannot clear a discovery error', () => {
+  const { context, elements } = harness([]);
+  context.escapeHtml = (value) => value;
+  vm.runInContext(source.slice(source.indexOf('function showError'), source.indexOf('/* ── Endpoints')), context);
+  context.methodDiscoveryError = 'Missing scipy';
+  context.showError(null);
+  assert.equal(elements.get('error-banner').hidden, false);
+  assert.match(elements.get('error-banner').innerHTML, /Missing scipy/);
+});

--- a/veloxquant_mlx/ui/static/panel.js
+++ b/veloxquant_mlx/ui/static/panel.js
@@ -15,6 +15,7 @@ const FIELDS = {
 };
 
 let METHODS = [];
+let methodDiscoveryError = null;
 let state = 'stopped';
 let logCount = 0;
 let selectedMethod = null;
@@ -91,6 +92,7 @@ function readForm() {
 
 function applyConfig(cfg) {
   for (const [key, id] of Object.entries(FIELDS)) {
+    if (key === 'method' && !METHODS.some((m) => m.name === cfg[key] && m.is_servable)) continue;
     if (cfg[key] !== undefined && cfg[key] !== null) $(id).value = cfg[key];
   }
   onHostChange();
@@ -146,8 +148,18 @@ function readKnobs() {
 }
 
 /* ── Methods (server view dropdown) ────────────────────── */
+function availabilityLabel(m) {
+  if (m.is_servable) return m.serve_tier_label || 'available';
+  if (/ModuleNotFoundError|ImportError/.test(m.unsupported_reason || '')) return 'dependency error';
+  if (/cache construction failed|probe failed/.test(m.unsupported_reason || '')) return 'runtime check failed';
+  return 'unsupported for serving';
+}
+
 async function loadMethods() {
   const data = await api('/api/methods');
+  if (!Array.isArray(data.methods) || data.methods.some((m) => !m || typeof m.name !== 'string' || typeof m.is_servable !== 'boolean')) {
+    throw new Error('Invalid method-discovery response; check the backend package version.');
+  }
   METHODS = data.methods;
 
   const select = $('f-method');
@@ -163,17 +175,27 @@ async function loadMethods() {
       opt.value = m.name;
       // Unsupported methods stay visible but unselectable — hiding five of
       // forty would misrepresent the catalog.
-      opt.textContent = m.is_servable ? m.name : `${m.name} — not available yet`;
+      opt.textContent = m.is_servable ? m.name : `${m.name} — ${availabilityLabel(m)}`;
+      opt.title = m.unsupported_reason || '';
       opt.disabled = !m.is_servable;
       group.appendChild(opt);
     }
     select.appendChild(group);
   }
-  select.value = data.default_serve_method;
+  select.value = METHODS.find((m) => m.name === data.default_serve_method && m.is_servable)?.name
+    || METHODS.find((m) => m.is_servable)?.name || '';
 
   const servable = METHODS.filter((m) => m.is_servable).length;
   $('methods-summary').textContent =
-    `${METHODS.length} methods · ${servable} ready to use · ${METHODS.length - servable} coming soon`;
+    `${METHODS.length} methods · ${servable} ready to use · ${METHODS.length - servable} unavailable`;
+
+  if (!servable) {
+    const reasons = [...new Set(METHODS.map((m) => m.unsupported_reason).filter(Boolean))];
+    methodDiscoveryError = `No serving methods are available. ${reasons.join('; ')} Check dependencies in the Python environment running this panel, then restart the panel to repeat its cached runtime checks.`;
+  } else {
+    methodDiscoveryError = null;
+  }
+  showError(methodDiscoveryError);
 
   onMethodChange();
   renderMethodTable();
@@ -186,13 +208,13 @@ function onMethodChange(knobValues) {
 
   const tierBadge = info.is_servable
     ? '<span class="badge badge-accounting">available</span>'
-    : '<span class="badge badge-unsupported">not available yet</span>';
+    : `<span class="badge badge-unsupported">${escapeHtml(availabilityLabel(info))}</span>`;
 
   let html = `<div class="blurb"><span class="badge badge-family">${info.family}</span>${tierBadge}</div>`
     + `<div class="blurb">${escapeHtml(info.blurb)}</div>`;
 
   if (info.unsupported_reason) {
-    html += `<div class="deviation"><strong>Can't use this one yet.</strong> ${escapeHtml(info.unsupported_reason)}</div>`;
+    html += `<div class="deviation"><strong>Unavailable.</strong> ${escapeHtml(info.unsupported_reason)}</div>`;
   }
   if (info.paper_deviation) {
     html += `<div class="deviation"><strong>Good to know:</strong> ${escapeHtml(info.paper_deviation)}</div>`;
@@ -229,7 +251,7 @@ function renderMethodTable() {
         class="${m.is_servable ? '' : 'is-unsupported'} ${m.name === selectedMethod ? 'is-selected' : ''}">
       <td><span class="method-name">${escapeHtml(m.name)}</span>${m.is_adapted ? ' <span class="badge badge-family">modified</span>' : ''}</td>
       <td>${escapeHtml(m.family)}</td>
-      <td class="${m.is_servable ? 'tier tier-ok' : 'tier tier-no'}">${escapeHtml(m.serve_tier_label)}</td>
+      <td class="${m.is_servable ? 'tier tier-ok' : 'tier tier-no'}">${escapeHtml(availabilityLabel(m))}</td>
       <td class="cov ${m.coverage === 'none' ? 'cov-none' : ''}">${escapeHtml(m.coverage_label)}</td>
     </tr>`).join('');
 
@@ -247,12 +269,12 @@ function selectMethodDetail(name) {
   let html = `<h3>${escapeHtml(m.name)}</h3>
     <div class="detail-row">
       <span class="badge badge-family">${escapeHtml(m.family)}</span>
-      <span class="badge ${m.is_servable ? 'badge-accounting' : 'badge-unsupported'}">${escapeHtml(m.serve_tier_label)}</span>
+      <span class="badge ${m.is_servable ? 'badge-accounting' : 'badge-unsupported'}">${escapeHtml(availabilityLabel(m))}</span>
     </div>
     <p class="detail-blurb">${escapeHtml(m.blurb)}</p>`;
 
   if (m.unsupported_reason) {
-    html += `<div class="deviation"><strong>Not available yet.</strong> ${escapeHtml(m.unsupported_reason)}</div>`;
+    html += `<div class="deviation"><strong>Unavailable.</strong> ${escapeHtml(m.unsupported_reason)}</div>`;
   }
   if (m.paper_deviation) {
     html += `<div class="deviation"><strong>Good to know:</strong> ${escapeHtml(m.paper_deviation)}</div>`;
@@ -385,6 +407,7 @@ function refreshPrimary() {
 }
 
 function showError(message) {
+  message = message || methodDiscoveryError;
   const banner = $('error-banner');
   if (!message) { banner.hidden = true; return; }
   banner.hidden = false;


### PR DESCRIPTION
## Summary
- Move `scipy` from `dev` to core dependencies in `pyproject.toml` — cache construction depends on it at runtime, not just in tests.
- `panel.js` now validates the shape of the `/api/methods` response and refuses to silently treat malformed data as "unsupported".
- Falls back to a servable method when the saved/default selection isn't available (e.g. because a dependency is missing), instead of leaving the dropdown on an unselectable value.
- Shows an actionable error banner with the underlying reason (e.g. missing dependency, failed runtime probe) when no serving methods are available, and labels unavailable methods more specifically (dependency error / runtime check failed / unsupported for serving).

## Test plan
- [x] `node --test veloxquant_mlx/tests/cache/panel-methods.test.cjs` — 5/5 passing
- [x] Manual check in browser: load panel with a method missing a dependency and confirm the error banner + fallback selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)