### PR TITLE
perf(h2o): vectorize per-eviction row drop instead of Python index list

### DIFF
--- a/veloxquant_mlx/quantizers/h2o.py
+++ b/veloxquant_mlx/quantizers/h2o.py
@@ -467,11 +467,14 @@ def _evict_via_mlx(
 
     evict_idx = int(mx.argmin(protected).item())
     evicted_pos = int(positions_cat[evict_idx].item())
-    keep_indices = [j for j in range(n_total) if j != evict_idx]
-    keys_kept = keys_cat[keep_indices]
-    values_kept = values_cat[keep_indices]
-    scores_kept = scores_cat[keep_indices]
-    old_positions_kept = positions_cat[keep_indices]
+
+    def _drop_row(arr: mx.array) -> mx.array:
+        return mx.concatenate([arr[:evict_idx], arr[evict_idx + 1 :]], axis=0)
+
+    keys_kept = _drop_row(keys_cat)
+    values_kept = _drop_row(values_cat)
+    scores_kept = _drop_row(scores_cat)
+    old_positions_kept = _drop_row(positions_cat)
 
     # Evicting row `evict_idx` leaves a size-1 gap at `evicted_pos`. Rows
     # that sat *before* the gap (sinks included) keep their exact original


### PR DESCRIPTION
## Summary
- `_evict_via_mlx` built the surviving-row index set via a Python-level list comprehension (`[j for j in range(n_total) if j != evict_idx]`), used as a fancy index into `keys_cat`/`values_cat`/`scores_cat`/`positions_cat`.
- This runs once per sequential eviction step inside `h2o_update`'s decode-time loop, so at `budget=2048` it was O(n) Python-level overhead per evicted token, every decode step once the cache is full.
- Replaced with a two-slice `mx.concatenate` per array, dropping the same row without materializing a Python index list.

## Verification
- Bit-for-bit identical output vs. the old implementation, checked across multiple `n_total`/`n_sink`/`grace` combinations.
- ~12% faster per call at `n_total=2048` in a local microbenchmark (0.83ms → 0.73ms).
- All 80 tests in `test_h2o.py`, `test_h2o_cache.py`, and `test_h2o_evict.py` pass unchanged, including the Metal-vs-MLX bit-for-bit parity suite.
- `ruff check` passes on the modified file.

## Test plan
- [x] `pytest veloxquant_mlx/tests/quantizers/test_h2o.py veloxquant_mlx/tests/cache/test_h2o_cache.py veloxquant_mlx/tests/metal/test_h2o_evict.py` — 80 passed
- [x] Manual numerical equivalence check (old vs. new) across shapes/sink/grace
- [x] `ruff check veloxquant_mlx/quantizers/h2o.py` — clean

Fixes #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)