### PR TITLE
docs(kernels): correct stale GQA head-packing finding, add eviction/quant benchmarks

### DIFF
--- a/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
+++ b/docs/KV_KERNEL_ROOFLINE_FINDINGS.md
@@ -381,6 +381,136 @@ case `fused_sdpa`'s docstring already names as its own remaining
 rationale) — this is the reference point to revisit, not a closed
 question in principle.
 
+## Addendum: re-measured after nsg autotune (issue #317) — packing verdict is now situational
+
+**The two addenda directly above (#307 pt.2 and #308) were measured with a
+fixed `nsg=2` on both sides of the comparison, before issue #317 added
+`_auto_nsg` and shrank the packed kernel's softmax-merge buffer (`DSLOTS_C`
+sized to `D` instead of a fixed 8 slots, `sh_o` stored as `half` instead of
+`float`).** That change raised the admissible `nsg` for `scalar_fused_decode_
+attend` from 8 to 16 at `heads_per_kv=4`, `D=128` — the same kernel the
+packed/unpacked comparison above times. Re-running the packed-vs-unpacked and
+two-pass-vs-unpacked benchmarks with each variant at its own **production
+`nsg` (`nsg=None`, i.e. whatever `_auto_nsg` actually picks for that shape)**
+instead of a fixed `nsg=2` for everything gives a materially different, and
+more nuanced, picture than either the original addenda or a naive re-run
+using `nsg=2` on both arms would suggest.
+
+**Do not compare this table's numbers to the `nsg=2` tables above directly —
+different nsg on each arm is the entire point of measuring "what production
+actually does," not a discrepancy to be reconciled line-by-line.**
+
+GQA head-packing (packed = one threadgroup per kv-head, `heads_per_kv` query
+heads sharing it; unpacked = one threadgroup per query head, the redundant-
+redecode baseline), Apple M4, `D=128, b=2, g=32`, `nsg` per `_auto_nsg`:
+
+| `(H_q,H_kv)` | `heads_per_kv` | S_kv | nsg (packed) | nsg (unpacked) | packed vs. unpacked |
+|---|---|---|---|---|---|
+| (32,4) | 8 | 512   | 8  | 8  | 0.71-0.90x (slower) |
+| (32,4) | 8 | 2048  | 8  | 8  | 0.79-0.85x (slower) |
+| (32,4) | 8 | 8192  | 8  | 8  | **1.11-1.16x faster** |
+| (32,4) | 8 | 16384 | 8  | 8  | **1.14-1.15x faster** |
+| (32,8) | 4 | 512   | 16 | 8  | 0.36-0.44x (slower) |
+| (32,8) | 4 | 2048  | 16 | 8  | 0.40-0.46x (slower) |
+| (32,8) | 4 | 8192  | 16 | 8  | 0.53-0.57x (slower) |
+| (32,8) | 4 | 16384 | 16 | 8  | 0.51-0.53x (slower) |
+| (8,2)  | 4 | 512   | 16 | 32 | 0.86-0.91x (slower) |
+| (8,2)  | 4 | 2048  | 16 | 32 | **1.09-1.22x faster** |
+| (8,2)  | 4 | 8192  | 16 | 32 | **1.48-1.50x faster** |
+| (8,2)  | 4 | 16384 | 16 | 32 | **1.68-1.70x faster** |
+
+Each row is a range across 3 repeated runs of the same shape (independent
+process each time, not just repeated calls within one run) — single-run
+point estimates on this kernel are noisy enough near the 1.0x crossover to
+flip sign row-to-row (e.g. a single run put (32,4)@512 at "1.17x faster";
+three runs show it's actually consistently 0.7-0.9x, i.e. slower). Report
+a range or re-run before trusting any single measurement close to 1.0x.
+
+**Revised conclusion: head-packing is no longer a uniform rejection — it is
+shape-dependent, and the shape that matters is `heads_per_kv` together with
+S_kv, not `H_q` or `S_kv` alone.** At `heads_per_kv=8` ((32,4)) or
+`heads_per_kv=4` with few kv-heads ((8,2)), packing now wins past a
+per-ratio S_kv crossover (~4000-8000 for (32,4), ~2048 for (8,2)) once the
+merge-buffer shrink lets those shapes reach a wide `nsg` — but still loses
+at short context, where the reduced threadgroup count isn't yet offset by
+the byte-traffic savings. At `heads_per_kv=4` with more kv-heads ((32,8),
+which still dispatches only `H_kv=4` threadgroups when packed vs. `H_q=32`
+unpacked — the largest relative threadgroup-count loss of the three ratios
+tested), packing is a clear loss at every S_kv tested, consistent with this
+document's original occupancy diagnosis. **This is not evidence the original
+occupancy analysis was wrong — occupancy is still the dominant lever, and
+(32,8) still proves it. It is evidence that "does packing help" depends on
+exactly how few threadgroups packing leaves you with, which #317 changed
+for some ratios (by admitting a wider `nsg`) without changing it for others
+in the same direction.**
+
+Two-pass decode-once vs. unpacked-redundant, same shapes, `nsg` per
+`_auto_nsg` for the unpacked arm (capped at 16 for `scalar_predecoded_attend`
+— see caveat below):
+
+| `(H_q,H_kv)` | S_kv | two-pass vs. unpacked |
+|---|---|---|
+| (32,4) | 256   | **2.20-2.43x faster** |
+| (32,4) | 1024  | **1.62-1.65x faster** |
+| (32,4) | 2048  | **1.37-1.41x faster** |
+| (32,4) | 3072  | **1.11-1.24x faster** |
+| (32,4) | 4096  | **1.05-1.15x faster** |
+| (32,4) | 8192  | 0.97-1.00x (roughly even) |
+| (32,4) | 16384 | 1.00-1.06x (roughly even) |
+| (32,8) | 256   | **2.09-2.21x faster** |
+| (32,8) | 1024  | **1.28-1.44x faster** |
+| (32,8) | 2048  | **1.08-1.12x faster** |
+| (32,8) | 3072  | 0.96-0.99x (roughly even, trending slower) |
+| (32,8) | 4096  | 0.90-0.94x (slower) |
+| (32,8) | 8192  | 0.86-0.90x (slower) |
+| (32,8) | 16384 | 0.84x (slower) |
+| (8,2)  | 256   | 0.90-1.38x (noisy, near crossover) |
+| (8,2)  | 1024  | **1.14-1.24x faster** |
+| (8,2)  | 2048  | 0.99-1.01x (even) |
+| (8,2)  | 3072  | 0.75-0.86x (slower) |
+| (8,2)  | 4096  | 0.68-0.71x (slower) |
+| (8,2)  | 8192  | 0.63-0.65x (slower) |
+| (8,2)  | 16384 | 0.58-0.59x (slower) |
+
+**Revised conclusion: the short-context-wins / long-context-loses crossover
+described in the #308 addendum still holds directionally, but the crossover
+point is per-ratio, not a single "~S_kv 2048-3072" figure** — it sits around
+S_kv≈4000-8000 for `(32,4)`, S_kv≈2500-3000 for `(32,8)`, and S_kv≈1500-2000
+for `(8,2)`. The disposition (not adopted; realistic decode targets sit past
+the crossover for the ratios this repo actually serves) is unchanged. The
+`(8,2)@256` row's wide 0.90-1.38x range (rather than a tight band like every
+other row) is a genuine measurement caveat, not a typo — it sits close
+enough to a 1.0x crossover for the smallest S_kv tested at this ratio that
+run-to-run scheduling noise flips which side of "faster" it lands on; a
+larger `iters` count or more repeats would be needed to pin it down, and it
+doesn't change the disposition either way since this ratio's realistic
+targets are far past its crossover anyway.
+
+**A separate bug found while re-measuring, not a benchmark-methodology
+issue:** `scalar_predecoded_attend` never received the `DSLOTS_C`/half-buffer
+shrink #317 applied to the packed kernel — its `sh_o` merge buffer is a fixed
+`NSG * 8 * 32` `float` array
+(`veloxquant_mlx/metal/src/scalar_predecoded_attend.metal:73`) regardless of
+`D`, and unlike `scalar_fused_decode_attend` it performs **no
+threadgroup-memory budget check before dispatch**
+(`veloxquant_mlx/metal/_scalar_attend.py:659-729`). Calling it with `nsg=32`
+does not raise a clean `ValueError` the way the packed kernel does for an
+oversized request — it crashes at the Metal-compiler level
+(`RuntimeError: Threadgroup memory size (33024) exceeds the maximum
+threadgroup memory allowed (32768)`). The two-pass table above caps
+`nsg` at 16 for this kernel to work around it; 31 is the actual ceiling
+its current buffer layout allows. Filed as a follow-up (not fixed as part of
+this re-measurement) — this document keeps to the original scope of "what
+limits these kernels," and a missing input-validation check is a distinct,
+smaller class of issue from the occupancy findings above.
+
+Reproduction: `python scripts/kv_kernel_gqa_packing_recheck.py` reproduces
+the tables above (see that script's docstring for the exact `nsg=None`
+methodology); the original #307pt.2/#308 addenda's `nsg=2`-fixed tables
+remain reproducible via the commands cited in those sections and are kept
+in this document as a record of what was measured at the time, not
+retracted.
+
 ## Addendum: cross-layer batched decode-attend dispatch (issue #307, part 1)
 
 This closes the one lever Recommendation #2 (below) named as unblocked and

--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -139,6 +139,7 @@
         <!-- Sticky / Segmented Section Quick Navigation -->
         <nav class="bench-nav" aria-label="Benchmark categories">
           <a href="#metal" class="bench-nav-pill active">⚡ Metal GPU Speedup</a>
+          <a href="#eviction-quant-kernels" class="bench-nav-pill">🗜️ Eviction &amp; Quant Kernels</a>
           <a href="#kernel-roofline" class="bench-nav-pill">🧩 Decode Occupancy</a>
           <a href="#kivi-matrix" class="bench-nav-pill">🧠 12-Model Safety Matrix</a>
           <a href="#qfilters-scorer" class="bench-nav-pill">🎯 Attention Correlation</a>
@@ -286,6 +287,102 @@
               </div>
             </div>
           </div>
+        </div>
+      </section>
+
+      <!-- ── SECTION: EVICTION & QUANTIZATION KERNELS ── -->
+      <section id="eviction-quant-kernels" class="bench-section">
+        <div class="bench-section-header">
+          <span class="bench-section-tag">01.5 · Fused Metal Kernels</span>
+          <h2 class="bench-section-title">Eviction &amp; Quantization Kernels vs. Pure MLX</h2>
+          <p class="bench-section-subtitle">
+            Fused Metal kernels for the H2O / Keyformer eviction scoring loop and the KIVI / RVQ quantize+pack path, measured against the equivalent pure-MLX implementation on the same Apple M4. Each speedup is a range across repeated runs (median of interleaved samples per run) rather than a single reading — these are small, fast kernels where run-to-run scheduling noise is visible at larger sizes.
+          </p>
+        </div>
+
+        <div class="bench-card">
+          <div class="bench-card-head">
+            <span class="bench-card-title">Eviction Scoring: Python Loop vs. Fused Metal Kernel</span>
+            <span class="bench-badge-chip">n_kept=512, D=128 · Apple M4</span>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Kernel</th>
+                  <th>Python loop</th>
+                  <th>Fused Metal</th>
+                  <th>Speedup</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>H2O fused eviction</td>
+                  <td class="td-muted">~0.60–0.69 ms/call</td>
+                  <td class="td-winner">~0.28–0.42 ms/call</td>
+                  <td class="td-winner">1.65×–2.42×</td>
+                </tr>
+                <tr>
+                  <td>Keyformer fused eviction</td>
+                  <td class="td-muted">~0.72–0.89 ms/call</td>
+                  <td class="td-winner">~0.28–0.33 ms/call</td>
+                  <td class="td-winner">2.45×–2.69×</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="gap-footnote">Reproduce: <code>pytest veloxquant_mlx/tests/metal/test_h2o_evict.py veloxquant_mlx/tests/metal/test_keyformer_evict.py -k benchmark -s</code>. Both eviction paths replace a per-token Python score-and-compact loop with a single fused dispatch.</p>
+        </div>
+
+        <div class="bench-card" style="margin-top: 1.5rem;">
+          <div class="bench-card-head">
+            <span class="bench-card-title">KIVI Group-Affine Quantization: MLX vs. Fused Metal</span>
+            <span class="bench-badge-chip">B=1 H=8 D=128 b=2 g=32 · Apple M4</span>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>S</th>
+                  <th>Scheme</th>
+                  <th>Speedup</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>32</td><td class="td-muted">keys (per-channel)</td><td class="td-winner">1.30×–1.35×</td></tr>
+                <tr><td>32</td><td class="td-muted">values (per-token)</td><td class="td-winner">1.47×–1.50×</td></tr>
+                <tr><td>512</td><td class="td-muted">keys (per-channel)</td><td class="td-winner">2.05×–2.12×</td></tr>
+                <tr><td>512</td><td class="td-muted">values (per-token)</td><td class="td-winner">1.65×–1.71×</td></tr>
+                <tr><td>2048</td><td class="td-muted">keys (per-channel)</td><td class="td-winner">4.30×–4.34× typical, up to 6.4× in one noisy run</td></tr>
+                <tr><td>2048</td><td class="td-muted">values (per-token)</td><td class="td-winner">2.85×–3.66× typical, up to 4.9× in one noisy run</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="gap-footnote">Medians of interleaved samples over a rotating input pool. The win grows with block size — these kernels replace several full-size MLX intermediates with one pass, so they scale with bytes moved. Prefill (one large group-aligned flush) is where this matters; decode flushes only <code>group_size</code> tokens at a time. Reproduce: <code>pytest veloxquant_mlx/tests/metal/test_kivi_quant.py -k benchmark -s</code>.</p>
+        </div>
+
+        <div class="bench-card" style="margin-top: 1.5rem;">
+          <div class="bench-card-head">
+            <span class="bench-card-title">RVQ Quantize+Pack: MLX vs. Fused Metal</span>
+            <span class="bench-badge-chip">D=128, bits=2 · Apple M4</span>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>N</th>
+                  <th>Speedup</th>
+                  <th>Fused GB/s (nominal)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>64</td><td class="td-winner">1.34×–1.80×</td><td class="td-muted">0.09–0.14 GB/s</td></tr>
+                <tr><td>1,024</td><td class="td-winner">1.46×–1.81×</td><td class="td-muted">1.14–2.26 GB/s</td></tr>
+                <tr><td>8,192</td><td class="td-winner">2.38×–2.40× typical, one 1.31× low outlier</td><td class="td-muted">2.65–7.18 GB/s</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="gap-footnote">GB/s is nominal traffic (input read once + packed streams written), not a hardware counter; the MLX baseline additionally charges the two full-size uint8 index intermediates the fused kernel never materializes. Reproduce: <code>pytest veloxquant_mlx/tests/metal/test_rvq_quant_pack.py -k benchmark -s</code>.</p>
         </div>
       </section>
 
@@ -442,12 +539,12 @@
               <tbody>
                 <tr>
                   <td>GQA head-packing (share K/V decode across query heads)</td>
-                  <td class="td-hot">2.7×–4.7× slower</td>
-                  <td class="td-muted">Reduces threadgroup count, which is the actual bottleneck — kept as tested code, not the default.</td>
+                  <td>Depends on <code>heads_per_kv</code> and S_kv — re-measured after a later occupancy fix changed the picture. <span class="td-hot">0.4×–0.9× (slower)</span> at <code>heads_per_kv=4-8</code> and short context, but <span class="td-winner">1.1×–1.7× faster</span> at <code>heads_per_kv=4</code> with few kv-heads or long context.</td>
+                  <td class="td-muted">No longer a uniform rejection, but still situational and not adopted as the default — see the doc for the full per-ratio breakdown.</td>
                 </tr>
                 <tr>
                   <td>Two-pass "decode-once" (separate decode + attend kernels)</td>
-                  <td><span class="td-winner">1.1×–3.2× faster</span> at S_kv≤2048, <span class="td-hot">0.80×–0.85× (slower)</span> at S_kv≥3072</td>
+                  <td><span class="td-winner">1.1×–2.4× faster</span> at short context, <span class="td-hot">0.6×–0.9× (slower)</span> at long context — exact crossover point shifts per head ratio (S_kv≈1.5k–8k)</td>
                   <td class="td-muted">Real crossover, but this project's realistic decode targets sit past it — not adopted as the default.</td>
                 </tr>
                 <tr>
@@ -458,6 +555,10 @@
               </tbody>
             </table>
           </div>
+          <p class="gap-footnote">
+            The head-packing numbers above were revised after this table's original measurement (before issue #317's occupancy fix changed the packed kernel's threadgroup-memory footprint) turned out to be superseded, not simply wrong — full re-measurement and methodology →
+            <a href="https://github.com/rajveer43/VeloxQuant-MLX/blob/master/docs/KV_KERNEL_ROOFLINE_FINDINGS.md#addendum-re-measured-after-nsg-autotune-issue-317--packing-verdict-is-now-situational" target="_blank" rel="noopener">re-measured after nsg autotune addendum</a>.
+          </p>
         </div>
 
         <!-- Reproduce command terminal box -->

--- a/scripts/kv_kernel_gqa_packing_recheck.py
+++ b/scripts/kv_kernel_gqa_packing_recheck.py
@@ -17,13 +17,18 @@ addenda's headline tables used. See the "re-measured after nsg autotune
 
 Usage: python scripts/kv_kernel_gqa_packing_recheck.py
 """
+
 import math
 import time
 
 import mlx.core as mx
 import numpy as np
 
-from veloxquant_mlx.metal._scalar_attend import _auto_nsg, scalar_decode_once, scalar_predecoded_attend
+from veloxquant_mlx.metal._scalar_attend import (
+    _auto_nsg,
+    scalar_decode_once,
+    scalar_predecoded_attend,
+)
 from veloxquant_mlx.metal.kernels import scalar_fused_decode_attend
 
 
@@ -88,7 +93,9 @@ scale = 1.0 / math.sqrt(D)
 
 print(f"MLX {mx.__version__}\n")
 print("## GQA head-packing: packed (nsg=None, auto) vs. unpacked-redundant (nsg=None, auto)\n")
-print("| H_q,H_kv | heads_per_kv | S_kv | nsg(packed) | nsg(unpacked) | packed ms | unpacked ms | packed vs unpacked |")
+print(
+    "| H_q,H_kv | heads_per_kv | S_kv | nsg(packed) | nsg(unpacked) | packed ms | unpacked ms | packed vs unpacked |"
+)
 print("|---|---|---|---|---|---|---|---|")
 
 for H_q, H_kv in [(32, 4), (32, 8), (8, 2)]:
@@ -111,18 +118,29 @@ for H_q, H_kv in [(32, 4), (32, 8), (8, 2)]:
                     hq = hkv * heads_per_kv + hp
                     outs.append(
                         scalar_fused_decode_attend(
-                            aq[:, hq : hq + 1], akc[:, hkv : hkv + 1], aks[:, hkv : hkv + 1],
-                            akz[:, hkv : hkv + 1], avc[:, hkv : hkv + 1], avs[:, hkv : hkv + 1],
-                            avz[:, hkv : hkv + 1], g, scale, nsg=None,
+                            aq[:, hq : hq + 1],
+                            akc[:, hkv : hkv + 1],
+                            aks[:, hkv : hkv + 1],
+                            akz[:, hkv : hkv + 1],
+                            avc[:, hkv : hkv + 1],
+                            avs[:, hkv : hkv + 1],
+                            avz[:, hkv : hkv + 1],
+                            g,
+                            scale,
+                            nsg=None,
                         )
                     )
             return mx.concatenate(outs, axis=1)
 
         tp = _timeit(_packed)
         tu = _timeit(_unpacked)
-        print(f"| ({H_q},{H_kv}) | {heads_per_kv} | {S_kv} | {nsg_packed} | {nsg_unpacked} | {tp:.3f} | {tu:.3f} | {tp/tu:.2f}x |")
+        print(
+            f"| ({H_q},{H_kv}) | {heads_per_kv} | {S_kv} | {nsg_packed} | {nsg_unpacked} | {tp:.3f} | {tu:.3f} | {tp / tu:.2f}x |"
+        )
 
-print("\n## Two-pass decode-once vs. unpacked-redundant (nsg=None, auto for unpacked; decode/attend also nsg=None)\n")
+print(
+    "\n## Two-pass decode-once vs. unpacked-redundant (nsg=None, auto for unpacked; decode/attend also nsg=None)\n"
+)
 print("| H_q,H_kv | S_kv | unpacked ms | two-pass ms | two-pass vs unpacked |")
 print("|---|---|---|---|---|")
 
@@ -140,9 +158,16 @@ for H_q, H_kv in [(32, 4), (32, 8), (8, 2)]:
                     hq = hkv * heads_per_kv + hp
                     outs.append(
                         scalar_fused_decode_attend(
-                            aq[:, hq : hq + 1], akc[:, hkv : hkv + 1], aks[:, hkv : hkv + 1],
-                            akz[:, hkv : hkv + 1], avc[:, hkv : hkv + 1], avs[:, hkv : hkv + 1],
-                            avz[:, hkv : hkv + 1], g, scale, nsg=None,
+                            aq[:, hq : hq + 1],
+                            akc[:, hkv : hkv + 1],
+                            aks[:, hkv : hkv + 1],
+                            akz[:, hkv : hkv + 1],
+                            avc[:, hkv : hkv + 1],
+                            avs[:, hkv : hkv + 1],
+                            avz[:, hkv : hkv + 1],
+                            g,
+                            scale,
+                            nsg=None,
                         )
                     )
             return mx.concatenate(outs, axis=1)
@@ -162,4 +187,4 @@ for H_q, H_kv in [(32, 4), (32, 8), (8, 2)]:
 
         tu = _timeit(_unpacked)
         tt = _timeit(_two_pass)
-        print(f"| ({H_q},{H_kv}) | {S_kv} | {tu:.3f} | {tt:.3f} | {tu/tt:.2f}x |")
+        print(f"| ({H_q},{H_kv}) | {S_kv} | {tu:.3f} | {tt:.3f} | {tu / tt:.2f}x |")

--- a/scripts/kv_kernel_gqa_packing_recheck.py
+++ b/scripts/kv_kernel_gqa_packing_recheck.py
@@ -1,0 +1,165 @@
+"""Re-measure GQA head-packing and two-pass decode after issue #317 (nsg autotune).
+
+docs/KV_KERNEL_ROOFLINE_FINDINGS.md's #307pt.2 and #308 addenda measured
+GQA head-packing and the two-pass decode-once design with a fixed nsg=2 on
+every variant. Issue #317 (`_auto_nsg`) later shrank the packed kernel's
+threadgroup-memory footprint, raising the nsg it can admit — a change those
+two addenda's `nsg=2`-fixed comparisons never got re-run against, and one
+that (per this script's own output) does not just uniformly flip the sign;
+it depends on `heads_per_kv`.
+
+This script uses each variant's own production nsg (`nsg=None`, i.e. what
+`_auto_nsg` actually picks for that shape) and sweeps all three head ratios
+`docs/KV_KERNEL_ROOFLINE_FINDINGS.md` originally tested
+(`(H_q,H_kv) ∈ {(32,4), (32,8), (8,2)}`), not just the one ratio those
+addenda's headline tables used. See the "re-measured after nsg autotune
+(issue #317)" addendum in that doc for the results and their interpretation.
+
+Usage: python scripts/kv_kernel_gqa_packing_recheck.py
+"""
+import math
+import time
+
+import mlx.core as mx
+import numpy as np
+
+from veloxquant_mlx.metal._scalar_attend import _auto_nsg, scalar_decode_once, scalar_predecoded_attend
+from veloxquant_mlx.metal.kernels import scalar_fused_decode_attend
+
+
+def _quant_keys(k, g, levels, eps=1e-8):
+    B, H, S, D = k.shape
+    GK = (S + g - 1) // g
+    pad = GK * g - S
+    x = k.astype(np.float32)
+    if pad:
+        x = np.concatenate([x, np.broadcast_to(x[:, :, -1:, :], (B, H, pad, D))], axis=2)
+    xg = x.reshape(B, H, GK, g, D)
+    gmin = xg.min(axis=3, keepdims=True)
+    gmax = xg.max(axis=3, keepdims=True)
+    scale = np.maximum((gmax - gmin) / levels, eps)
+    codes = np.clip(np.round((xg - gmin) / scale), 0, levels)
+    codes = codes.reshape(B, H, GK * g, D)[:, :, :S, :].astype(np.uint8)
+    return codes, scale.reshape(B, H, GK, D), gmin.reshape(B, H, GK, D)
+
+
+def _quant_values(v, g, levels, eps=1e-8):
+    B, H, S, D = v.shape
+    GV = (D + g - 1) // g
+    pad = GV * g - D
+    x = v.astype(np.float32)
+    if pad:
+        x = np.concatenate([x, np.broadcast_to(x[:, :, :, -1:], (B, H, S, pad))], axis=3)
+    xg = x.reshape(B, H, S, GV, g)
+    gmin = xg.min(axis=4, keepdims=True)
+    gmax = xg.max(axis=4, keepdims=True)
+    scale = np.maximum((gmax - gmin) / levels, eps)
+    codes = np.clip(np.round((xg - gmin) / scale), 0, levels)
+    codes = codes.reshape(B, H, S, GV * g)[:, :, :, :D].astype(np.uint8)
+    return codes, scale.reshape(B, H, S, GV), gmin.reshape(B, H, S, GV)
+
+
+def _make_inputs(B, H, S_kv, D, b, g, seed=0, H_kv=None):
+    if H_kv is None:
+        H_kv = H
+    rng = np.random.default_rng(seed)
+    levels = (1 << b) - 1
+    q = rng.standard_normal((B, H, 1, D)).astype(np.float16)
+    kf = rng.standard_normal((B, H_kv, S_kv, D)).astype(np.float32)
+    vf = rng.standard_normal((B, H_kv, S_kv, D)).astype(np.float32)
+    kc, ks, kz = _quant_keys(kf, g, levels)
+    vc, vs, vz = _quant_values(vf, g, levels)
+    return q, kc, ks, kz, vc, vs, vz
+
+
+def _timeit(fn, iters=20, warmup=10):
+    for _ in range(warmup):
+        mx.eval(fn())
+    mx.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        mx.eval(fn())
+    mx.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+D, b, g = 128, 2, 32
+scale = 1.0 / math.sqrt(D)
+
+print(f"MLX {mx.__version__}\n")
+print("## GQA head-packing: packed (nsg=None, auto) vs. unpacked-redundant (nsg=None, auto)\n")
+print("| H_q,H_kv | heads_per_kv | S_kv | nsg(packed) | nsg(unpacked) | packed ms | unpacked ms | packed vs unpacked |")
+print("|---|---|---|---|---|---|---|---|")
+
+for H_q, H_kv in [(32, 4), (32, 8), (8, 2)]:
+    heads_per_kv = H_q // H_kv
+    for S_kv in [512, 2048, 8192, 16384]:
+        q, kc, ks, kz, vc, vs, vz = _make_inputs(1, H_q, S_kv, D, b, g, H_kv=H_kv)
+        aq, akc, aks, akz, avc, avs, avz = [mx.array(x) for x in (q, kc, ks, kz, vc, vs, vz)]
+        mx.eval(aq, akc, aks, akz, avc, avs, avz)
+
+        nsg_packed = _auto_nsg(D, heads_per_kv, n_tg=H_kv)
+        nsg_unpacked = _auto_nsg(D, 1, n_tg=H_q)
+
+        def _packed():
+            return scalar_fused_decode_attend(aq, akc, aks, akz, avc, avs, avz, g, scale, nsg=None)
+
+        def _unpacked():
+            outs = []
+            for hkv in range(H_kv):
+                for hp in range(heads_per_kv):
+                    hq = hkv * heads_per_kv + hp
+                    outs.append(
+                        scalar_fused_decode_attend(
+                            aq[:, hq : hq + 1], akc[:, hkv : hkv + 1], aks[:, hkv : hkv + 1],
+                            akz[:, hkv : hkv + 1], avc[:, hkv : hkv + 1], avs[:, hkv : hkv + 1],
+                            avz[:, hkv : hkv + 1], g, scale, nsg=None,
+                        )
+                    )
+            return mx.concatenate(outs, axis=1)
+
+        tp = _timeit(_packed)
+        tu = _timeit(_unpacked)
+        print(f"| ({H_q},{H_kv}) | {heads_per_kv} | {S_kv} | {nsg_packed} | {nsg_unpacked} | {tp:.3f} | {tu:.3f} | {tp/tu:.2f}x |")
+
+print("\n## Two-pass decode-once vs. unpacked-redundant (nsg=None, auto for unpacked; decode/attend also nsg=None)\n")
+print("| H_q,H_kv | S_kv | unpacked ms | two-pass ms | two-pass vs unpacked |")
+print("|---|---|---|---|---|")
+
+for H_q, H_kv in [(32, 4), (32, 8), (8, 2)]:
+    heads_per_kv = H_q // H_kv
+    for S_kv in [256, 1024, 2048, 3072, 4096, 8192, 16384]:
+        q, kc, ks, kz, vc, vs, vz = _make_inputs(1, H_q, S_kv, D, b, g, H_kv=H_kv)
+        aq, akc, aks, akz, avc, avs, avz = [mx.array(x) for x in (q, kc, ks, kz, vc, vs, vz)]
+        mx.eval(aq, akc, aks, akz, avc, avs, avz)
+
+        def _unpacked():
+            outs = []
+            for hkv in range(H_kv):
+                for hp in range(heads_per_kv):
+                    hq = hkv * heads_per_kv + hp
+                    outs.append(
+                        scalar_fused_decode_attend(
+                            aq[:, hq : hq + 1], akc[:, hkv : hkv + 1], aks[:, hkv : hkv + 1],
+                            akz[:, hkv : hkv + 1], avc[:, hkv : hkv + 1], avs[:, hkv : hkv + 1],
+                            avz[:, hkv : hkv + 1], g, scale, nsg=None,
+                        )
+                    )
+            return mx.concatenate(outs, axis=1)
+
+        # scalar_predecoded_attend has its own (unoptimized, fixed 8-D-slot fp32
+        # sh_o) threadgroup-memory layout distinct from the packed kernel's, and
+        # performs no budget check before dispatch -- nsg=32 silently overflows
+        # 32KB and crashes at the Metal-compiler level. Cap at 16, which fits
+        # (16*8*32*4 + 16*4*2 = 16512B) and matches the widest nsg _auto_nsg
+        # picks for these shapes elsewhere in this sweep.
+        nsg_attend = min(_auto_nsg(D, 1, n_tg=H_q), 16)
+
+        def _two_pass():
+            k_hat = scalar_decode_once(akc, aks, akz, g, mode="K")
+            v_hat = scalar_decode_once(avc, avs, avz, g, mode="V")
+            return scalar_predecoded_attend(aq, k_hat, v_hat, scale, nsg=nsg_attend)
+
+        tu = _timeit(_unpacked)
+        tt = _timeit(_two_pass)
+        print(f"| ({H_q},{H_kv}) | {S_kv} | {tu:.3f} | {tt:.3f} | {tu/tt:.2f}x |")


### PR DESCRIPTION
## Summary

**Correction:** `docs/KV_KERNEL_ROOFLINE_FINDINGS.md`'s GQA head-packing (#307pt.2) and two-pass decode-once (#308) addenda were measured with a fixed `nsg=2` on both arms, before issue #317's nsg-autotune fix changed the packed kernel's threadgroup-memory footprint (smaller merge buffer → wider admissible `nsg`). The doc was never re-run after that change, so its "head-packing is 2.7×–4.7× slower, always" conclusion was stale rather than currently true.

Re-ran both benchmarks using each variant's actual production `nsg` (`nsg=None` → `_auto_nsg`), across all three head ratios the original doc tested, averaged over multiple runs to separate real signal from scheduling noise near the 1.0x crossover (a single run can and did flip sign on some rows). Result: the verdict is no longer a uniform rejection — it's shape-dependent:
- `(H_q,H_kv)=(32,4)`, `(8,2)`: packing now wins past a per-ratio S_kv crossover
- `(32,8)`: packing is still a clear loss at every S_kv tested — the original occupancy diagnosis was correct, just not uniformly applicable across ratios

Added a new doc addendum with the corrected tables + methodology, synced the landing page's "Also Measured, Not Adopted" table to match, and added `scripts/kv_kernel_gqa_packing_recheck.py` as the reproducible source of these numbers.

Also flagged (not fixed — separate scope) a bug found while re-measuring: `scalar_predecoded_attend` has no threadgroup-memory budget check and crashes at `nsg=32` instead of raising a clean `ValueError` the way the packed kernel does.

**Landing page additions:** benchmark cards for four fused Metal kernels not previously shown on `/benchmarks` — H2O/Keyformer eviction scoring and KIVI/RVQ quantize+pack — reported as ranges across repeated runs rather than single readings, for the same noise-honesty reason as the GQA correction above.

## Test plan
- [x] All four new benchmark numbers independently re-run 3-5x each on this Apple M4, ranges reflect actual observed spread
- [x] GQA/two-pass re-measurement cross-checked against 3 independent runs before writing the doc table
- [x] `scripts/kv_kernel_gqa_packing_recheck.py` runs standalone and reproduces the doc's tables
- [x] `landing/benchmarks.html` verified well-formed (balanced tags) and serves correctly from a local static server
- [ ] Manual visual check of the new `#eviction-quant-kernels` section and updated roofline table in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)