### PR TITLE
feat(panel): add Hugging Face Hub search to model picker

### DIFF
--- a/veloxquant_mlx/ui/models.py
+++ b/veloxquant_mlx/ui/models.py
@@ -1,8 +1,9 @@
-"""Enumerate already-downloaded models for the panel's model picker.
+"""Model discovery for the panel's model picker: local cache + Hub search.
 
-Surfaces what is already on disk — it never downloads. #33 lists a download
-manager as an explicit non-goal, and this stays on the right side of that line:
-it is autocomplete for the free-text field, not a hub.
+Both `local_models` (already on disk) and `search_hub_models` (Hugging Face
+Hub lookup) only ever surface information — neither downloads anything. #33
+lists a download manager as an explicit non-goal, and this stays on the right
+side of that line: it is autocomplete for the free-text field, not a hub.
 """
 
 from __future__ import annotations
@@ -76,3 +77,49 @@ def _human_size(num_bytes: float) -> str:
             return f"{num_bytes:.0f} {unit}" if unit == "B" else f"{num_bytes:.1f} {unit}"
         num_bytes /= 1024
     return f"{num_bytes:.1f} PB"
+
+
+def search_hub_models(query: str, limit: int = 20) -> List[Dict[str, Any]]:
+    """Search the Hugging Face Hub for text-generation models matching ``query``.
+
+    This is discovery only, same as :func:`local_models` — it never downloads
+    anything. Selecting a result just fills the free-text model field; the
+    existing start-server path handles fetching the weights if needed.
+
+    Returns ``[]`` on any failure (offline, rate-limited, huggingface_hub
+    missing, or an empty/whitespace query) so a flaky network never breaks the
+    panel.
+    """
+    query = query.strip()
+    if not query:
+        return []
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        return []
+
+    try:
+        api = HfApi()
+        results = api.list_models(
+            search=query,
+            filter="text-generation",
+            sort="downloads",
+            limit=limit,
+        )
+
+        models: List[Dict[str, Any]] = []
+        for repo in results:
+            repo_id = repo.id
+            if not _looks_servable(repo_id):
+                continue
+            models.append(
+                {
+                    "repo_id": repo_id,
+                    "downloads": getattr(repo, "downloads", None),
+                    "is_mlx": "mlx-community/" in repo_id.lower(),
+                }
+            )
+        return models
+    except Exception:
+        return []

--- a/veloxquant_mlx/ui/server.py
+++ b/veloxquant_mlx/ui/server.py
@@ -124,6 +124,16 @@ class PanelHandler(BaseHTTPRequestHandler):
             self._send_json({"models": local_models()})
             return
 
+        if route == "/api/models/search":
+            from urllib.parse import parse_qs, urlparse
+
+            from veloxquant_mlx.ui.models import search_hub_models
+
+            qs = parse_qs(urlparse(self.path).query)
+            query = (qs.get("q", [""])[0]).strip()
+            self._send_json({"models": search_hub_models(query) if query else []})
+            return
+
         if route == "/api/memory":
             from veloxquant_mlx.ui.memory import memory_report
 

--- a/veloxquant_mlx/ui/static/index.html
+++ b/veloxquant_mlx/ui/static/index.html
@@ -69,11 +69,11 @@
 
           <section class="card">
             <h2>Model</h2>
-            <div class="field">
+            <div class="field model-field">
               <label for="f-model">Model id or local path</label>
-              <input type="text" id="f-model" list="model-suggestions"
+              <input type="text" id="f-model" autocomplete="off"
                      placeholder="mlx-community/Llama-3.2-1B-Instruct-4bit" />
-              <datalist id="model-suggestions"></datalist>
+              <ul class="model-dropdown" id="model-dropdown" hidden></ul>
               <p class="hint" id="model-hint">Required. Any MLX model id or a path on disk.</p>
             </div>
           </section>

--- a/veloxquant_mlx/ui/static/panel.css
+++ b/veloxquant_mlx/ui/static/panel.css
@@ -232,6 +232,28 @@ code, pre, .mono { font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace
 
 .hint { font-size: 0.76rem; color: var(--muted); margin-top: 0.15rem; }
 
+/* ── Model dropdown ────────────────────────────────────── */
+.model-field { position: relative; }
+.model-dropdown {
+  position: absolute; top: calc(100% + 0.3rem); left: 0; right: 0; z-index: 20;
+  max-height: 280px; overflow-y: auto; margin: 0; padding: 0.3rem;
+  list-style: none; background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; box-shadow: var(--shadow);
+}
+.model-dropdown-group {
+  padding: 0.3rem 0.5rem 0.15rem; font-size: 0.68rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted);
+}
+.model-dropdown-item {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+  padding: 0.45rem 0.5rem; border-radius: 6px; cursor: pointer;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.8rem;
+}
+.model-dropdown-item:hover, .model-dropdown-item.is-active { background: var(--bg); }
+.model-dropdown-item .repo-id { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.model-dropdown-item .repo-meta { flex: 0 0 auto; font-size: 0.7rem; color: var(--muted); }
+.model-dropdown-empty { padding: 0.5rem; font-size: 0.78rem; color: var(--muted); }
+
 /* ── Method info ───────────────────────────────────────── */
 .method-info { margin-top: 0.85rem; font-size: 0.82rem; color: var(--muted); }
 .method-info .blurb { margin-bottom: 0.5rem; }

--- a/veloxquant_mlx/ui/static/panel.js
+++ b/veloxquant_mlx/ui/static/panel.js
@@ -334,17 +334,84 @@ document.querySelectorAll('#family-chips .chip').forEach((chip) => {
 });
 
 /* ── Models ────────────────────────────────────────────── */
+let LOCAL_MODELS = [];
+let hubSearchTimer = null;
+let hubSearchSeq = 0;
+
 async function loadModels() {
   let data;
   try { data = await api('/api/models'); } catch (e) { return; }
-  const list = $('model-suggestions');
-  list.innerHTML = data.models.map(
-    (m) => `<option value="${escapeHtml(m.repo_id)}">${escapeHtml(m.size_label)}</option>`
-  ).join('');
-  if (data.models.length) {
+  LOCAL_MODELS = data.models;
+  if (LOCAL_MODELS.length) {
     $('model-hint').textContent =
-      `Required. ${data.models.length} model(s) found in your local cache — start typing to pick one.`;
+      `Required. ${LOCAL_MODELS.length} model(s) found in your local cache — start typing to pick one, or keep typing to search Hugging Face.`;
   }
+}
+
+function renderModelDropdown(sections) {
+  const box = $('model-dropdown');
+  const nonEmpty = sections.filter((s) => s.items.length);
+  if (!nonEmpty.length) {
+    box.innerHTML = '<li class="model-dropdown-empty">No matches.</li>';
+    box.hidden = false;
+    return;
+  }
+  box.innerHTML = nonEmpty.map((s) => `
+    <li class="model-dropdown-group">${escapeHtml(s.label)}</li>
+    ${s.items.map((m) => `
+      <li class="model-dropdown-item" data-repo="${escapeHtml(m.repo_id)}">
+        <span class="repo-id">${escapeHtml(m.repo_id)}</span>
+        <span class="repo-meta">${escapeHtml(m.meta || '')}</span>
+      </li>`).join('')}
+  `).join('');
+  box.querySelectorAll('.model-dropdown-item').forEach((li) => {
+    // mousedown fires before the input's blur, so the click still lands.
+    li.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      $('f-model').value = li.dataset.repo;
+      hideModelDropdown();
+      refreshPrimary();
+    });
+  });
+  box.hidden = false;
+}
+
+function hideModelDropdown() {
+  $('model-dropdown').hidden = true;
+}
+
+function matchingLocalModels(query) {
+  const q = query.toLowerCase();
+  return LOCAL_MODELS
+    .filter((m) => m.repo_id.toLowerCase().includes(q))
+    .map((m) => ({ repo_id: m.repo_id, meta: m.size_label }));
+}
+
+async function onModelInput() {
+  const query = $('f-model').value.trim();
+  refreshPrimary();
+
+  if (!query) { hideModelDropdown(); return; }
+
+  const local = matchingLocalModels(query);
+  renderModelDropdown([{ label: 'On this Mac', items: local }, { label: 'Hugging Face', items: [] }]);
+
+  clearTimeout(hubSearchTimer);
+  hubSearchTimer = setTimeout(async () => {
+    const seq = ++hubSearchSeq;
+    let data;
+    try { data = await api(`/api/models/search?q=${encodeURIComponent(query)}`); }
+    catch (e) { return; }
+    if (seq !== hubSearchSeq || $('f-model').value.trim() !== query) return; // stale response
+
+    const hub = data.models
+      .filter((m) => !local.some((l) => l.repo_id === m.repo_id))
+      .map((m) => ({
+        repo_id: m.repo_id,
+        meta: m.downloads != null ? `${m.downloads.toLocaleString()} downloads` : '',
+      }));
+    renderModelDropdown([{ label: 'On this Mac', items: local }, { label: 'Hugging Face', items: hub }]);
+  }, 300);
 }
 
 /* ── Memory ────────────────────────────────────────────── */
@@ -577,7 +644,9 @@ $('primary-btn').addEventListener('click', async () => {
 // Wrapped, not passed directly: the listener receives an Event, which
 // renderKnobs would treat as a values object.
 $('f-method').addEventListener('change', () => onMethodChange());
-$('f-model').addEventListener('input', refreshPrimary);
+$('f-model').addEventListener('input', onModelInput);
+$('f-model').addEventListener('focus', () => { if ($('f-model').value.trim()) onModelInput(); });
+$('f-model').addEventListener('blur', () => setTimeout(hideModelDropdown, 120));
 $('f-host').addEventListener('change', onHostChange);
 
 function onHostChange() {


### PR DESCRIPTION
## Summary
- Adds live Hugging Face Hub search to the "Model id or local path" field in the control panel, alongside the existing local-cache autocomplete.
- New backend: `search_hub_models()` in `veloxquant_mlx/ui/models.py` (wraps `HfApi.list_models`, filters to servable text-generation models, fails safe to `[]` on any error) and a new `GET /api/models/search?q=` route in `server.py`.
- Frontend: replaces the native `<datalist>` with a custom dropdown (`panel.js`/`panel.css`/`index.html`) showing "On this Mac" results instantly and "Hugging Face" results after a 300ms debounce, with stale-response guarding.
- Search is discovery only — selecting a Hub result just fills the free-text field; no download is triggered by the picker itself. This keeps scope on the right side of #33's explicit non-goal (no download manager).

## Test plan
- [x] `search_hub_models()` verified against the live Hub API (returns sorted-by-downloads, filtered results; empty query / network failure return `[]`)
- [x] `GET /api/models/search` verified end-to-end against a running `PanelHandler` instance
- [x] Manual browser check: type in the model field, confirm both dropdown sections render and clicking a result fills the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)