### PR TITLE
fix(cli): warn when --set targets a field irrelevant to the chosen method

### DIFF
--- a/veloxquant_mlx/cache/registry.py
+++ b/veloxquant_mlx/cache/registry.py
@@ -38,6 +38,7 @@ __all__ = [
     "get_method",
     "probe_serve_tier",
     "describe_field",
+    "field_is_relevant",
     "telemetry_coverage",
     "TelemetryCoverage",
     "DEFAULT_SERVE_METHOD",
@@ -379,6 +380,17 @@ _CONFIG_FIELDS: Dict[str, List[str]] = {
 
 _GENERIC_FIELDS = ["bit_width_inlier", "seed"]
 
+#: Methods whose config-field prefix doesn't match the method name itself
+#: (e.g. ``snapkv``'s fields are ``snap_*``, not ``snapkv_*``). Every other
+#: method's fields follow a plain ``{method}_*`` prefix — verified against
+#: every field name in ``KVCacheConfig`` — so this map only needs the
+#: exceptions, not a full method -> prefix table.
+_FIELD_PREFIX_ALIAS: Dict[str, str] = {
+    "snapkv": "snap",
+    "streaming_llm": "stream",
+    "pyramidkv": "pyramid",
+}
+
 _TIER_CACHE: Dict[str, "ServeTier"] = {}
 _UNSUPPORTED_REASON: Dict[str, str] = {}
 
@@ -440,6 +452,35 @@ def describe_field(name: str) -> Dict[str, Any]:
         "optional": optional,
         "help": _FIELD_HELP.get(name),
     }
+
+
+def field_is_relevant(method: str, name: str) -> bool:
+    """Whether ``KVCacheConfig`` field ``name`` has any effect for ``method``.
+
+    ``KVCacheConfig`` is one flat dataclass covering all methods, so nothing
+    stops constructing e.g. ``KVCacheConfig(method="h2o", kivi_group_size=64)``
+    — it succeeds and silently ignores the unrelated field. This gives callers
+    (``veloxquant serve --set``, the control panel) a way to catch that before
+    it looks like a no-op configuration change (issue #345).
+
+    A field not tied to any single method (``_GENERIC_FIELDS``, plus any name
+    with no ``_`` at all, e.g. ``capacity``) is always considered relevant.
+    Otherwise: methods listed in ``_CONFIG_FIELDS`` use that explicit list: it
+    is curated for the control panel (#35) and may be narrower than the
+    prefix (e.g. a shared field intentionally left off one method's list).
+    Methods not yet in ``_CONFIG_FIELDS`` fall back to a name-prefix check
+    (via ``_FIELD_PREFIX_ALIAS`` for the few methods whose fields don't share
+    the method's own name) rather than rejecting the field outright, since
+    most methods have not had their exact field list curated yet.
+    """
+    if name in _GENERIC_FIELDS or "_" not in name:
+        return True
+
+    if method in _CONFIG_FIELDS:
+        return name in _CONFIG_FIELDS[method]
+
+    prefix = _FIELD_PREFIX_ALIAS.get(method, method)
+    return name.startswith(prefix + "_")
 
 
 def all_method_names() -> List[str]:

--- a/veloxquant_mlx/cli/serve.py
+++ b/veloxquant_mlx/cli/serve.py
@@ -141,17 +141,23 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def parse_overrides(pairs: List[str]) -> Dict[str, Any]:
+def parse_overrides(pairs: List[str], method: Optional[str] = None) -> Dict[str, Any]:
     """Turn ``FIELD=VALUE`` strings into typed ``KVCacheConfig`` kwargs.
 
     Types come from the dataclass via the registry, so a value that the config
     would reject is refused here — with the field name in the message — instead
     of surfacing as an opaque failure deep in cache construction.
+
+    When ``method`` is given, a field with no effect for that method (e.g.
+    ``--set kivi_group_size=64`` while ``--method h2o``) prints a warning
+    instead of silently doing nothing (issue #345) — a warning, not a hard
+    error, since ``_CONFIG_FIELDS`` does not yet curate every method and a
+    false positive there must not block a legitimate override.
     """
     import dataclasses
 
     from veloxquant_mlx.cache.base import KVCacheConfig
-    from veloxquant_mlx.cache.registry import describe_field
+    from veloxquant_mlx.cache.registry import describe_field, field_is_relevant
 
     valid = {f.name for f in dataclasses.fields(KVCacheConfig)}
     overrides: Dict[str, Any] = {}
@@ -167,6 +173,9 @@ def parse_overrides(pairs: List[str]) -> Dict[str, Any]:
             raise SystemExit(f"error: unknown config field {name!r}")
         if name in ("method", "store", "observers", "dtype"):
             raise SystemExit(f"error: {name!r} cannot be set with --set")
+
+        if method is not None and not field_is_relevant(method, name):
+            _warn(f"{name!r} has no effect for method {method!r}; ignoring.")
 
         schema = describe_field(name)
         if raw == "" and schema["optional"]:
@@ -220,7 +229,7 @@ def _warn(message: str) -> None:
 def build_config(args: argparse.Namespace) -> Any:
     from veloxquant_mlx.cache import KVCacheConfig
 
-    overrides = parse_overrides(getattr(args, "set", []) or [])
+    overrides = parse_overrides(getattr(args, "set", []) or [], method=args.method)
     if overrides:
         rendered = ", ".join(f"{k}={v!r}" for k, v in sorted(overrides.items()))
         _warn(f"method overrides: {rendered}")

--- a/veloxquant_mlx/tests/cache/test_registry.py
+++ b/veloxquant_mlx/tests/cache/test_registry.py
@@ -19,6 +19,7 @@ from veloxquant_mlx.cache.registry import (
     MethodFamily,
     ServeTier,
     all_method_names,
+    field_is_relevant,
     get_method,
     list_methods,
     probe_serve_tier,
@@ -220,3 +221,51 @@ def test_methods_cli_json_contract():
     assert payload["accounting_only"] is True
     assert payload["default_serve_method"] == DEFAULT_SERVE_METHOD
     assert len(payload["methods"]) == EXPECTED_TOTAL
+
+
+class TestFieldIsRelevant:
+    """#345: KVCacheConfig has no built-in way to tell a field is irrelevant
+    to the active method (e.g. kivi_group_size while method="h2o"). These pin
+    field_is_relevant's three lookup tiers: curated _CONFIG_FIELDS entries,
+    the prefix fallback for uncurated methods, and always-relevant generics.
+    """
+
+    def test_generic_fields_always_relevant(self):
+        for method in ("h2o", "kivi", "turboquant_rvq"):
+            assert field_is_relevant(method, "bit_width_inlier")
+            assert field_is_relevant(method, "seed")
+
+    def test_field_without_underscore_is_generic(self):
+        assert field_is_relevant("h2o", "capacity")
+
+    def test_curated_method_uses_explicit_list(self):
+        assert field_is_relevant("kivi", "kivi_group_size")
+        assert not field_is_relevant("kivi", "svdq_rank")
+
+    def test_curated_method_rejects_other_methods_own_field(self):
+        assert not field_is_relevant("svdq", "kivi_group_size")
+
+    def test_uncurated_method_falls_back_to_prefix(self):
+        # h2o is not in _CONFIG_FIELDS, so this exercises the prefix branch.
+        assert field_is_relevant("h2o", "h2o_budget")
+        assert not field_is_relevant("h2o", "tova_budget")
+
+    def test_prefix_alias_methods(self):
+        """snapkv/streaming_llm/pyramidkv fields don't share the method name."""
+        assert field_is_relevant("snapkv", "snap_budget")
+        assert field_is_relevant("streaming_llm", "stream_n_sink")
+        assert field_is_relevant("pyramidkv", "pyramid_beta")
+        assert not field_is_relevant("snapkv", "stream_n_sink")
+
+    def test_every_config_fields_entry_exists_on_the_dataclass(self):
+        """Catches _CONFIG_FIELDS drifting from KVCacheConfig's real fields --
+        e.g. a field renamed in base.py but not updated in the registry."""
+        import dataclasses
+
+        from veloxquant_mlx.cache.base import KVCacheConfig
+        from veloxquant_mlx.cache.registry import _CONFIG_FIELDS
+
+        valid = {f.name for f in dataclasses.fields(KVCacheConfig)}
+        for method, fields in _CONFIG_FIELDS.items():
+            for name in fields:
+                assert name in valid, (method, name)

--- a/veloxquant_mlx/tests/cache/test_serve_cli.py
+++ b/veloxquant_mlx/tests/cache/test_serve_cli.py
@@ -161,3 +161,42 @@ def test_not_trimmable_method_gate_used_by_serve_warning():
     exercised without a real model load."""
     assert probe_serve_tier("h2o") is ServeTier.NOT_TRIMMABLE
     assert probe_serve_tier(DEFAULT_SERVE_METHOD) is not ServeTier.NOT_TRIMMABLE
+
+
+def test_set_irrelevant_field_warns_but_still_applies(capsys):
+    """#345: KVCacheConfig accepts any field regardless of method, so
+    --set kivi_group_size=64 with --method h2o previously succeeded with no
+    indication the flag had no effect. It must now warn -- but the value
+    still applies (unused, harmless) rather than being silently dropped or
+    hard-rejected, since the relevance table does not yet cover every method."""
+    overrides = serve_cli.parse_overrides(["kivi_group_size=64"], method="h2o")
+
+    assert overrides == {"kivi_group_size": 64}
+    err = capsys.readouterr().err
+    assert "'kivi_group_size' has no effect for method 'h2o'" in err
+
+
+def test_set_relevant_field_does_not_warn(capsys):
+    overrides = serve_cli.parse_overrides(["kivi_group_size=64"], method="kivi")
+
+    assert overrides == {"kivi_group_size": 64}
+    err = capsys.readouterr().err
+    assert err == ""
+
+
+def test_set_generic_field_never_warns(capsys):
+    """bit_width_inlier/seed apply to every method, regardless of curation."""
+    overrides = serve_cli.parse_overrides(["seed=7"], method="h2o")
+
+    assert overrides == {"seed": 7}
+    err = capsys.readouterr().err
+    assert err == ""
+
+
+def test_set_without_method_skips_relevance_check(capsys):
+    """method=None (the prior default) preserves old behavior exactly."""
+    overrides = serve_cli.parse_overrides(["kivi_group_size=64"])
+
+    assert overrides == {"kivi_group_size": 64}
+    err = capsys.readouterr().err
+    assert err == ""


### PR DESCRIPTION
## Summary
- `KVCacheConfig` is one dataclass covering all 40+ methods, so `veloxquant serve --method h2o --set kivi_group_size=64` previously succeeded with `kivi_group_size` silently unused — no error, no warning.
- Adds `registry.field_is_relevant(method, name)`, built on the existing `_CONFIG_FIELDS` table (already used for the control panel's per-method form rendering): curated methods use that explicit list, the 26 uncurated methods fall back to a name-prefix check (with a small alias map for the 3 methods whose field prefix doesn't match the method name: `snapkv`→`snap_*`, `streaming_llm`→`stream_*`, `pyramidkv`→`pyramid_*`). Fields shared across every method (`bit_width_inlier`, `seed`) are always relevant.
- `parse_overrides()` now takes an optional `method=` and warns (does not error) when a `--set` field fails that check. It's a warning rather than a hard rejection because the prefix fallback isn't a complete per-method curation yet, and a false positive must not silently block a legitimate override. The value still applies — this makes the no-op visible instead of silent.

## Verification
- New `TestFieldIsRelevant` suite in `test_registry.py` covers all three lookup tiers (curated list, prefix fallback, generic fields) plus the alias map and a consistency check against `KVCacheConfig`'s real fields.
- New tests in `test_serve_cli.py` cover: warns on an irrelevant field, doesn't warn on a relevant one, never warns on generic fields, and preserves old (no-warning) behavior when `method` isn't passed.
- Full `veloxquant_mlx/tests/cache/` suite: 1049 passed, 1 skipped (pre-existing skip, unrelated).
- `ruff check` on touched files: only pre-existing `UP0xx` (deprecated `typing.List`/`Dict`/`Optional`) findings already tracked in #40; no new lint categories introduced.

## Test plan
- [x] `pytest veloxquant_mlx/tests/cache/test_registry.py veloxquant_mlx/tests/cache/test_serve_cli.py` — 43 passed
- [x] `pytest veloxquant_mlx/tests/cache/` — 1049 passed, 1 skipped
- [x] Manual check: `--method h2o --set kivi_group_size=64` now prints `[veloxquant serve] 'kivi_group_size' has no effect for method 'h2o'; ignoring.`
- [x] Manual check: relevant/generic overrides produce no warning

Fixes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)