### PR TITLE
feat: add MLX Metal worker protocol

### DIFF
--- a/docs-site/docs/getting-started/architecture.md
+++ b/docs-site/docs/getting-started/architecture.md
@@ -1,0 +1,279 @@
+---
+id: architecture
+title: System Architecture
+sidebar_label: Architecture
+slug: /getting-started/architecture
+description: End-to-end architecture of VeloxQuant-MLX, its MLX and Metal kernel layers, Python worker protocol, and JavaScript SDK integration.
+keywords: [architecture, MLX, Metal, Python worker, TypeScript SDK, KV cache]
+---
+
+# System Architecture
+
+VeloxQuant-MLX is a Python/MLX runtime for compressing transformer KV caches on Apple Silicon. The JavaScript SDK is an orchestration layer around that runtime. This page explains how the pieces fit together, where tensors live, how Metal kernels are dispatched, and which boundaries are intentionally kept stable.
+
+## System overview
+
+```text
+Application
+  ├── Python API: KVCacheBuilder / mlx_lm integration
+  ├── TypeScript API: @veloxquant/sdk
+  │       │
+  │       └── JSON-lines worker + .npy tensor transport
+  │                    │
+  └────────────────────┘
+                       ▼
+              veloxquant_mlx worker
+                       │
+             MLX tensors and cache objects
+                       │
+                mx.fast.metal_kernel
+                       │
+                    Apple GPU
+```
+
+The Python package remains the source of truth for tensor execution, cache semantics, model compatibility, and Metal dispatch. The npm package does not reimplement MLX or compile arbitrary Metal source.
+
+## Runtime layers
+
+### 1. User and framework layer
+
+Users can call the Python API directly, use the command line, launch the control panel, or use the npm SDK from Node.js.
+
+Relevant entry points:
+
+- [Quickstart](./quickstart)
+- [Python API reference](../api/core-api)
+- [CLI and installation](./installation)
+- [Control panel guide](../guides/control-panel)
+- [JavaScript SDK](https://github.com/rajveer43/veloxquant-sdk)
+
+### 2. Model integration layer
+
+The model integration layer connects VeloxQuant caches to `mlx_lm` model generation. `KVCacheBuilder` creates per-layer cache instances from a `KVCacheConfig`. The cache contract is designed to match the `mlx_lm` cache interface so model generation can continue to own tokenization, sampling, and scheduling.
+
+Read more:
+
+- [MLX-LM integration](../guides/mlx-lm-integration)
+- [Cache API](../api/cache)
+- [Core API](../api/core-api)
+- [Concepts](./concepts)
+
+### 3. Cache and algorithm layer
+
+Every method is selected through a common configuration and registry path:
+
+```text
+KVCacheConfig(method="...")
+          ▼
+       Registry
+          ▼
+   Cache / quantizer handler
+          ▼
+   Encode → store → decode/attend
+```
+
+The methods fall into three broad families:
+
+- Quantization: represent every token with fewer bits.
+- Eviction: remove tokens that contribute less to future attention.
+- Hybrid and cross-layer methods: combine compression, eviction, or layer sharing.
+
+See the [algorithm overview](../algorithms/overview) and [method API reference](../api/quantizers).
+
+### 4. MLX tensor layer
+
+MLX owns the device arrays, lazy evaluation graph, dtype conversion, shape propagation, and synchronization. Kernel wrappers pass MLX arrays into custom operations and call `mx.eval()` at explicit synchronization points when results must be materialized.
+
+A `.metal` file by itself is not a complete VeloxQuant operation. The Python wrapper supplies input names, output names, templates, grids, threadgroups, output shapes, output dtypes, and MLX graph integration.
+
+### 5. Metal kernel layer
+
+Custom kernels are compiled lazily through `mx.fast.metal_kernel`. Sources live under:
+
+```text
+veloxquant_mlx/metal/src/*.metal
+```
+
+Python dispatch wrappers live under:
+
+```text
+veloxquant_mlx/metal/*.py
+```
+
+The [Metal API reference](../api/metal-api) lists the supported kernel families. The [Metal kernel guide](../guides/metal-kernels) explains dispatch, lazy compilation, synchronization, and performance measurement.
+
+## Kernel families
+
+| Family | Python wrapper | Main use |
+|---|---|---|
+| Bit packing | `metal/_bit_packing.py` | Store low-bit indices compactly |
+| VecInfer | `metal/_vecinfer.py` | Product VQ encode/decode |
+| Scalar quantization | `metal/_scalar_quant.py` | Affine and scalar quantization |
+| RaBitQ | `metal/_rabitq*.py` | Binary encoding and Hamming operations |
+| QJL | `metal/_qjl.py` | Quantized inner products and encoding |
+| RVQ | `metal/_rvq_*.py` | Fused residual VQ operations |
+| Attention | `metal/_scalar_attend.py`, `metal/fused_sdpa.py` | Decode and prefill attention |
+| Eviction | `metal/_h2o_evict.py`, `_tova_evict.py`, `_keyformer_evict.py`, `_qfilters_evict.py` | Token selection and removal |
+| Cross-model transfer | `metal/_crosskv_rope.py` | Fused RoPE re-encoding |
+
+Not every kernel is exposed through the npm worker. The Python API remains broader than the Node.js transport surface.
+
+## Python worker architecture
+
+The worker is an optional long-lived process started with:
+
+```bash
+python -m veloxquant_mlx worker
+```
+
+It communicates over newline-delimited JSON:
+
+```json
+{"protocol_version":1,"id":"request-1","op":"capabilities","args":{}}
+```
+
+Responses preserve the request ID:
+
+```json
+{
+  "protocol_version": 1,
+  "id": "request-1",
+  "ok": true,
+  "result": {
+    "metalAvailable": true,
+    "device": "Device(gpu, 0)"
+  }
+}
+```
+
+The worker currently exposes a reviewed operation set:
+
+- `ping`
+- `capabilities`
+- `metal_probe`
+- `bit_pack`
+- `bit_pack_file`
+- `rope_recode_file`
+
+Unknown operations and invalid arguments return structured errors. Arbitrary Metal source is never accepted from the client.
+
+## Tensor transport
+
+Small control values may be sent directly in JSON. Large tensors use `.npy` files:
+
+```text
+Node writes input.npy
+        ▼
+Python loads input.npy into MLX
+        ▼
+Metal kernel executes
+        ▼
+Python writes output.npy
+        ▼
+Node consumes output.npy
+```
+
+The file transport is deliberately explicit and debuggable. It avoids inventing a native tensor ABI before performance measurements justify zero-copy memory. Future transport options include memory-mapped files and shared memory.
+
+See the [npm worker architecture decision](https://github.com/rajveer43/veloxquant-sdk/blob/master/docs/metal-node-architecture.md) and the [npm worker implementation](https://github.com/rajveer43/veloxquant-sdk/blob/master/src/python/worker.ts).
+
+## JavaScript SDK boundary
+
+The npm SDK exposes the worker through typed methods:
+
+```ts
+import { startWorker } from "@veloxquant/sdk";
+
+const worker = startWorker();
+const capabilities = await worker.capabilities();
+const packed = await worker.bitPack([0, 1, 2, 3, 0, 1, 2, 3], 2);
+await worker.close();
+```
+
+The SDK is responsible for:
+
+- Python interpreter resolution
+- Worker startup and shutdown
+- Request IDs and timeouts
+- Response validation
+- TypeScript result types
+- Node-side errors and lifecycle behavior
+
+The Python package is responsible for:
+
+- MLX imports and device selection
+- Tensor validation
+- Kernel compilation and dispatch
+- Cache and model integration
+- Metal synchronization
+- Numerical correctness
+
+## Capability and fallback model
+
+Applications should call `capabilities()` before using a Metal operation. A valid result identifies the backend and device. The SDK must not label a result as Metal if it used a fallback.
+
+Supported environments:
+
+- Apple Silicon macOS with MLX and Metal: Metal backend.
+- macOS without a usable GPU: structured capability error.
+- Linux, Windows, Intel macOS, or unsupported Python environments: SDK can remain installable, but Metal operations are unavailable unless a documented fallback exists.
+
+The fallback hierarchy is:
+
+1. Metal-backed MLX implementation.
+2. MLX non-Metal implementation, where available.
+3. NumPy/reference implementation, where correctness and performance are acceptable.
+4. Explicit unsupported-operation error.
+
+## Testing architecture
+
+Correctness is checked at multiple boundaries:
+
+1. Metal kernel unit tests validate shapes, dtypes, grid sizes, and edge cases.
+2. Reference parity tests compare Metal output with pure MLX or NumPy output.
+3. Worker protocol tests validate envelopes, IDs, errors, timeouts, and shutdown.
+4. End-to-end tests validate Node → worker → MLX → Metal → output transport.
+5. Model tests validate generation and KV-cache behavior.
+6. Benchmarks measure warm-up, kernel latency, IPC, file transport, memory, and end-to-end throughput.
+
+Relevant resources:
+
+- [Metal tests](https://github.com/rajveer43/VeloxQuant-MLX/tree/master/veloxquant_mlx/tests/metal)
+- [Worker parity tests](https://github.com/rajveer43/VeloxQuant-MLX/blob/master/veloxquant_mlx/tests/metal/test_worker_kernel_parity.py)
+- [Benchmarking guide](../guides/benchmarking)
+- [Validation report](../guides/validation-report)
+- [Metal kernel research notes](../blog/turboquant-metal-kernels)
+
+## Packaging and release boundaries
+
+The base npm package does not bundle MLX, Metal, or a native Node addon. Users install the Python package separately. This keeps the npm package portable and avoids coupling Node ABI compatibility to MLX and macOS GPU distribution.
+
+The current integration is implemented across two companion pull requests:
+
+- [npm SDK PR #33](https://github.com/rajveer43/veloxquant-sdk/pull/33)
+- [Python worker PR #336](https://github.com/rajveer43/VeloxQuant-MLX/pull/336)
+
+A native Node-API or Swift bridge is a future research option, not the current execution path. It would require a stable tensor ABI, numerical parity, zero-copy measurements, Apple Silicon packaging, code signing, notarization, and fallback behavior before adoption.
+
+## Design principles
+
+- Keep MLX and Metal execution in Python where the mature runtime already exists.
+- Expose reviewed high-level operations, not arbitrary GPU code execution.
+- Treat compression and memory numbers honestly: accounting estimates are not automatically resident RSS savings.
+- Require parity tests before exposing a kernel through the worker.
+- Measure IPC and file transport before introducing native bindings.
+- Keep unsupported hardware explicit and diagnosable.
+
+## Related documentation
+
+- [Getting started](./intro)
+- [Core concepts](./concepts)
+- [Algorithm overview](../algorithms/overview)
+- [Metal kernel guide](../guides/metal-kernels)
+- [Metal API reference](../api/metal-api)
+- [Cache API](../api/cache)
+- [Cross-model transfer](../algorithms/cross-model-transfer)
+- [Profiling](../guides/profiling)
+- [Benchmarking](../guides/benchmarking)
+- [Installation](./installation)
+

--- a/docs-site/docs/getting-started/architecture.md
+++ b/docs-site/docs/getting-started/architecture.md
@@ -175,7 +175,7 @@ Node consumes output.npy
 
 The file transport is deliberately explicit and debuggable. It avoids inventing a native tensor ABI before performance measurements justify zero-copy memory. Future transport options include memory-mapped files and shared memory.
 
-See the [npm worker architecture decision](https://github.com/rajveer43/veloxquant-sdk/blob/master/docs/metal-node-architecture.md) and the [npm worker implementation](https://github.com/rajveer43/veloxquant-sdk/blob/master/src/python/worker.ts).
+See the [npm worker architecture decision](https://github.com/rajveer43/veloxquant-sdk/pull/33) and the [npm worker implementation](https://github.com/rajveer43/veloxquant-sdk/pull/33/files).
 
 ## JavaScript SDK boundary
 
@@ -238,8 +238,8 @@ Correctness is checked at multiple boundaries:
 
 Relevant resources:
 
-- [Metal tests](https://github.com/rajveer43/VeloxQuant-MLX/tree/master/veloxquant_mlx/tests/metal)
-- [Worker parity tests](https://github.com/rajveer43/VeloxQuant-MLX/blob/master/veloxquant_mlx/tests/metal/test_worker_kernel_parity.py)
+- [Metal tests](https://github.com/rajveer43/VeloxQuant-MLX/tree/codex/metal-worker-protocol/veloxquant_mlx/tests/metal)
+- [Worker parity tests](https://github.com/rajveer43/VeloxQuant-MLX/blob/codex/metal-worker-protocol/veloxquant_mlx/tests/metal/test_worker_kernel_parity.py)
 - [Benchmarking guide](../guides/benchmarking)
 - [Validation report](../guides/validation-report)
 - [Metal kernel research notes](../blog/turboquant-metal-kernels)

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -12,6 +12,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/quickstart',
         'getting-started/comparison',
         'getting-started/concepts',
+        'getting-started/architecture',
       ],
     },
   ],

--- a/veloxquant_mlx/__main__.py
+++ b/veloxquant_mlx/__main__.py
@@ -9,7 +9,7 @@ def main() -> None:
     if len(sys.argv) < 2:
         print(
             "Usage: veloxquant "
-            "{precompute|benchmark|recommend|auto-config|methods|serve|profile|panel}"
+            "{precompute|benchmark|recommend|auto-config|methods|serve|profile|panel|worker}"
         )
         sys.exit(1)
 
@@ -49,10 +49,14 @@ def main() -> None:
         from veloxquant_mlx.cli.panel import main as _main
 
         _main()
+    elif command == "worker":
+        from veloxquant_mlx.cli.worker import main as _main
+
+        _main()
     else:
         print(
             f"Unknown command: {command!r}. "
-            "Choices: precompute, benchmark, recommend, auto-config, methods, serve, profile, panel"
+            "Choices: precompute, benchmark, recommend, auto-config, methods, serve, profile, panel, worker"
         )
         sys.exit(1)
 

--- a/veloxquant_mlx/cli/worker.py
+++ b/veloxquant_mlx/cli/worker.py
@@ -1,0 +1,141 @@
+"""JSON-lines worker used by the JavaScript SDK."""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+PROTOCOL_VERSION = 1
+
+
+def _reply(request_id: str, *, result: Any = None, error: Any = None) -> None:
+    payload: dict[str, Any] = {"protocol_version": PROTOCOL_VERSION, "id": request_id, "ok": error is None}
+    payload["result" if error is None else "error"] = result if error is None else error
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+def main() -> None:
+    from veloxquant_mlx import __version__
+    for line in sys.stdin:
+        request: Any = None
+        try:
+            request = json.loads(line)
+            request_id = str(request["id"])
+            op = request.get("op")
+            if op == "ping":
+                _reply(request_id, result={"version": __version__})
+            elif op == "capabilities":
+                _reply(request_id, result=_capabilities(__version__))
+            elif op == "metal_probe":
+                _reply(request_id, result=_metal_probe())
+            elif op == "bit_pack":
+                _reply(request_id, result=_bit_pack(request.get("args", {})))
+            elif op == "bit_pack_file":
+                _reply(request_id, result=_bit_pack_file(request.get("args", {})))
+            elif op == "rope_recode_file":
+                _reply(request_id, result=_rope_recode_file(request.get("args", {})))
+            elif op == "shutdown":
+                _reply(request_id, result={"stopped": True})
+                return
+            else:
+                _reply(request_id, error=f"unknown worker operation: {op!r}")
+        except Exception as exc:
+            _reply(str(request.get("id", "unknown")) if isinstance(request, dict) else "unknown", error={"code": "WORKER_ERROR", "message": str(exc)})
+
+
+def _capabilities(version: str) -> dict[str, Any]:
+    import mlx.core as mx
+    return {"veloxquantVersion": version, "mlxVersion": getattr(mx, "__version__", None),
+            "device": str(mx.default_device()), "metalAvailable": True,
+            "supportedOperations": ["ping", "capabilities", "metal_probe", "bit_pack", "bit_pack_file", "rope_recode_file"]}
+
+
+def _bit_pack(args: dict[str, Any]) -> dict[str, Any]:
+    bits = int(args.get("bits", 0))
+    values = args.get("values")
+    if bits not in (1, 2, 4):
+        raise ValueError("INVALID_BITS: bits must be one of 1, 2, or 4")
+    if not isinstance(values, list) or not all(isinstance(value, int) for value in values):
+        raise ValueError("INVALID_VALUES: values must be an integer array")
+    import mlx.core as mx
+    from veloxquant_mlx.metal._bit_packing import turboquant_bit_pack
+    packed = turboquant_bit_pack(mx.array(values, dtype=mx.uint8), bits)
+    mx.eval(packed)
+    return {"bits": bits, "inputLength": len(values), "values": [int(value) for value in packed.tolist()],
+            "backend": "metal", "device": str(mx.default_device())}
+
+
+def _bit_pack_file(args: dict[str, Any]) -> dict[str, Any]:
+    from pathlib import Path
+    import numpy as np
+
+    input_path = Path(str(args.get("inputPath", ""))).resolve()
+    output_path = Path(str(args.get("outputPath", ""))).resolve()
+    if input_path.suffix != ".npy" or output_path.suffix != ".npy":
+        raise ValueError("INVALID_PATH: inputPath and outputPath must be .npy files")
+    if not input_path.is_file():
+        raise FileNotFoundError(f"INPUT_NOT_FOUND: {input_path}")
+    values = np.load(input_path, allow_pickle=False)
+    if values.ndim != 1 or values.dtype.kind not in "iu":
+        raise ValueError("INVALID_ARRAY: input must be a one-dimensional integer .npy array")
+    result = _bit_pack({"values": [int(value) for value in values.tolist()], "bits": args.get("bits")})
+    np.save(output_path, np.asarray(result["values"], dtype=np.uint8), allow_pickle=False)
+    return {"outputPath": str(output_path), "shape": [len(result["values"])], "dtype": "uint8",
+            "inputLength": result["inputLength"], "bits": result["bits"], "backend": result["backend"],
+            "device": result["device"]}
+
+
+def _rope_recode_file(args: dict[str, Any]) -> dict[str, Any]:
+    from pathlib import Path
+    import numpy as np
+    import mlx.core as mx
+    from veloxquant_mlx.metal._crosskv_rope import crosskv_rope_recode
+
+    input_path = Path(str(args.get("inputPath", ""))).resolve()
+    positions_path = Path(str(args.get("positionsPath", ""))).resolve()
+    output_path = Path(str(args.get("outputPath", ""))).resolve()
+    if any(path.suffix != ".npy" for path in (input_path, positions_path, output_path)):
+        raise ValueError("INVALID_PATH: inputPath, positionsPath, and outputPath must be .npy files")
+    if not input_path.is_file() or not positions_path.is_file():
+        raise FileNotFoundError("INPUT_NOT_FOUND: input or positions file does not exist")
+    keys = np.load(input_path, allow_pickle=False)
+    positions = np.load(positions_path, allow_pickle=False)
+    if keys.ndim != 3 or keys.shape[2] % 2 != 0:
+        raise ValueError("INVALID_ARRAY: keys must have shape [BH, N, even_head_dim]")
+    if positions.ndim != 1 or positions.shape[0] != keys.shape[1]:
+        raise ValueError("INVALID_POSITIONS: positions must be [N] matching keys")
+    source_base = float(args["sourceBase"])
+    target_base = float(args["targetBase"])
+    result = crosskv_rope_recode(mx.array(keys), mx.array(positions), source_base, target_base)
+    mx.eval(result)
+    np.save(output_path, np.asarray(result.tolist(), dtype=keys.dtype), allow_pickle=False)
+    return {"outputPath": str(output_path), "shape": list(keys.shape), "dtype": str(keys.dtype),
+            "backend": "metal", "device": str(mx.default_device())}
+
+
+def _metal_probe() -> dict[str, Any]:
+    """Compile and execute one tiny MLX custom Metal kernel."""
+    import mlx.core as mx
+
+    source = """
+        uint i = thread_position_in_grid.x;
+        if (i < x_shape[0]) out[i] = x[i] + 1.0f;
+    """
+    kernel = mx.fast.metal_kernel(
+        name="veloxquant_worker_probe",
+        input_names=["x"],
+        output_names=["out"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+    values = mx.array([1.0, 2.0, 3.0], dtype=mx.float32)
+    output = kernel(
+        inputs=[values],
+        grid=(3, 1, 1),
+        threadgroup=(3, 1, 1),
+        output_shapes=[(3,)],
+        output_dtypes=[mx.float32],
+    )[0]
+    mx.eval(output)
+    result = [float(value) for value in output.tolist()]
+    return {"device": str(mx.default_device()), "output": result, "passed": result == [2.0, 3.0, 4.0]}

--- a/veloxquant_mlx/tests/metal/test_worker_kernel_parity.py
+++ b/veloxquant_mlx/tests/metal/test_worker_kernel_parity.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+if not mx.metal.is_available():
+    pytest.skip("Metal GPU is required", allow_module_level=True)
+
+from veloxquant_mlx.cli.worker import _bit_pack_file, _rope_recode_file
+from veloxquant_mlx.transfer.rope import recode_rope
+
+
+def test_worker_bit_pack_file_matches_exact_reference(tmp_path):
+    source = tmp_path / "input.npy"
+    target = tmp_path / "output.npy"
+    values = np.array([0, 1, 2, 3, 0, 1, 2, 3], dtype=np.uint8)
+    np.save(source, values, allow_pickle=False)
+
+    result = _bit_pack_file({"inputPath": str(source), "outputPath": str(target), "bits": 2})
+
+    assert result["backend"] == "metal"
+    np.testing.assert_array_equal(np.load(target, allow_pickle=False), np.array([228, 228], dtype=np.uint8))
+
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32])
+def test_worker_rope_file_matches_reference(tmp_path, dtype):
+    source = tmp_path / "keys.npy"
+    positions_path = tmp_path / "positions.npy"
+    target = tmp_path / "output.npy"
+    keys = np.arange(2 * 4 * 8, dtype=np.float32).reshape(2, 4, 8).astype(dtype)
+    positions = np.arange(4, dtype=np.int32)
+    np.save(source, keys, allow_pickle=False)
+    np.save(positions_path, positions, allow_pickle=False)
+
+    result = _rope_recode_file({
+        "inputPath": str(source), "positionsPath": str(positions_path),
+        "outputPath": str(target), "sourceBase": 10000.0, "targetBase": 100000.0,
+    })
+
+    actual = mx.array(np.load(target, allow_pickle=False))
+    expected = recode_rope(mx.array(keys), mx.array(positions), 10000.0, 100000.0, use_metal=False)
+    mx.eval(actual, expected)
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=2e-3, atol=2e-3)
+    assert result["shape"] == [2, 4, 8]


### PR DESCRIPTION
## Summary

Adds the Python half of the persistent MLX/Metal worker used by `@veloxquant/sdk`.

## What changed

- Adds `python -m veloxquant_mlx worker`.
- Implements protocol version 1 over newline-delimited JSON.
- Adds `ping`, `capabilities`, `metal_probe`, `bit_pack`, `bit_pack_file`, and `rope_recode_file`.
- Adds structured worker errors.
- Adds `.npy` tensor transport with shape, dtype, and path validation.
- Adds Apple-GPU parity tests for bit packing and float16/float32 RoPE recoding.

## Validation

- Python bytecode compilation passed.
- 15 Metal parity tests passed on macOS Apple GPU / Python 3.12.9.
- Live worker validation passed on `Device(gpu, 0)`.
- MLX `0.32.1`, VeloxQuant `0.80.0`.

## Companion change

This PR is required by [the npm SDK PR](https://github.com/rajveer43/veloxquant-sdk/pull/33).