### PR TITLE
fix(cache): warn instead of silently swallowing make_cache() failures

### DIFF
--- a/veloxquant_mlx/cache/base.py
+++ b/veloxquant_mlx/cache/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 from dataclasses import dataclass, field
 from dataclasses import replace as dataclasses_replace
 from typing import Any, Literal, Optional, Union
@@ -942,7 +943,23 @@ class KVCacheBuilder:
                 built = _native_fn()
                 if isinstance(built, list) and len(built) == len(layers):
                     _native = built
-            except Exception:  # pragma: no cover - model-specific constructors
+            except Exception as exc:  # pragma: no cover - model-specific constructors
+                # Kept broad rather than narrowed to TypeError (the two known
+                # hybrid-attention cases above): make_cache() runs arbitrary
+                # model code across every mlx_lm architecture, and an
+                # unanticipated model could just as plausibly raise
+                # AttributeError/KeyError/IndexError from its own config
+                # access. Swallowing unconditionally previously made a novel
+                # failure indistinguishable from the two documented ones;
+                # warn so it is visible without turning it into a hard
+                # failure (fallback path below is still correct either way).
+                warnings.warn(
+                    f"KVCacheBuilder.for_model: {type(model).__name__}.make_cache() "
+                    f"raised {type(exc).__name__}: {exc}. Falling back to a plain "
+                    f"KVCache for any unquantized layer; recurrent/linear-attention "
+                    f"layers on this model may not behave correctly.",
+                    stacklevel=2,
+                )
                 _native = []
 
         def _fallback_for(i: int):

--- a/veloxquant_mlx/tests/cache/test_base_for_model.py
+++ b/veloxquant_mlx/tests/cache/test_base_for_model.py
@@ -13,6 +13,7 @@ at config/patch time.
 
 from __future__ import annotations
 
+import warnings
 from types import SimpleNamespace
 
 import pytest
@@ -119,6 +120,41 @@ def test_default_method_is_serving_compatible() -> None:
 
     model = _make_fake_model()
     caches = KVCacheBuilder.for_model(model, KVCacheConfig())
+    assert len(caches) == 2
+
+
+def test_native_make_cache_failure_warns_and_falls_back() -> None:
+    """#346: make_cache() runs arbitrary model code across every mlx_lm
+    architecture, so a broad except is kept deliberately (narrowing to
+    TypeError risks turning some other model's legitimate but differently
+    -typed failure into an unhandled crash) -- but it must warn instead of
+    silently vanishing, or a genuine constructor bug looks identical to the
+    two documented hybrid-attention TypeError cases.
+    """
+
+    def _broken_make_cache():
+        raise KeyError("boom")
+
+    model = _make_fake_model()
+    model.make_cache = _broken_make_cache
+    config = KVCacheConfig(method="turboquant_rvq", bit_width_inlier=1, seed=42)
+
+    with pytest.warns(UserWarning, match="make_cache.* raised KeyError"):
+        caches = KVCacheBuilder.for_model(model, config)
+
+    # Falls back to a plain KVCache per layer rather than failing the build.
+    assert len(caches) == 2
+
+
+def test_native_make_cache_success_does_not_warn() -> None:
+    model = _make_fake_model()
+    model.make_cache = lambda: []  # wrong length -> ignored, not an error
+    config = KVCacheConfig(method="turboquant_rvq", bit_width_inlier=1, seed=42)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        caches = KVCacheBuilder.for_model(model, config)
+
     assert len(caches) == 2
 
 


### PR DESCRIPTION
## Summary
- `KVCacheBuilder.for_model()` calls the model's own `make_cache()` to get native caches for unquantized layers (recurrent/linear-attention slots in hybrid models like qwen3_5/qwen3_next), inside a bare `except Exception` with no re-raise or logging.
- The two known failure modes (GatedDeltaNet's missing `__setitem__`, a `make_mask()` signature mismatch) both raise `TypeError` — but `make_cache()` runs arbitrary model-specific code across every `mlx_lm` architecture, so I kept the catch broad rather than narrowing it to `TypeError`: narrowing risks turning some other model's legitimate but differently-typed failure (`AttributeError`/`KeyError`/`IndexError` from its own config access) into an unhandled crash instead of the existing graceful fallback.
- Swallowing unconditionally, though, made a genuine constructor bug indistinguishable from the two documented cases. Now it warns — via `warnings.warn`, matching the existing convention in `adakv.py` (this repo has no `logging` usage anywhere) — with the model class name, exception type, and message, before falling back to a plain `KVCache`.

## Verification
- Two new tests in `test_base_for_model.py`: a broken `make_cache()` triggers `pytest.warns(UserWarning, match="make_cache.* raised KeyError")` and still returns the correct number of fallback caches; a working `make_cache()` (even one whose output is ignored for shape mismatch) raises no warning at all (checked with `warnings.simplefilter("error")`).
- Full `veloxquant_mlx/tests/cache/` suite: 1051 passed (2 new), 1 skipped (pre-existing, unrelated).
- `ruff check veloxquant_mlx/cache/base.py`: exactly 50 pre-existing findings, same count as before this change — confirmed via `git stash` diff. No new lint debt introduced.

## Test plan
- [x] `pytest veloxquant_mlx/tests/cache/test_base_for_model.py -v` — 18 passed
- [x] `pytest veloxquant_mlx/tests/cache/` — 1051 passed, 1 skipped
- [x] `ruff check veloxquant_mlx/cache/base.py` — 50 errors before and after (no new ones)

Fixes #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)