### PR TITLE
fix(landing): remove internal repo paths from visitor-facing copy

### DIFF
--- a/landing/benchmarks.html
+++ b/landing/benchmarks.html
@@ -109,7 +109,7 @@
           Measured on Apple Silicon.<br>Verified across 12 models.
         </h1>
         <p class="hero-subheadline bench-hero-desc">
-          Real causal-LM generation throughput, attention correlation accuracy, and perplexity measurements on Apple Silicon hardware (M1 through M4). Zero synthetic projections — all logs committed under <code>figures/</code>.
+          Real causal-LM generation throughput, attention correlation accuracy, and perplexity measurements on Apple Silicon hardware (M1 through M4). Zero synthetic projections — every result below is measured and reproducible, not estimated.
         </p>
 
         <!-- Executive Metrics Grid -->
@@ -1006,7 +1006,8 @@
             <span>Reproduce these benchmarks on your Mac</span>
             <span class="bench-cli-chip">CLI</span>
           </div>
-          <pre><code>python -m veloxquant_mlx benchmark --all</code></pre>
+          <pre><code>pip install veloxquant-mlx
+veloxquant benchmark --all</code></pre>
         </div>
       </section>
 

--- a/landing/playground.html
+++ b/landing/playground.html
@@ -379,7 +379,7 @@
 
           <!-- Disclaimer & Trust Footer -->
           <p class="pg-disclaimer">
-            <strong>Where these numbers come from:</strong> Sizing formulas and recommendations run the same logic that powers the <code>veloxquant recommend</code> CLI tool (<code>veloxquant_mlx/tools/mac_recommender.py</code>). Benchmark curves in Step 3 are exact Metal kernel measurements committed under <code>figures/</code>. To run native profiling on your machine, run <code>python -m veloxquant_mlx benchmark</code>.
+            <strong>Where these numbers come from:</strong> Sizing formulas and recommendations run the exact same logic as the <code>veloxquant recommend</code> CLI tool, so what you see here matches what you'd get locally. Benchmark curves in Step 3 are real, measured Metal kernel results, not projections. To run native profiling on your own machine, install VeloxQuant-MLX and run <code>veloxquant benchmark</code>.
           </p>
         </section>
       </div>


### PR DESCRIPTION
Replace raw file paths (veloxquant_mlx/tools/mac_recommender.py, figures/) in the playground and benchmarks disclaimers with plain-language framing, and update the reproduce-benchmarks command to the installed veloxquant CLI.

## Summary

Brief description of what this PR changes and why.

## Related issue

Closes #

## Test plan

- [ ] `python -m pytest veloxquant_mlx/tests -q` passes locally on Apple Silicon
- [ ] New or updated unit tests cover the change
- [ ] Docs updated if user-facing behavior changed

## Number claims (if any)

Compression, speedup, or memory claims **must** link a reproducible script and a committed `results.json`.

- Script path:
- Results path:
- Metric type (check one):
  - [ ] Key-byte **accounting** (`fp16_key_bytes / compressed_key_bytes`)
  - [ ] Full-KV accounting (keys + values + residual windows)
  - [ ] MLX peak memory (`mx.get_peak_memory`)
  - [ ] OS RSS / long-context OOM comparison
  - [ ] Throughput (tok/s)

Do not describe accounting ratios as resident RAM savings unless resident memory was measured.
